### PR TITLE
Improve Makefile targets and Codex task helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,31 @@
-.PHONY: lint typecheck test codex-bootstrap unit integration e2e
+.PHONY: lint typecheck test codex-bootstrap check unit integration e2e acceptance
+
+PYTHON ?= python3
+TASK_LIMIT ?= 5
 
 lint:
-	ruff check . || true
-	yamllint -s . || true
+$(PYTHON) -m ruff check .
+yamllint -s codex/ flows/
 
 typecheck:
-	mypy . || true
+$(PYTHON) -m mypy .
 
 test:
-	pytest --maxfail=1 --disable-warnings || true
+$(PYTHON) -m pytest --maxfail=1 --disable-warnings
+
+check: lint typecheck test
 
 codex-bootstrap:
-	python scripts/codex_next_tasks.py || true
+$(PYTHON) -m scripts.codex_next_tasks --limit $(TASK_LIMIT)
 
 unit:
-	pytest -q tests/unit || true
+$(PYTHON) -m pytest -q tests/unit
 
 integration:
-	pytest -q tests/integration || true
+$(PYTHON) -m pytest -q tests/integration
 
 e2e:
-	pytest -q tests/e2e || true
+$(PYTHON) -m pytest -q tests/e2e
+
+acceptance:
+$(PYTHON) -m pytest -q tests/acceptance

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Utility scripts for the RAGX development workflow."""
+
+__all__ = [
+    "codex_next_tasks",
+]

--- a/scripts/codex_next_tasks.py
+++ b/scripts/codex_next_tasks.py
@@ -1,0 +1,147 @@
+"""CLI helper that surfaces the next Codex automation tasks.
+
+This module scans ``codex/agents/TASKS`` (the single source of truth for
+automation work items) and exposes a simple CLI for humans and bots.  The CLI
+supports a concise plain-text view as well as a machine-readable JSON mode so
+that other tooling can easily integrate with it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import yaml
+
+TASKS_ROOT = Path("codex/agents/TASKS")
+
+
+@dataclass(slots=True)
+class TaskRecord:
+    """Lightweight representation of a Codex task entry."""
+
+    task_id: str
+    title: str
+    component_ids: tuple[str, ...]
+    path: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Render the task record as a plain ``dict`` suitable for JSON."""
+
+        return {
+            "id": self.task_id,
+            "title": self.title,
+            "component_ids": list(self.component_ids),
+            "path": self.path,
+        }
+
+
+def _coerce_title(raw: object, fallback: str) -> str:
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return fallback
+
+
+def _coerce_component_ids(raw: object) -> tuple[str, ...]:
+    if isinstance(raw, Iterable) and not isinstance(raw, (str, bytes)):
+        return tuple(str(item) for item in raw)
+    return ()
+
+
+def _task_sort_key(task_id: str, path: Path) -> tuple[int, str]:
+    prefix, _, remainder = task_id.partition("_")
+    try:
+        numeric = int(prefix)
+    except ValueError:
+        numeric = 1_000_000
+    return (numeric, remainder or path.name)
+
+
+def load_tasks(directory: Path | None = None) -> list[TaskRecord]:
+    """Load and sort every task definition under ``codex/agents/TASKS``."""
+
+    base = directory or TASKS_ROOT
+    if not base.exists():
+        return []
+
+    records: list[TaskRecord] = []
+    for task_path in sorted(base.glob("*.yaml")):
+        data = yaml.safe_load(task_path.read_text(encoding="utf-8")) or {}
+        task_id = str(data.get("id") or task_path.stem)
+        title = _coerce_title(data.get("title"), fallback="(missing title)")
+        component_ids = _coerce_component_ids(data.get("component_ids"))
+        records.append(
+            TaskRecord(
+                task_id=task_id,
+                title=title,
+                component_ids=component_ids,
+                path=str(task_path),
+            )
+        )
+
+    records.sort(key=lambda record: _task_sort_key(record.task_id, Path(record.path)))
+    return records
+
+
+def _format_task_line(record: TaskRecord, show_path: bool) -> str:
+    component_text = ", ".join(record.component_ids) if record.component_ids else "unassigned"
+    extra_parts: list[str] = []
+    if show_path:
+        extra_parts.append(record.path)
+    suffix = f" ({'; '.join(extra_parts)})" if extra_parts else ""
+    return f"- {record.task_id} [{component_text}] — {record.title}{suffix}"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum number of tasks to show (defaults to 10). Use 0 to show all.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("plain", "json"),
+        default="plain",
+        help="Output mode: human-readable plain text or JSON array.",
+    )
+    parser.add_argument(
+        "--show-path",
+        action="store_true",
+        help="Include absolute task file paths in the plain-text output.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    records = load_tasks()
+    total = len(records)
+
+    if args.limit and args.limit > 0:
+        visible = records[: args.limit]
+    else:
+        visible = records
+
+    if args.format == "json":
+        payload = [record.to_dict() for record in visible]
+        json.dump(payload, fp=sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    header_limit = len(visible)
+    print(f"Next tasks (showing {header_limit} of {total} total):")
+    for record in visible:
+        print(_format_task_line(record, show_path=args.show_path))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via CLI in tests
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/unit/observability/test_ci_tooling.py
+++ b/tests/unit/observability/test_ci_tooling.py
@@ -62,12 +62,16 @@ def test_makefile_has_ci_targets():
     assert MAKEFILE_PATH.exists(), "Makefile must exist"
     content = MAKEFILE_PATH.read_text(encoding="utf-8")
 
-    assert ".PHONY: lint typecheck test codex-bootstrap" in content
+    assert ".PHONY: lint typecheck test codex-bootstrap check unit integration e2e acceptance" in content
     assert "lint:" in content
     assert "typecheck:" in content
     assert "test:" in content
+    assert "check: lint typecheck test" in content
     assert "codex-bootstrap:" in content
 
-    assert "ruff check ." in content
-    assert "mypy ." in content
-    assert "pytest" in content
+    assert "PYTHON ?= python3" in content
+    assert "ruff check ." in content and "ruff check . || true" not in content
+    assert "yamllint -s codex/ flows/" in content
+    assert "mypy ." in content and "mypy . || true" not in content
+    assert "pytest --maxfail=1 --disable-warnings" in content and "|| true" not in content
+    assert "-m scripts.codex_next_tasks" in content

--- a/tests/unit/observability/test_codex_next_tasks.py
+++ b/tests/unit/observability/test_codex_next_tasks.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from importlib import util
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "codex_next_tasks.py"
+
+spec = util.spec_from_file_location("codex_next_tasks", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None, "Unable to load codex_next_tasks module"
+codex_next_tasks = util.module_from_spec(spec)
+sys.modules.setdefault("codex_next_tasks", codex_next_tasks)
+spec.loader.exec_module(codex_next_tasks)
+
+
+def test_task_loading_is_sorted_and_enriched() -> None:
+    tasks = codex_next_tasks.load_tasks()
+    assert tasks, "expected to discover at least one task definition"
+
+    ids = [task.task_id for task in tasks[:3]]
+    assert ids == [
+        "00_scaffold_directories",
+        "01_ci_and_tooling",
+        "02_glue_makefile_and_scripts",
+    ]
+
+    for task in tasks:
+        assert Path(task.path).is_file()
+        assert task.title
+
+
+def test_cli_plain_output_lists_tasks() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.codex_next_tasks", "--limit", "5"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    assert lines[0].startswith("Next tasks (showing")
+    assert any(
+        "02_glue_makefile_and_scripts" in line
+        and "Add Makefile and codex helper scripts" in line
+        for line in lines[1:]
+    )
+
+
+def test_cli_plain_limit_zero_shows_all_tasks() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.codex_next_tasks", "--limit", "0"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    header = lines[0]
+    assert header.startswith("Next tasks (showing")
+    assert len(lines) - 1 >= 10, "expected multiple tasks when limit is zero"
+
+
+def test_cli_json_output() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.codex_next_tasks",
+            "--format",
+            "json",
+            "--limit",
+            "2",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert [item["id"] for item in payload] == [
+        "00_scaffold_directories",
+        "01_ci_and_tooling",
+    ]
+    assert all(Path(item["path"]).is_file() for item in payload)


### PR DESCRIPTION
## Summary
- implement `scripts/codex_next_tasks.py` to surface Codex task metadata from `codex/agents/TASKS` per the `observability_ci` component in `codex/specs/ragx_master_spec.yaml`
- tighten the Makefile lint/type/test targets, add a `check` aggregate, and expose an acceptance test target for CI orchestration
- extend observability unit tests to cover the richer Makefile expectations and the Codex bootstrap helper CLI

## Testing
- pytest tests/unit/observability -q


------
https://chatgpt.com/codex/tasks/task_e_68d8ca264de0832c8b1b9e56819a10b8