### PR TITLE
Implement Markdown ingestion for vectordb builder

### DIFF
--- a/codex/specs/ragx_master_spec.yaml
+++ b/codex/specs/ragx_master_spec.yaml
@@ -61,6 +61,7 @@ arg_spec:
     - { flag: "--merge",             dest: merge,             type: path,   repeatable: true }
     - { flag: "--faiss-threads",     dest: faiss_threads,     type: int,    default: 0 }
     - { flag: "--to-gpu",            dest: to_gpu,            type: int }
+    - { flag: "--accept-format",     dest: accept_format,     type: enum,   choices: [pdf,md], repeatable: true, default: [pdf,md], help: "Accepted source formats when scanning --corpus-dir." }
 
   retrieval:
     - { flag: "--search",            dest: search,            type: enum,   choices: [bing,tavily,none], default: none, help: "Web search provider used by retriever." }
@@ -466,6 +467,7 @@ components:
   description: Stable Python registry + protocols; C++ interface design; CLI wrapper; CPU-serialized index contract. Consumed by MCP tool implementations and Serving Node; NOT imported directly by the Task Runner.
   responsibilities:
     - Provide Backend/Handle protocols, registry, CLI; enforce CPU serialization contract; shard merge API.
+    - Orchestrate ingestion from PDF and Markdown corpora discovered under --corpus-dir, extracting text and metadata (front-matter aware).
   interfaces:
     cli:
       command: "vectordb-builder"
@@ -483,6 +485,11 @@ components:
       index_spec_json: "index_spec.json"
       docmap_json: "docmap.json"
       shards_dir: "shards/"
+    corpus_input:
+      description: "Files discovered under --corpus-dir; PDFs and Markdown are supported."
+      formats:
+        pdf: "Extract text and document metadata when available."
+        md: "Extract Markdown content; parse optional front-matter (YAML or key:value headers) above a '---' delimiter."
   dependencies: [numpy]
   observability:
     metrics: [shards_merged_total, index_serialize_seconds, index_deserialize_seconds]
@@ -591,7 +598,7 @@ components:
   repository: "git+ssh://example.com/your-org/research-collector.git"
   artifacts_out: ["collector/manifest.json", "collector/corpus.jsonl", "collector/pdfs/"]
   responsibilities:
-    - Build manifest, download PDFs, enrich metadata, export corpus for indexing.
+    - Build manifest, download PDFs/Markdown, enrich metadata, export corpus for indexing.
   interfaces:
     cli:
       command: "research-collector"
@@ -602,6 +609,9 @@ components:
   data_contracts:
     manifest_json: "collector/manifest.schema.json"
     corpus_jsonl: "collector/corpus.schema.json"
+    markdown_front_matter:
+      description: "When Markdown has front-matter, prefer YAML; otherwise support key:value header blocks above a '---' delimiter."
+      precedence: "Front-matter keys override embedded metadata fields."
   dependencies: [aria2c, jdownloader, pypdf_or_pymupdf]
   observability:
     logs: [download_success_rate, metadata_completion_rate]
@@ -737,6 +747,10 @@ open_decisions:
     question: How to handle tools marked deterministic:false?
     options: [bypass_cache_warn, block_in_ci, allow_with_tag]
     default: bypass_cache_warn
+  - id: markdown_front_matter_precedence
+    question: If both embedded metadata and front-matter exist, which wins?
+    options: [front_matter_overrides, prefer_embedded_metadata, merge_with_priority_front_matter]
+    default: front_matter_overrides
 
 # Test matrix (high-level)
 tests:
@@ -761,5 +775,6 @@ tests:
     - planner_outline_hitl_flow
     - agents_parallel_speedup_and_dedupe
     - vectordb_build_and_search_small_fixture
+    - vectordb_build_md_fixture
   ci:
     coverage_minimum: 85

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -1,0 +1,77 @@
+# Ingestion Pipeline
+
+RAGX supports corpus ingestion for the vector database builder through the
+`vectordb-builder build` CLI command. The command walks the directory supplied
+via `--corpus-dir`, parses each supported document type, and emits normalized
+records (text + metadata) to `docmap.json` in the build output directory.
+
+## Supported formats
+
+The accepted formats are controlled by the repeatable `--accept-format` flag.
+By default the builder scans for both Markdown (`md`) and PDF (`pdf`) files. A
+single format can be selected by supplying the flag one or more times, e.g.:
+
+```bash
+vectordb-builder build \
+  --corpus-dir ./corpus \
+  --out ./build \
+  --accept-format md
+```
+
+### Markdown (`.md`)
+
+Markdown ingestion is front-matter aware. If a document begins with front
+matter it is parsed and merged into the record metadata. Two front-matter
+flavours are recognised:
+
+1. **YAML front-matter** using the classic `---` fenced block.
+
+   ```markdown
+   ---
+   id: doc-one
+   title: Document One
+   tags:
+     - alpha
+     - beta
+   ---
+   # Document One
+   Body text...
+   ```
+
+2. **Key-value header** lines preceding a `---` delimiter.
+
+   ```markdown
+   title: Document Two
+   tags: overview, getting-started
+   ---
+   Document content...
+   ```
+
+Front-matter keys override any existing metadata supplied by upstream systems
+(per the `markdown_front_matter_precedence` open decision). Content below the
+delimiter is preserved verbatim.
+
+### PDF (`.pdf`)
+
+PDF ingestion relies on `pypdf` for text extraction. When the package is not
+available the builder raises a clear error prompting installation. Extracted
+document metadata is merged with the base record while preserving any fields
+already populated.
+
+## Output
+
+The CLI writes `docmap.json` into the directory supplied via `--out`. Each
+entry contains:
+
+```json
+{
+  "id": "doc-one",
+  "path": "guides/doc1.md",
+  "format": "md",
+  "metadata": {"title": "Document One", "tags": ["alpha", "beta"]},
+  "text": "# Document One\nBody text..."
+}
+```
+
+Document identifiers default to the Markdown front-matter `id`. When not
+present the filename stem is used and deduplicated automatically.

--- a/ragcore/__init__.py
+++ b/ragcore/__init__.py
@@ -1,0 +1,5 @@
+"""Vector DB core package."""
+
+from __future__ import annotations
+
+__all__ = ["ingest"]

--- a/ragcore/cli.py
+++ b/ragcore/cli.py
@@ -1,0 +1,94 @@
+"""CLI entry point for vectordb-builder."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from .ingest.scanner import IngestedDocument, scan_corpus
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="vectordb-builder")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build", help="Build vector index artifacts from a corpus.")
+    build.add_argument("--corpus-dir", type=Path, required=True, help="Path to corpus directory.")
+    build.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Output directory for build artifacts.",
+    )
+    build.add_argument(
+        "--accept-format",
+        dest="accept_format",
+        action="append",
+        choices=["pdf", "md"],
+        help="Accepted source formats when scanning --corpus-dir.",
+    )
+    build.set_defaults(func=_cmd_build)
+
+    return parser
+
+
+def _cmd_build(args: argparse.Namespace) -> int:
+    formats: Sequence[str] | None = args.accept_format
+    documents = scan_corpus(args.corpus_dir, accept_formats=formats)
+
+    out_dir: Path = args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    docmap = _build_docmap(args.corpus_dir, documents)
+    docmap_path = out_dir / "docmap.json"
+    docmap_path.write_text(json.dumps(docmap, indent=2, sort_keys=True), encoding="utf-8")
+
+    summary = {"documents": len(documents), "docmap_path": str(docmap_path)}
+    print(json.dumps(summary))
+    return 0
+
+
+def _build_docmap(corpus_dir: Path, documents: Sequence[IngestedDocument]) -> dict[str, Any]:
+    entries: list[dict[str, Any]] = []
+    seen: dict[str, int] = {}
+
+    for record in documents:
+        metadata = dict(record.metadata)
+        doc_id = str(metadata.get("id") or record.path.stem)
+        counter = seen.get(doc_id)
+        if counter is None:
+            seen[doc_id] = 0
+        else:
+            seen[doc_id] = counter + 1
+            doc_id = f"{doc_id}-{seen[doc_id]}"
+
+        try:
+            rel_path = record.path.relative_to(corpus_dir).as_posix()
+        except ValueError:
+            rel_path = record.path.resolve().as_posix()
+
+        entries.append(
+            {
+                "id": doc_id,
+                "path": rel_path,
+                "format": record.format,
+                "metadata": metadata,
+                "text": record.text,
+            }
+        )
+
+    return {"documents": entries}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ragcore/ingest/__init__.py
+++ b/ragcore/ingest/__init__.py
@@ -1,0 +1,9 @@
+"""Ingestion helpers for vector DB corpora."""
+
+from __future__ import annotations
+
+from .md_parser import parse_markdown
+from .pdf_parser import parse_pdf
+from .scanner import IngestedDocument, scan_corpus
+
+__all__ = ["parse_markdown", "parse_pdf", "IngestedDocument", "scan_corpus"]

--- a/ragcore/ingest/md_parser.py
+++ b/ragcore/ingest/md_parser.py
@@ -1,0 +1,104 @@
+"""Markdown ingestion utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+FrontMatter = dict[str, Any]
+
+
+def parse_markdown(
+    path: Path,
+    base_metadata: Mapping[str, Any] | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """Parse a Markdown document extracting optional front-matter.
+
+    Parameters
+    ----------
+    path:
+        The Markdown file to parse.
+    base_metadata:
+        Existing metadata extracted from other sources. Values defined in
+        front-matter take precedence per the ``markdown_front_matter_precedence``
+        open decision.
+    """
+
+    raw_text = path.read_text(encoding="utf-8")
+    text, front_matter = _split_front_matter(raw_text)
+
+    metadata = dict(base_metadata or {})
+    if front_matter:
+        metadata.update(front_matter)
+
+    return text, metadata
+
+
+def _split_front_matter(raw_text: str) -> tuple[str, FrontMatter]:
+    text = raw_text.lstrip("\ufeff")
+
+    if text.startswith("---"):
+        extracted = _extract_yaml_front_matter(text)
+        if extracted is not None:
+            return extracted
+
+    extracted = _extract_key_value_front_matter(text)
+    if extracted is not None:
+        return extracted
+
+    return text, {}
+
+
+def _extract_yaml_front_matter(text: str) -> tuple[str, FrontMatter] | None:
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return None
+
+    closing = None
+    for idx, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            closing = idx
+            break
+
+    if closing is None:
+        return None
+
+    block = "".join(lines[1:closing])
+    try:
+        data = yaml.safe_load(block) or {}
+    except yaml.YAMLError:
+        data = {}
+
+    if not isinstance(data, dict):
+        data = {}
+
+    remainder = "".join(lines[closing + 1 :])
+    return remainder, data
+
+
+def _extract_key_value_front_matter(text: str) -> tuple[str, FrontMatter] | None:
+    lines = text.splitlines(keepends=True)
+    try:
+        delimiter_index = next(idx for idx, line in enumerate(lines) if line.strip() == "---")
+    except StopIteration:
+        return None
+
+    if delimiter_index == 0:
+        return None
+
+    header_lines = lines[:delimiter_index]
+    metadata: dict[str, Any] = {}
+    for raw_line in header_lines:
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        if ":" not in stripped:
+            return None
+        key, value = stripped.split(":", 1)
+        metadata[key.strip()] = value.strip()
+
+    remainder = "".join(lines[delimiter_index + 1 :])
+    return remainder, metadata

--- a/ragcore/ingest/pdf_parser.py
+++ b/ragcore/ingest/pdf_parser.py
@@ -1,0 +1,46 @@
+"""PDF ingestion utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+try:
+    from pypdf import PdfReader  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    PdfReader = None
+
+
+def parse_pdf(
+    path: Path,
+    base_metadata: Mapping[str, Any] | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """Parse a PDF document, extracting text and merging metadata."""
+
+    if PdfReader is None:
+        raise RuntimeError(
+            "pypdf is required for PDF ingestion; install ragx[ingest] "
+            "or add pypdf to your environment."
+        )
+
+    reader = PdfReader(str(path))
+
+    text_parts = []
+    for page in reader.pages:
+        extracted = page.extract_text() or ""
+        cleaned = extracted.strip()
+        if cleaned:
+            text_parts.append(cleaned)
+
+    text = "\n".join(text_parts)
+
+    metadata = dict(base_metadata or {})
+    pdf_meta = getattr(reader, "metadata", None) or {}
+    for key, value in pdf_meta.items():
+        if not key:
+            continue
+        key_str = key.lstrip("/") if isinstance(key, str) else str(key)
+        metadata.setdefault(key_str, value)
+
+    return text, metadata

--- a/ragcore/ingest/scanner.py
+++ b/ragcore/ingest/scanner.py
@@ -1,0 +1,73 @@
+"""Directory scanner for corpus ingestion."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .md_parser import parse_markdown
+from .pdf_parser import parse_pdf
+
+SUPPORTED_FORMATS = {"md", "pdf"}
+
+
+@dataclass(frozen=True)
+class IngestedDocument:
+    path: Path
+    text: str
+    metadata: dict[str, Any]
+    format: str
+
+
+def scan_corpus(
+    corpus_dir: Path,
+    accept_formats: Sequence[str] | None = None,
+) -> list[IngestedDocument]:
+    """Scan a corpus directory and parse supported documents."""
+
+    if not corpus_dir.exists():
+        raise FileNotFoundError(f"Corpus directory does not exist: {corpus_dir}")
+
+    requested = set(accept_formats) if accept_formats else set(SUPPORTED_FORMATS)
+    unknown = requested - SUPPORTED_FORMATS
+    if unknown:
+        raise ValueError(f"Unsupported formats requested: {sorted(unknown)}")
+
+    documents: list[IngestedDocument] = []
+    for file_path in _iter_files(corpus_dir):
+        suffix = file_path.suffix.lower().lstrip(".")
+        if suffix not in requested:
+            continue
+
+        parser = _get_parser(suffix)
+        text, metadata = parser(file_path, base_metadata={"format": suffix})
+        merged = dict(metadata)
+        merged.setdefault("format", suffix)
+
+        documents.append(
+            IngestedDocument(
+                path=file_path,
+                text=text,
+                metadata=merged,
+                format=suffix,
+            )
+        )
+
+    documents.sort(key=lambda doc: doc.path.relative_to(corpus_dir).as_posix())
+    return documents
+
+
+def _iter_files(corpus_dir: Path) -> Iterator[Path]:
+    for path in sorted(corpus_dir.rglob("*")):
+        if path.is_file():
+            yield path
+
+
+def _get_parser(fmt: str):
+    if fmt == "md":
+        return parse_markdown
+    if fmt == "pdf":
+        return parse_pdf
+    raise ValueError(f"Unsupported format: {fmt}")

--- a/tests/e2e/test_vectordb_build_md_fixture.py
+++ b/tests/e2e/test_vectordb_build_md_fixture.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_vectordb_build_md_fixture(tmp_path: Path) -> None:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+
+    (corpus / "doc1.md").write_text(
+        "---\n"
+        "id: doc-one\n"
+        "title: Document One\n"
+        "category: reference\n"
+        "---\n"
+        "# Document One\n"
+        "Body text here.\n",
+        encoding="utf-8",
+    )
+
+    (corpus / "doc2.md").write_text(
+        "title: Document Two\n"
+        "tags: t1, t2\n"
+        "---\n"
+        "Document two content.\n",
+        encoding="utf-8",
+    )
+
+    out_dir = tmp_path / "out"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "ragcore.cli",
+        "build",
+        "--corpus-dir",
+        str(corpus),
+        "--out",
+        str(out_dir),
+        "--accept-format",
+        "md",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+    docmap_path = out_dir / "docmap.json"
+    assert docmap_path.exists(), "docmap.json should be written"
+
+    docmap = json.loads(docmap_path.read_text(encoding="utf-8"))
+    documents = {entry["id"]: entry for entry in docmap["documents"]}
+
+    doc_one = documents["doc-one"]
+    assert doc_one["metadata"]["title"] == "Document One"
+    assert doc_one["metadata"]["category"] == "reference"
+
+    doc_two = documents["doc2"]
+    assert doc_two["metadata"]["title"] == "Document Two"
+    assert doc_two["metadata"]["tags"] == "t1, t2"
+
+    assert doc_one["path"].endswith("doc1.md")
+    assert doc_two["path"].endswith("doc2.md")

--- a/tests/unit/test_md_front_matter_parse.py
+++ b/tests/unit/test_md_front_matter_parse.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ragcore.ingest.md_parser import parse_markdown
+
+
+def _write(tmp_path: Path, name: str, contents: str) -> Path:
+    path = tmp_path / name
+    path.write_text(contents, encoding="utf-8")
+    return path
+
+
+def test_yaml_front_matter_overrides_base_metadata(tmp_path: Path) -> None:
+    doc = _write(
+        tmp_path,
+        "yaml_doc.md",
+        "---\n"
+        "title: Doc Title\n"
+        "aliases:\n"
+        "  - dt\n"
+        "---\n"
+        "# Heading\n"
+        "Body text.\n",
+    )
+
+    text, metadata = parse_markdown(doc, base_metadata={"title": "Old", "category": "notes"})
+
+    assert "Heading" in text
+    assert metadata["title"] == "Doc Title"
+    assert metadata["category"] == "notes"
+    assert metadata["aliases"] == ["dt"]
+
+
+def test_key_value_front_matter_parses_and_overrides(tmp_path: Path) -> None:
+    doc = _write(
+        tmp_path,
+        "kv_doc.md",
+        "title: Front Matter Title\n"
+        "tags: a, b\n"
+        "---\n"
+        "Actual content\n",
+    )
+
+    text, metadata = parse_markdown(doc, base_metadata={"title": "Fallback", "tags": "c"})
+
+    assert text.strip() == "Actual content"
+    assert metadata["title"] == "Front Matter Title"
+    assert metadata["tags"] == "a, b"
+
+
+def test_missing_front_matter_returns_plain_text(tmp_path: Path) -> None:
+    doc = _write(tmp_path, "plain.md", "No front matter here\nSecond line\n")
+
+    text, metadata = parse_markdown(doc, base_metadata={"category": "misc"})
+
+    assert text.startswith("No front matter")
+    assert metadata == {"category": "misc"}
+
+
+@pytest.mark.parametrize(
+    "header_lines",
+    [
+        "invalid header\n---\nBody\n",
+        "key only\n---\nBody\n",
+    ],
+)
+def test_invalid_header_does_not_raise(tmp_path: Path, header_lines: str) -> None:
+    doc = _write(tmp_path, "invalid.md", header_lines)
+
+    text, metadata = parse_markdown(doc)
+
+    assert text.endswith("Body\n")
+    # Invalid headers are ignored; metadata remains unchanged (empty dict)
+    assert metadata == {}


### PR DESCRIPTION
## Summary
- extend the master spec for `vector_db_core`/`research_collector` to document Markdown corpus ingestion and expose the repeatable `--accept-format` flag for `vectordb-builder`
- add Markdown/PDF parsers, a corpus scanner, and wire them into the `vectordb-builder build` CLI along with documentation of the ingestion workflow
- cover Markdown front matter handling and CLI ingestion flow with new unit and e2e tests

## Testing
- `python -m ruff check ragcore/cli.py ragcore/ingest/md_parser.py ragcore/ingest/pdf_parser.py ragcore/ingest/scanner.py tests/unit/test_md_front_matter_parse.py tests/e2e/test_vectordb_build_md_fixture.py -q`
- `python -m pytest tests/unit/test_md_front_matter_parse.py -q`
- `python -m pytest tests/e2e/test_vectordb_build_md_fixture.py -q`
- `python -m pytest -q` *(fails: existing CI scaffolding tests still expect yet-to-be-implemented tooling)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d3bc3c70832c81e3adf08c46a62a