### PR TITLE
Add simulated vector DB backends with registry and tests

### DIFF
--- a/docs/vectordb_backends.md
+++ b/docs/vectordb_backends.md
@@ -1,0 +1,62 @@
+# Vector Database Backends
+
+This document outlines the simulated vector database backends provided by `ragcore`. The
+implementations adhere to the `ragcore.backends.base.Handle` protocol so they can be used
+interchangeably by higher-level orchestration code and tests.
+
+## Common Capabilities
+
+All backends rely on a shared in-memory implementation that stores vectors in NumPy arrays and
+supports deterministic CPU serialisation. The handles expose:
+
+- `requires_training()` – indicates whether training data must be supplied before ingesting
+  vectors.
+- `train(vectors)` – validates the training data and toggles the trained state.
+- `add(vectors, ids=None)` – appends vectors to the index while optionally accepting external
+  identifiers.
+- `search(queries, k)` – performs exact nearest-neighbour search for the requested metric.
+- `serialize_cpu()` – returns a `SerializedIndex` payload suitable for persistence.
+- `merge_with(other)` – merges shards that share the same `IndexSpec`.
+- `to_gpu(device=None)` – clones the handle and marks it as GPU-backed when supported.
+
+### Distance Metrics
+
+The following metrics are supported across every backend:
+
+- `l2` – squared L2 distance.
+- `ip` – inner product; search results are ordered by highest similarity.
+- `cosine` – cosine distance, normalised and returned as `1 - cosine_similarity`.
+
+## FAISS Backend
+
+The FAISS backend (`FaissBackend`) simulates the behaviour of FAISS indexes. It supports three
+index kinds:
+
+| Kind       | Training Required | Notes                          |
+|------------|-------------------|--------------------------------|
+| `flat`     | No                | Brute-force exact search.      |
+| `ivf_flat` | Yes               | Simulates centroid-based IVF.  |
+| `ivf_pq`   | Yes               | Simulates IVF with PQ codebooks.|
+
+The backend advertises GPU support; calling `to_gpu()` on a handle returns a clone flagged for a
+specific CUDA device.
+
+## HNSW Backend
+
+`HnswBackend` exposes a graph-based index with deterministic reinsertion semantics. The Python
+implementation keeps behaviour simple by reusing the shared in-memory store while preserving the
+handle contract. Merging shards concatenates stored vectors and reassigns contiguous identifiers.
+
+## cuVS Backend
+
+`CuVSBackend` represents the GPU-first RAFT/cuVS indexes. Handles require training and expose the
+same API as FAISS, including GPU promotion via `to_gpu()`. Serialisation always uses the CPU code
+path so higher-level tooling can persist indexes without GPU dependencies.
+
+## Registry
+
+Backends register with `ragcore.registry`, which maintains a mapping from backend names to
+instances. Call `ragcore.backends.register_default_backends()` to populate the registry with the
+FAISS, HNSW, and cuVS implementations. The registry exposes `register`, `get`, and
+`list_backends` helpers used by unit and end-to-end tests to orchestrate builds and searches.
+

--- a/ragcore/backends/__init__.py
+++ b/ragcore/backends/__init__.py
@@ -1,0 +1,35 @@
+from .base import Backend, Handle, IndexSpec, SerializedIndex, VectorIndexHandle
+from .cuvs import CuVSBackend
+from .faiss import FaissBackend
+from .hnsw import HnswBackend
+
+
+DEFAULT_BACKENDS = (FaissBackend, HnswBackend, CuVSBackend)
+
+
+def register_default_backends() -> None:
+    """Register the default set of backends with :mod:`ragcore.registry`."""
+
+    from ragcore.registry import list_backends, register
+
+    existing = set(list_backends())
+    for backend_cls in DEFAULT_BACKENDS:
+        name = getattr(backend_cls, "name", None)
+        if name in existing:
+            continue
+        register(backend_cls())
+        existing.add(name)
+
+__all__ = [
+    "Backend",
+    "Handle",
+    "IndexSpec",
+    "SerializedIndex",
+    "VectorIndexHandle",
+    "DEFAULT_BACKENDS",
+    "register_default_backends",
+    "CuVSBackend",
+    "FaissBackend",
+    "HnswBackend",
+]
+

--- a/ragcore/backends/base.py
+++ b/ragcore/backends/base.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Protocol
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+FloatArray = NDArray[np.float32]
+IntArray = NDArray[np.int64]
+
+
+class Backend(Protocol):
+    """Protocol describing a backend factory registered with ragcore."""
+
+    name: str
+
+    def capabilities(self) -> Mapping[str, Any]:
+        """Return a JSON-serialisable description of backend capabilities."""
+
+    def build(self, spec: Mapping[str, Any]) -> "Handle":
+        """Construct a new handle that implements :class:`Handle`."""
+
+
+class Handle(Protocol):
+    """Protocol describing the concrete index handle exposed to Python."""
+
+    is_gpu: bool
+    device: str | None
+
+    def requires_training(self) -> bool: ...
+
+    def train(self, vectors: FloatArray) -> None: ...
+
+    def add(self, vectors: FloatArray, ids: IntArray | None = None) -> None: ...
+
+    def search(self, queries: FloatArray, k: int, **kwargs: Any) -> Dict[str, FloatArray | IntArray]: ...
+
+    def ntotal(self) -> int: ...
+
+    def serialize_cpu(self) -> "SerializedIndex": ...
+
+    def to_gpu(self, device: str | None = None) -> "Handle": ...
+
+    def merge_with(self, other: "Handle") -> "Handle": ...
+
+    def spec(self) -> Mapping[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class IndexSpec:
+    """Parsed configuration for an index."""
+
+    backend: str
+    kind: str
+    metric: str
+    dim: int
+    params: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, Any], *, default_backend: str | None = None) -> "IndexSpec":
+        backend_value = mapping.get("backend", default_backend)
+        if backend_value is None:
+            raise ValueError("index spec must include a backend")
+        backend = str(backend_value)
+        kind_value = mapping.get("kind")
+        metric_value = mapping.get("metric")
+        kind = str(kind_value) if kind_value is not None else None
+        metric = str(metric_value) if metric_value is not None else None
+        dim = mapping.get("dim")
+        if kind is None or metric is None or dim is None:
+            raise ValueError("index spec missing required fields: kind, metric, dim")
+        if not isinstance(dim, int) or dim <= 0:
+            raise ValueError("dim must be a positive integer")
+        params = mapping.get("params") or {}
+        if not isinstance(params, Mapping):
+            raise ValueError("params must be a mapping if provided")
+        return cls(backend=backend, kind=kind, metric=metric, dim=dim, params=dict(params))
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "backend": self.backend,
+            "kind": self.kind,
+            "metric": self.metric,
+            "dim": self.dim,
+            "params": dict(self.params),
+        }
+
+
+@dataclass(frozen=True)
+class SerializedIndex:
+    """CPU serialised payload for an index."""
+
+    spec: Mapping[str, Any]
+    vectors: FloatArray
+    ids: IntArray
+    metadata: Mapping[str, Any]
+    is_trained: bool
+    is_gpu: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-friendly representation of the serialised index."""
+
+        return {
+            "spec": dict(self.spec),
+            "vectors": self.vectors.tolist(),
+            "ids": self.ids.tolist(),
+            "metadata": dict(self.metadata),
+            "is_trained": self.is_trained,
+            "is_gpu": self.is_gpu,
+        }
+
+
+def _ensure_2d_float32(data: FloatArray, *, dim: int) -> FloatArray:
+    array = np.asarray(data, dtype=np.float32)
+    if array.ndim != 2:
+        raise ValueError("expected a 2D array of float32 vectors")
+    if array.shape[1] != dim:
+        raise ValueError(f"expected vectors with dimension {dim}, got {array.shape[1]}")
+    return array
+
+
+def _ensure_ids(ids: IntArray | None, *, count: int) -> IntArray | None:
+    if ids is None:
+        return None
+    array = np.asarray(ids, dtype=np.int64)
+    if array.ndim != 1 or array.shape[0] != count:
+        raise ValueError("ids must be a 1D array matching the number of vectors")
+    return array
+
+
+def _distance_matrix(vectors: FloatArray, queries: FloatArray, metric: str) -> FloatArray:
+    if metric == "l2":
+        diffs = queries[:, None, :] - vectors[None, :, :]
+        return np.sum(diffs * diffs, axis=2)
+    if metric == "ip":
+        sims = queries @ vectors.T
+        return -sims
+    if metric == "cosine":
+        vectors_norm = np.linalg.norm(vectors, axis=1)
+        queries_norm = np.linalg.norm(queries, axis=1)
+        denom = np.clip(np.outer(queries_norm, vectors_norm), a_min=1e-12, a_max=None)
+        cosine = (queries @ vectors.T) / denom
+        return 1.0 - cosine
+    raise ValueError(f"unsupported metric '{metric}'")
+
+
+class VectorIndexHandle:
+    """Concrete implementation shared by all simulated backends."""
+
+    def __init__(self, spec: IndexSpec, *, requires_training: bool, supports_gpu: bool = False) -> None:
+        self._spec = spec
+        self._requires_training = requires_training
+        self._supports_gpu = supports_gpu
+        self._factory_kwargs: Dict[str, Any] = {}
+        self._vectors: FloatArray = np.empty((0, spec.dim), dtype=np.float32)
+        self._ids: IntArray = np.empty((0,), dtype=np.int64)
+        self._next_id = 0
+        self._is_trained = not requires_training
+        self.is_gpu = False
+        self.device: str | None = None
+
+    def requires_training(self) -> bool:
+        return self._requires_training
+
+    def train(self, vectors: FloatArray) -> None:
+        if not self._requires_training:
+            self._is_trained = True
+            return
+        _ensure_2d_float32(vectors, dim=self._spec.dim)
+        self._is_trained = True
+
+    def add(self, vectors: FloatArray, ids: IntArray | None = None) -> None:
+        if self._requires_training and not self._is_trained:
+            raise RuntimeError("index requires training before adding vectors")
+        batch = _ensure_2d_float32(vectors, dim=self._spec.dim)
+        ids_array = _ensure_ids(ids, count=batch.shape[0])
+        if ids_array is None:
+            ids_array = np.arange(self._next_id, self._next_id + batch.shape[0], dtype=np.int64)
+        self._next_id = max(self._next_id, int(ids_array.max()) + 1)
+        self._vectors = np.concatenate([self._vectors, batch], axis=0)
+        self._ids = np.concatenate([self._ids, ids_array], axis=0)
+
+    def search(self, queries: FloatArray, k: int, **_: Any) -> Dict[str, FloatArray | IntArray]:
+        if self._vectors.shape[0] == 0:
+            raise RuntimeError("cannot search an empty index")
+        query_array = _ensure_2d_float32(queries, dim=self._spec.dim)
+        k = min(k, self._vectors.shape[0])
+        distances = _distance_matrix(self._vectors, query_array, self._spec.metric)
+        order = np.argsort(distances, axis=1)
+        topk = order[:, :k]
+        ids_matrix = np.tile(self._ids, (query_array.shape[0], 1))
+        top_distances = np.take_along_axis(distances, topk, axis=1)
+        top_ids = np.take_along_axis(ids_matrix, topk, axis=1)
+        return {"ids": top_ids, "distances": top_distances}
+
+    def ntotal(self) -> int:
+        return int(self._vectors.shape[0])
+
+    def serialize_cpu(self) -> SerializedIndex:
+        metadata = {
+            "requires_training": self._requires_training,
+            "supports_gpu": self._supports_gpu,
+        }
+        return SerializedIndex(
+            spec=self._spec.as_dict(),
+            vectors=self._vectors.copy(),
+            ids=self._ids.copy(),
+            metadata=metadata,
+            is_trained=self._is_trained,
+            is_gpu=self.is_gpu,
+        )
+
+    def to_gpu(self, device: str | None = None) -> "VectorIndexHandle":
+        clone = self._clone()
+        if self._supports_gpu:
+            clone.is_gpu = True
+            clone.device = device or "cuda:0"
+        return clone
+
+    def merge_with(self, other: "Handle") -> "VectorIndexHandle":
+        if not isinstance(other, VectorIndexHandle):
+            raise TypeError("can only merge with another VectorIndexHandle")
+        if other._spec != self._spec:
+            raise ValueError("cannot merge indexes with different specs")
+        merged = self._clone(empty=True)
+        merged._vectors = np.concatenate([self._vectors, other._vectors], axis=0)
+        merged._ids = np.arange(merged._vectors.shape[0], dtype=np.int64)
+        merged._next_id = merged._ids.shape[0]
+        merged._is_trained = self._is_trained or other._is_trained
+        merged.is_gpu = self.is_gpu or other.is_gpu
+        merged.device = self.device if self.is_gpu else other.device
+        return merged
+
+    def spec(self) -> Mapping[str, Any]:
+        return self._spec.as_dict()
+
+    def _clone(self, *, empty: bool = False) -> "VectorIndexHandle":
+        clone = self.__class__(self._spec, **self._factory_kwargs)
+        clone._requires_training = self._requires_training
+        clone._supports_gpu = self._supports_gpu
+        clone._is_trained = self._is_trained
+        if not empty:
+            clone._vectors = self._vectors.copy()
+            clone._ids = self._ids.copy()
+            clone._next_id = self._next_id
+            clone.is_gpu = self.is_gpu
+            clone.device = self.device
+        return clone
+
+
+__all__ = [
+    "Backend",
+    "Handle",
+    "IndexSpec",
+    "SerializedIndex",
+    "VectorIndexHandle",
+]
+

--- a/ragcore/backends/cuvs.py
+++ b/ragcore/backends/cuvs.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .base import IndexSpec, VectorIndexHandle
+
+
+class CuVSBackend:
+    """Simulated RAFT/cuVS backend with GPU-aware handle."""
+
+    name = "cuvs"
+
+    _SUPPORTED_KINDS = {"ivf_flat", "ivf_pq"}
+    _METRICS = {"l2", "ip", "cosine"}
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return {
+            "name": self.name,
+            "supports_gpu": True,
+            "kinds": {
+                "ivf_flat": {"requires_training": True, "params": ["nlist", "nprobe"]},
+                "ivf_pq": {"requires_training": True, "params": ["nlist", "m", "nbits"]},
+            },
+            "metrics": sorted(self._METRICS),
+        }
+
+    def build(self, spec: Mapping[str, Any]) -> VectorIndexHandle:
+        config = IndexSpec.from_mapping(spec, default_backend=self.name)
+        if config.backend != self.name:
+            raise ValueError(f"cuVS backend cannot build for '{config.backend}'")
+        if config.kind not in self._SUPPORTED_KINDS:
+            raise ValueError(f"unsupported cuVS kind '{config.kind}'")
+        if config.metric not in self._METRICS:
+            raise ValueError(f"unsupported cuVS metric '{config.metric}'")
+        return CuVSHandle(config)
+
+
+class CuVSHandle(VectorIndexHandle):
+    def __init__(self, spec: IndexSpec) -> None:
+        super().__init__(spec, requires_training=True, supports_gpu=True)
+
+
+__all__ = ["CuVSBackend", "CuVSHandle"]
+

--- a/ragcore/backends/faiss.py
+++ b/ragcore/backends/faiss.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .base import IndexSpec, VectorIndexHandle
+
+
+class FaissBackend:
+    """Simulated FAISS backend covering flat, IVF-Flat, and IVFPQ indexes."""
+
+    name = "faiss"
+
+    _SUPPORTED_KINDS = {"flat", "ivf_flat", "ivf_pq"}
+    _METRICS = {"l2", "ip", "cosine"}
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return {
+            "name": self.name,
+            "supports_gpu": True,
+            "kinds": {
+                "flat": {"requires_training": False},
+                "ivf_flat": {"requires_training": True, "params": ["nlist", "nprobe"]},
+                "ivf_pq": {"requires_training": True, "params": ["nlist", "m", "nbits"]},
+            },
+            "metrics": sorted(self._METRICS),
+        }
+
+    def build(self, spec: Mapping[str, Any]) -> VectorIndexHandle:
+        config = IndexSpec.from_mapping(spec, default_backend=self.name)
+        if config.backend != self.name:
+            raise ValueError(f"FAISS backend cannot build for '{config.backend}'")
+        if config.kind not in self._SUPPORTED_KINDS:
+            raise ValueError(f"unsupported FAISS kind '{config.kind}'")
+        if config.metric not in self._METRICS:
+            raise ValueError(f"unsupported FAISS metric '{config.metric}'")
+        requires_training = config.kind in {"ivf_flat", "ivf_pq"}
+        return FaissHandle(config, requires_training=requires_training)
+
+
+class FaissHandle(VectorIndexHandle):
+    """Python implementation mirroring the FAISS handle protocol."""
+
+    def __init__(self, spec: IndexSpec, *, requires_training: bool) -> None:
+        super().__init__(spec, requires_training=requires_training, supports_gpu=True)
+        self._factory_kwargs = {"requires_training": requires_training}
+
+
+__all__ = ["FaissBackend", "FaissHandle"]
+

--- a/ragcore/backends/hnsw.py
+++ b/ragcore/backends/hnsw.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .base import IndexSpec, VectorIndexHandle
+
+
+class HnswBackend:
+    """Simulated HNSW backend using the shared vector handle."""
+
+    name = "hnsw"
+
+    _SUPPORTED_KINDS = {"hnsw"}
+    _METRICS = {"l2", "ip", "cosine"}
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return {
+            "name": self.name,
+            "supports_gpu": False,
+            "kinds": {
+                "hnsw": {"requires_training": False, "params": ["m", "ef", "ef_construction"]},
+            },
+            "metrics": sorted(self._METRICS),
+        }
+
+    def build(self, spec: Mapping[str, Any]) -> VectorIndexHandle:
+        config = IndexSpec.from_mapping(spec, default_backend=self.name)
+        if config.backend != self.name:
+            raise ValueError(f"HNSW backend cannot build for '{config.backend}'")
+        if config.kind not in self._SUPPORTED_KINDS:
+            raise ValueError(f"unsupported HNSW kind '{config.kind}'")
+        if config.metric not in self._METRICS:
+            raise ValueError(f"unsupported HNSW metric '{config.metric}'")
+        return HnswHandle(config)
+
+
+class HnswHandle(VectorIndexHandle):
+    def __init__(self, spec: IndexSpec) -> None:
+        super().__init__(spec, requires_training=False, supports_gpu=False)
+
+
+__all__ = ["HnswBackend", "HnswHandle"]
+

--- a/ragcore/registry.py
+++ b/ragcore/registry.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from ragcore.backends.base import Backend
+
+
+_REGISTRY: Dict[str, Backend] = {}
+
+
+def register(backend: Backend) -> None:
+    """Register a backend instance by name."""
+
+    name = getattr(backend, "name", None)
+    if not name:
+        raise ValueError("backend must define a non-empty 'name' attribute")
+    if name in _REGISTRY:
+        raise ValueError(f"backend '{name}' already registered")
+    _REGISTRY[name] = backend
+
+
+def get(name: str) -> Backend:
+    try:
+        return _REGISTRY[name]
+    except KeyError as exc:
+        raise KeyError(f"backend '{name}' is not registered") from exc
+
+
+def list_backends() -> Iterable[str]:
+    return tuple(sorted(_REGISTRY))
+
+
+def _reset_registry() -> None:
+    _REGISTRY.clear()
+
+
+__all__ = ["register", "get", "list_backends", "_reset_registry"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ jinja2
 jsonschema
 pyyaml
 pytest
+numpy
 ruff
 mypy
 yamllint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/e2e/test_vectordb_build_and_search.py
+++ b/tests/e2e/test_vectordb_build_and_search.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import pytest
+
+from ragcore.backends.cuvs import CuVSBackend
+from ragcore.backends.faiss import FaissBackend
+from ragcore.backends.hnsw import HnswBackend
+from ragcore.registry import get, register, _reset_registry
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> Iterable[None]:
+    _reset_registry()
+    yield
+    _reset_registry()
+
+
+@pytest.mark.parametrize(
+    "backend, spec",
+    [
+        (
+            FaissBackend(),
+            {
+                "backend": "faiss",
+                "kind": "flat",
+                "metric": "l2",
+                "dim": 3,
+            },
+        ),
+        (
+            FaissBackend(),
+            {
+                "backend": "faiss",
+                "kind": "ivf_flat",
+                "metric": "ip",
+                "dim": 3,
+                "params": {"nlist": 1, "nprobe": 1},
+            },
+        ),
+        (
+            HnswBackend(),
+            {
+                "backend": "hnsw",
+                "kind": "hnsw",
+                "metric": "cosine",
+                "dim": 3,
+                "params": {"m": 8, "ef_construction": 24, "ef": 24},
+            },
+        ),
+        (
+            CuVSBackend(),
+            {
+                "backend": "cuvs",
+                "kind": "ivf_pq",
+                "metric": "l2",
+                "dim": 3,
+                "params": {"nlist": 1, "m": 1, "nbits": 8},
+            },
+        ),
+    ],
+)
+def test_small_index_build_and_search(backend, spec) -> None:
+    name = spec["backend"]
+    register(backend)
+    handle = backend.build(spec)
+
+    base = np.eye(3, dtype="float32")
+    queries = base.copy()
+
+    if handle.requires_training():
+        handle.train(base)
+
+    handle.add(base)
+
+    results = handle.search(queries, k=1)
+    assert results["ids"].shape == (3, 1)
+    assert np.array_equal(results["ids"].ravel(), np.arange(3))
+
+    serialized = handle.serialize_cpu()
+    assert serialized.vectors.shape == (3, 3)
+
+    # Round-trip via registry get
+    fetched = get(name)
+    assert fetched.capabilities()["name"] == name
+
+
+def test_merge_shards_across_backends() -> None:
+    faiss = FaissBackend()
+    hnsw = HnswBackend()
+    cuvs = CuVSBackend()
+
+    register(faiss)
+    register(hnsw)
+    register(cuvs)
+
+    faiss_handle = faiss.build({
+        "backend": "faiss",
+        "kind": "flat",
+        "metric": "l2",
+        "dim": 2,
+    })
+    hnsw_handle = hnsw.build({
+        "backend": "hnsw",
+        "kind": "hnsw",
+        "metric": "l2",
+        "dim": 2,
+    })
+    cuvs_handle = cuvs.build({
+        "backend": "cuvs",
+        "kind": "ivf_flat",
+        "metric": "l2",
+        "dim": 2,
+        "params": {"nlist": 1},
+    })
+
+    for handle in (faiss_handle, hnsw_handle, cuvs_handle):
+        if handle.requires_training():
+            handle.train(np.eye(2, dtype="float32"))
+
+    shard_a = np.array([[1.0, 0.0], [0.0, 1.0]], dtype="float32")
+    shard_b = np.array([[2.0, 0.0]], dtype="float32")
+
+    faiss_handle.add(shard_a)
+    hnsw_handle.add(shard_a)
+    cuvs_handle.add(shard_a)
+
+    faiss_other = faiss.build({
+        "backend": "faiss",
+        "kind": "flat",
+        "metric": "l2",
+        "dim": 2,
+    })
+    hnsw_other = hnsw.build({
+        "backend": "hnsw",
+        "kind": "hnsw",
+        "metric": "l2",
+        "dim": 2,
+    })
+    cuvs_other = cuvs.build({
+        "backend": "cuvs",
+        "kind": "ivf_flat",
+        "metric": "l2",
+        "dim": 2,
+        "params": {"nlist": 1},
+    })
+
+    for other in (faiss_other, hnsw_other, cuvs_other):
+        if other.requires_training():
+            other.train(np.eye(2, dtype="float32"))
+        other.add(shard_b)
+
+    merged_faiss = faiss_handle.merge_with(faiss_other)
+    merged_hnsw = hnsw_handle.merge_with(hnsw_other)
+    merged_cuvs = cuvs_handle.merge_with(cuvs_other)
+
+    assert merged_faiss.ntotal() == 3
+    assert merged_hnsw.ntotal() == 3
+    assert merged_cuvs.ntotal() == 3
+
+    for merged in (merged_faiss, merged_hnsw, merged_cuvs):
+        search = merged.search(np.array([[1.0, 0.0]], dtype="float32"), k=1)
+        assert search["ids"].shape == (1, 1)
+        assert search["distances"].shape == (1, 1)
+

--- a/tests/unit/test_spec_vectordb_backends.py
+++ b/tests/unit/test_spec_vectordb_backends.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import pytest
+
+from ragcore.backends import register_default_backends
+from ragcore.backends.base import SerializedIndex
+from ragcore.backends.cuvs import CuVSBackend
+from ragcore.backends.faiss import FaissBackend
+from ragcore.backends.hnsw import HnswBackend
+from ragcore.registry import list_backends, register, _reset_registry
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> Iterable[None]:
+    _reset_registry()
+    yield
+    _reset_registry()
+
+
+def test_backends_register_and_list() -> None:
+    register_default_backends()
+
+    assert set(list_backends()) == {"faiss", "hnsw", "cuvs"}
+
+
+def test_faiss_ivf_training_and_serialization() -> None:
+    backend = FaissBackend()
+    register(backend)
+
+    handle = backend.build({
+        "backend": "faiss",
+        "kind": "ivf_flat",
+        "metric": "l2",
+        "dim": 4,
+        "params": {"nlist": 4, "nprobe": 2},
+    })
+
+    assert handle.requires_training()
+
+    training = np.random.RandomState(42).randn(32, 4).astype("float32")
+    handle.train(training)
+
+    xb = np.random.RandomState(0).randn(10, 4).astype("float32")
+    handle.add(xb)
+
+    assert handle.ntotal() == 10
+
+    search = handle.search(xb[:2], k=3)
+    assert search["ids"].shape == (2, 3)
+    assert search["distances"].shape == (2, 3)
+
+    serialized = handle.serialize_cpu()
+    assert isinstance(serialized, SerializedIndex)
+    assert serialized.spec["kind"] == "ivf_flat"
+    assert serialized.vectors.shape == (10, 4)
+    assert serialized.is_trained is True
+
+
+def test_faiss_merge_and_gpu_clone() -> None:
+    backend = FaissBackend()
+    register(backend)
+
+    spec = {"backend": "faiss", "kind": "flat", "metric": "ip", "dim": 3}
+    left = backend.build(spec)
+    right = backend.build(spec)
+
+    a = np.eye(3, dtype="float32")
+    b = (np.eye(3) * 2).astype("float32")
+
+    left.add(a)
+    right.add(b)
+
+    merged = left.merge_with(right)
+    assert merged.ntotal() == 6
+
+    gpu_clone = merged.to_gpu(device="cuda:0")
+    assert gpu_clone.is_gpu
+    assert gpu_clone.device == "cuda:0"
+    assert gpu_clone.ntotal() == 6
+
+
+def test_hnsw_roundtrip() -> None:
+    backend = HnswBackend()
+    register(backend)
+
+    handle = backend.build({
+        "backend": "hnsw",
+        "kind": "hnsw",
+        "metric": "cosine",
+        "dim": 5,
+        "params": {"m": 8, "ef_construction": 32},
+    })
+
+    assert handle.requires_training() is False
+
+    xb = np.random.RandomState(123).randn(12, 5).astype("float32")
+    handle.add(xb)
+
+    results = handle.search(xb[:1], k=4)
+    assert results["ids"].shape == (1, 4)
+    assert np.all(results["distances"][:, 0] <= results["distances"][:, 1])
+
+    serialized = handle.serialize_cpu()
+    assert serialized.spec["backend"] == "hnsw"
+    assert serialized.ids.shape == (12,)
+
+
+def test_cuvs_gpu_behaviour_and_merge() -> None:
+    backend = CuVSBackend()
+    register(backend)
+
+    spec = {
+        "backend": "cuvs",
+        "kind": "ivf_pq",
+        "metric": "l2",
+        "dim": 6,
+        "params": {"nlist": 2, "m": 2, "nbits": 8},
+    }
+
+    handle = backend.build(spec)
+    assert handle.requires_training()
+
+    training = np.random.RandomState(9).randn(16, 6).astype("float32")
+    handle.train(training)
+
+    xb = np.random.RandomState(7).randn(8, 6).astype("float32")
+    handle.add(xb)
+    assert handle.ntotal() == 8
+
+    gpu_handle = handle.to_gpu()
+    assert gpu_handle.is_gpu
+    assert gpu_handle.ntotal() == 8
+
+    clone = backend.build(spec)
+    clone.train(training)
+    clone.add(xb[:2])
+
+    merged = handle.merge_with(clone)
+    assert merged.ntotal() == 10
+    assert merged.serialize_cpu().vectors.shape == (10, 6)
+


### PR DESCRIPTION
## Summary
- introduce a shared vector index handle with CPU serialization, merging, and GPU promotion semantics
- implement FAISS, HNSW, and cuVS backend facades plus a registry helper for default registration
- cover behaviour with targeted unit/e2e tests and document backend usage

## Testing
- pytest tests/unit/test_spec_vectordb_backends.py tests/e2e/test_vectordb_build_and_search.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d8e49e8728832c8ccd0660f2b967a5