### PR TITLE
Add optional C++ backend scaffold with pybind11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *__pycache__*
+ragcore/backends/_ragcore_cpp*.so
+build/
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+project(ragcore_cpp_stub LANGUAGES CXX)
+
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
+
+pybind11_add_module(_ragcore_cpp MODULE ragcore_cpp_module.cpp)
+target_compile_features(_ragcore_cpp PRIVATE cxx_std_17)
+
+target_include_directories(
+    _ragcore_cpp
+    PRIVATE
+        ${Python_INCLUDE_DIRS}
+)

--- a/cpp/ragcore_cpp_module.cpp
+++ b/cpp/ragcore_cpp_module.cpp
@@ -1,0 +1,368 @@
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+namespace {
+
+constexpr float kEpsilon = 1e-12F;
+
+py::array_t<float, py::array::c_style | py::array::forcecast> ensure_vectors(
+    const py::array& vectors, std::size_t dim
+) {
+    auto converted = py::array_t<float, py::array::c_style | py::array::forcecast>(vectors);
+    if (converted.ndim() != 2) {
+        throw std::invalid_argument("expected a 2D array of vectors");
+    }
+    if (static_cast<std::size_t>(converted.shape(1)) != dim) {
+        throw std::invalid_argument("vector dimension mismatch");
+    }
+    return converted;
+}
+
+std::optional<py::array_t<std::int64_t, py::array::c_style | py::array::forcecast>> ensure_ids(
+    const py::object& ids, std::size_t expected
+) {
+    if (ids.is_none()) {
+        return std::nullopt;
+    }
+    py::array raw(ids);
+    auto converted =
+        py::array_t<std::int64_t, py::array::c_style | py::array::forcecast>(raw);
+    if (converted.ndim() != 1) {
+        throw std::invalid_argument("ids must be a 1D array");
+    }
+    if (static_cast<std::size_t>(converted.shape(0)) != expected) {
+        throw std::invalid_argument("ids length must match number of vectors");
+    }
+    return converted;
+}
+
+float compute_distance(
+    const float* query,
+    const float* vector,
+    std::size_t dim,
+    const std::string& metric,
+    float query_norm
+) {
+    if (metric == "l2") {
+        float sum = 0.0F;
+        for (std::size_t i = 0; i < dim; ++i) {
+            const float diff = query[i] - vector[i];
+            sum += diff * diff;
+        }
+        return sum;
+    }
+    if (metric == "ip") {
+        float dot = 0.0F;
+        for (std::size_t i = 0; i < dim; ++i) {
+            dot += query[i] * vector[i];
+        }
+        return -dot;
+    }
+    if (metric == "cosine") {
+        float dot = 0.0F;
+        float vector_norm = 0.0F;
+        for (std::size_t i = 0; i < dim; ++i) {
+            dot += query[i] * vector[i];
+            vector_norm += vector[i] * vector[i];
+        }
+        vector_norm = std::sqrt(vector_norm);
+        const float denom = std::max(query_norm * vector_norm, kEpsilon);
+        const float cosine = dot / denom;
+        return 1.0F - cosine;
+    }
+    throw std::invalid_argument("unsupported metric: " + metric);
+}
+
+float compute_query_norm(const float* query, std::size_t dim) {
+    float norm = 0.0F;
+    for (std::size_t i = 0; i < dim; ++i) {
+        norm += query[i] * query[i];
+    }
+    return std::sqrt(norm);
+}
+
+}  // namespace
+
+class CPPHandle {
+  public:
+    CPPHandle(py::dict spec, std::string metric, bool requires_training, bool supports_gpu)
+        : spec_dict_(std::move(spec)),
+          metric_(std::move(metric)),
+          requires_training_(requires_training),
+          supports_gpu_(supports_gpu),
+          is_trained_(!requires_training),
+          is_gpu_(false),
+          device_(),
+          next_id_(0) {
+        dim_ = static_cast<std::size_t>(py::int_(spec_dict_["dim"]));
+        kind_ = py::str(spec_dict_["kind"]);
+        backend_ = py::str(spec_dict_["backend"]);
+    }
+
+    bool requires_training() const { return requires_training_; }
+
+    void train(const py::array& vectors) {
+        if (!requires_training_) {
+            is_trained_ = true;
+            return;
+        }
+        auto batch = ensure_vectors(vectors, dim_);
+        if (batch.shape(0) == 0) {
+            throw std::invalid_argument("training vectors cannot be empty");
+        }
+        is_trained_ = true;
+    }
+
+    void add(const py::array& vectors, const py::object& ids = py::none()) {
+        if (requires_training_ && !is_trained_) {
+            throw std::runtime_error("index requires training before adding vectors");
+        }
+        auto batch = ensure_vectors(vectors, dim_);
+        const std::size_t rows = static_cast<std::size_t>(batch.shape(0));
+        if (rows == 0) {
+            return;
+        }
+        auto ids_array = ensure_ids(ids, rows);
+        const auto batch_buffer = batch.request();
+        const float* data = static_cast<float*>(batch_buffer.ptr);
+        std::optional<py::buffer_info> ids_buffer;
+        const std::int64_t* id_ptr = nullptr;
+        if (ids_array.has_value()) {
+            ids_buffer = ids_array->request();
+            id_ptr = static_cast<std::int64_t*>(ids_buffer->ptr);
+        }
+        for (std::size_t row = 0; row < rows; ++row) {
+            const float* vector = data + row * dim_;
+            vectors_.insert(vectors_.end(), vector, vector + dim_);
+            norms_.push_back(compute_query_norm(vector, dim_));
+            if (ids_array.has_value()) {
+                ids_.push_back(id_ptr[row]);
+                next_id_ = std::max(next_id_, ids_.back() + 1);
+            } else {
+                ids_.push_back(next_id_++);
+            }
+        }
+    }
+
+    py::dict search(const py::array& queries, std::int64_t k) const {
+        if (ids_.empty()) {
+            throw std::runtime_error("cannot search an empty index");
+        }
+        auto query_array = ensure_vectors(queries, dim_);
+        const std::size_t query_count = static_cast<std::size_t>(query_array.shape(0));
+        const std::size_t total = ids_.size();
+        const std::size_t limit = static_cast<std::size_t>(std::max<std::int64_t>(0, k));
+        const std::size_t topk = std::min(limit, total);
+
+        if (topk == 0) {
+            throw std::invalid_argument("k must be greater than zero");
+        }
+
+        auto ids_result = py::array_t<std::int64_t>({py::ssize_t(query_count), py::ssize_t(topk)});
+        auto distances_result = py::array_t<float>({py::ssize_t(query_count), py::ssize_t(topk)});
+
+        const auto query_buffer = query_array.request();
+        const float* query_ptr = static_cast<float*>(query_buffer.ptr);
+        auto ids_view = ids_result.mutable_unchecked<2>();
+        auto dist_view = distances_result.mutable_unchecked<2>();
+
+        for (std::size_t qi = 0; qi < query_count; ++qi) {
+            const float* query_vector = query_ptr + qi * dim_;
+            const float query_norm = metric_ == "cosine" ? compute_query_norm(query_vector, dim_) : 0.0F;
+            std::vector<std::pair<float, std::size_t>> ranking;
+            ranking.reserve(total);
+            for (std::size_t vi = 0; vi < total; ++vi) {
+                const float* stored_vector = vectors_.data() + vi * dim_;
+                float distance = compute_distance(query_vector, stored_vector, dim_, metric_, query_norm);
+                ranking.emplace_back(distance, vi);
+            }
+            std::partial_sort(
+                ranking.begin(),
+                ranking.begin() + topk,
+                ranking.end(),
+                [](const auto& lhs, const auto& rhs) {
+                    if (lhs.first == rhs.first) {
+                        return lhs.second < rhs.second;
+                    }
+                    return lhs.first < rhs.first;
+                }
+            );
+            for (std::size_t rank = 0; rank < topk; ++rank) {
+                const auto index = ranking[rank].second;
+                ids_view(qi, rank) = ids_[index];
+                dist_view(qi, rank) = ranking[rank].first;
+            }
+        }
+
+        py::dict result;
+        result["ids"] = std::move(ids_result);
+        result["distances"] = std::move(distances_result);
+        return result;
+    }
+
+    std::int64_t ntotal() const { return static_cast<std::int64_t>(ids_.size()); }
+
+    py::object serialize_cpu() const {
+        py::module interfaces = py::module::import("ragcore.interfaces");
+        py::object serialized_index = interfaces.attr("SerializedIndex");
+
+        const std::size_t count = ids_.size();
+        py::array_t<float> vectors({py::ssize_t(count), py::ssize_t(dim_)});
+        std::memcpy(vectors.mutable_data(), vectors_.data(), sizeof(float) * vectors_.size());
+
+        py::array_t<std::int64_t> ids({py::ssize_t(count)});
+        std::memcpy(ids.mutable_data(), ids_.data(), sizeof(std::int64_t) * ids_.size());
+
+        py::dict metadata;
+        metadata["requires_training"] = requires_training_;
+        metadata["supports_gpu"] = supports_gpu_;
+
+        return serialized_index(
+            spec_dict_,
+            vectors,
+            ids,
+            metadata,
+            py::bool_(is_trained_),
+            py::bool_(is_gpu_)
+        );
+    }
+
+    std::shared_ptr<CPPHandle> to_gpu(const py::object& device = py::none()) const {
+        auto clone = std::make_shared<CPPHandle>(*this);
+        if (supports_gpu_) {
+            clone->is_gpu_ = true;
+            clone->device_ = device.is_none() ? std::string("cuda:0") : device.cast<std::string>();
+        }
+        return clone;
+    }
+
+    std::shared_ptr<CPPHandle> merge_with(const CPPHandle& other) const {
+        const int comparison = PyObject_RichCompareBool(other.spec_dict_.ptr(), spec_dict_.ptr(), Py_EQ);
+        if (comparison == -1) {
+            throw py::error_already_set();
+        }
+        if (comparison == 0) {
+            throw std::invalid_argument("cannot merge handles with different specs");
+        }
+        auto merged = std::make_shared<CPPHandle>(*this);
+        merged->vectors_ = vectors_;
+        merged->vectors_.insert(merged->vectors_.end(), other.vectors_.begin(), other.vectors_.end());
+        merged->norms_ = norms_;
+        merged->norms_.insert(merged->norms_.end(), other.norms_.begin(), other.norms_.end());
+        merged->ids_.reserve(ids_.size() + other.ids_.size());
+        merged->ids_ = ids_;
+        merged->ids_.insert(merged->ids_.end(), other.ids_.begin(), other.ids_.end());
+        merged->next_id_ = std::max(next_id_, other.next_id_);
+        merged->is_trained_ = is_trained_ || other.is_trained_;
+        merged->is_gpu_ = is_gpu_ || other.is_gpu_;
+        merged->device_ = is_gpu_ ? device_ : other.device_;
+        return merged;
+    }
+
+    py::dict spec() const { return py::dict(spec_dict_); }
+
+    bool is_gpu() const { return is_gpu_; }
+
+    py::object device() const {
+        if (device_.empty()) {
+            return py::none();
+        }
+        return py::str(device_);
+    }
+
+  private:
+    py::dict spec_dict_;
+    std::string metric_;
+    bool requires_training_;
+    bool supports_gpu_;
+    bool is_trained_;
+    bool is_gpu_;
+    std::string device_;
+    std::vector<float> vectors_;
+    std::vector<float> norms_;
+    std::vector<std::int64_t> ids_;
+    std::size_t dim_;
+    std::string kind_;
+    std::string backend_;
+    std::int64_t next_id_;
+};
+
+class CPPBackend {
+  public:
+    CPPBackend() = default;
+
+    py::dict capabilities() const {
+        py::dict kinds;
+        py::dict flat_params;
+        flat_params["requires_training"] = false;
+        kinds["flat"] = flat_params;
+
+        py::list metrics;
+        metrics.append("cosine");
+        metrics.append("ip");
+        metrics.append("l2");
+
+        py::dict result;
+        result["name"] = "cpp";
+        result["supports_gpu"] = false;
+        result["kinds"] = kinds;
+        result["metrics"] = metrics;
+        return result;
+    }
+
+    std::shared_ptr<CPPHandle> build(const py::object& spec) const {
+        py::module interfaces = py::module::import("ragcore.interfaces");
+        py::object index_spec = interfaces.attr("IndexSpec");
+        py::object parsed = index_spec.attr("from_mapping")(spec, py::arg("default_backend") = "cpp");
+
+        std::string backend = py::str(parsed.attr("backend"));
+        if (backend != "cpp") {
+            throw std::invalid_argument("CPP backend cannot build other backends");
+        }
+
+        std::string kind = py::str(parsed.attr("kind"));
+        std::string metric = py::str(parsed.attr("metric"));
+        py::dict spec_dict = parsed.attr("as_dict")();
+
+        bool requires_training = kind != "flat";
+        return std::make_shared<CPPHandle>(spec_dict, metric, requires_training, false);
+    }
+};
+
+PYBIND11_MODULE(_ragcore_cpp, m) {
+    py::class_<CPPHandle, std::shared_ptr<CPPHandle>>(m, "CPPHandle")
+        .def("requires_training", &CPPHandle::requires_training)
+        .def("train", &CPPHandle::train, py::arg("vectors"))
+        .def("add", &CPPHandle::add, py::arg("vectors"), py::arg("ids") = py::none())
+        .def("search", &CPPHandle::search, py::arg("queries"), py::arg("k"))
+        .def("ntotal", &CPPHandle::ntotal)
+        .def("serialize_cpu", &CPPHandle::serialize_cpu)
+        .def("to_gpu", &CPPHandle::to_gpu, py::arg("device") = py::none())
+        .def("merge_with", &CPPHandle::merge_with, py::arg("other"))
+        .def("spec", &CPPHandle::spec)
+        .def_property_readonly("is_gpu", &CPPHandle::is_gpu)
+        .def_property_readonly("device", &CPPHandle::device);
+
+    auto backend = py::class_<CPPBackend>(m, "CPPBackend")
+                       .def(py::init<>())
+                       .def("capabilities", &CPPBackend::capabilities)
+                       .def("build", &CPPBackend::build, py::arg("spec"));
+
+    backend.attr("name") = "cpp";
+
+    m.attr("__all__") = py::make_tuple("CPPBackend", "CPPHandle");
+}

--- a/docs/native_backend_setup.md
+++ b/docs/native_backend_setup.md
@@ -1,3 +1,48 @@
-# Native Backend Setup
+# Native C++ Backend Stub
 
-TODO
+The optional ``ragcore.backends.cpp`` module wraps the stub C++ backend compiled via
+`pybind11`. The extension is not required for Python-only development, but building it locally
+provides parity with the future FAISS-backed implementation.
+
+## Prerequisites
+
+- A working C++17 compiler (``gcc`` or ``clang``).
+- Python development headers (installed with ``python3-dev`` on Debian/Ubuntu).
+- ``pybind11`` and ``numpy`` Python packages (already listed in ``requirements.txt``).
+
+## Building the Extension
+
+```bash
+pip install -r requirements.txt  # installs pybind11 and numpy
+python -m ragcore.backends.cpp build  # builds the extension in-place
+```
+
+Alternatively, the unit tests automatically invoke ``ragcore.backends.cpp.build_native()`` when
+the extension is missing. The resulting shared object is written to
+``ragcore/backends/_ragcore_cpp.*.so``.
+
+To rebuild from scratch:
+
+```bash
+python -m ragcore.backends.cpp build --force
+```
+
+## Using the Backend
+
+```python
+from ragcore.backends import register_default_backends
+from ragcore.backends.cpp import get_backend, is_available
+
+if is_available():
+    backend = get_backend()
+    handle = backend.build({
+        "backend": "cpp",
+        "kind": "flat",
+        "metric": "l2",
+        "dim": 128,
+    })
+    # add vectors, search, etc.
+```
+
+If the native module is not available, importing ``ragcore.backends.cpp`` still succeeds, but
+``ensure_available()`` raises an informative error until the extension is built.

--- a/ragcore/backends/cpp/__init__.py
+++ b/ragcore/backends/cpp/__init__.py
@@ -1,0 +1,84 @@
+"""Optional shim for the native C++ backend bindings."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+CPPBackend: type[Any] | None = None
+CPPHandle: type[Any] | None = None
+_HAS_NATIVE = False
+_NATIVE_ERROR: Exception | None = None
+__all__ = ("is_available", "ensure_available", "build_native", "get_backend")
+
+
+def _refresh_exports() -> None:
+    global __all__
+    exposed = ["is_available", "ensure_available", "build_native", "get_backend"]
+    if _HAS_NATIVE:
+        exposed.extend(["CPPBackend", "CPPHandle"])
+    __all__ = tuple(exposed)
+
+
+def _load_native() -> None:
+    global CPPBackend, CPPHandle, _HAS_NATIVE, _NATIVE_ERROR
+    try:
+        native = importlib.import_module("ragcore.backends._ragcore_cpp")
+    except ModuleNotFoundError as exc:  # pragma: no cover - import path guard
+        CPPBackend = None
+        CPPHandle = None
+        _HAS_NATIVE = False
+        _NATIVE_ERROR = exc
+    else:
+        CPPBackend = native.CPPBackend
+        CPPHandle = native.CPPHandle
+        _HAS_NATIVE = True
+        _NATIVE_ERROR = None
+    _refresh_exports()
+
+
+def is_available() -> bool:
+    """Return ``True`` when the native extension is importable."""
+
+    return _HAS_NATIVE
+
+
+def ensure_available() -> None:
+    """Raise a user-friendly error when the native extension is missing."""
+
+    if not _HAS_NATIVE:
+        message = (
+            "ragcore.backends._ragcore_cpp is not built; run build_native() "
+            "to compile the stub backend."
+        )
+        raise RuntimeError(message) from _NATIVE_ERROR
+
+
+def get_backend() -> Any:
+    """Return a ready-to-use ``CPPBackend`` instance."""
+
+    ensure_available()
+    assert CPPBackend is not None  # for type-checkers
+    return CPPBackend()
+
+
+def build_native(*, force: bool = False, verbose: bool = False) -> Path:
+    """Compile the native extension in-place and reload the module."""
+
+    from . import _builder
+
+    artifact = _builder.build_extension(force=force, verbose=verbose)
+    _load_native()
+    return artifact
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - delegated import path
+    if name in {"CPPBackend", "CPPHandle"}:
+        ensure_available()
+        return CPPBackend if name == "CPPBackend" else CPPHandle
+    raise AttributeError(name)
+
+
+_refresh_exports()
+_load_native()

--- a/ragcore/backends/cpp/__main__.py
+++ b/ragcore/backends/cpp/__main__.py
@@ -1,0 +1,24 @@
+"""CLI entry-point for building the C++ backend stub."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from . import build_native
+
+
+def main(argv: list[str] | None = None) -> Path:
+    parser = argparse.ArgumentParser(description="Build the ragcore C++ backend stub")
+    parser.add_argument("build", nargs="?", default="build", help=argparse.SUPPRESS)
+    parser.add_argument("--force", action="store_true", help="Force recompilation even if up-to-date")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose build output")
+    args = parser.parse_args(argv)
+
+    artifact = build_native(force=args.force, verbose=args.verbose)
+    print(f"Built {artifact}")
+    return artifact
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via tests/CLI
+    main()

--- a/ragcore/backends/cpp/_builder.py
+++ b/ragcore/backends/cpp/_builder.py
@@ -1,0 +1,51 @@
+"""Helpers to compile the `_ragcore_cpp` pybind11 extension."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy
+from pybind11.setup_helpers import Pybind11Extension, build_ext
+from setuptools import Distribution
+
+
+def build_extension(*, force: bool = False, verbose: bool = False) -> Path:
+    """Build the native extension in-place and return the produced artifact path."""
+
+    project_root = Path(__file__).resolve().parents[3]
+    source_dir = project_root / "cpp"
+    source_file = source_dir / "ragcore_cpp_module.cpp"
+    if not source_file.exists():  # pragma: no cover - safety net
+        raise FileNotFoundError(f"missing C++ source file: {source_file}")
+
+    ext_modules: Iterable[Pybind11Extension] = [
+        Pybind11Extension(
+            "ragcore.backends._ragcore_cpp",
+            [str(source_file)],
+            include_dirs=[numpy.get_include()],
+            cxx_std=17,
+        )
+    ]
+
+    distribution = Distribution({"name": "ragcore-backends-cpp", "ext_modules": ext_modules})
+    distribution.package_dir = {"": str(project_root)}
+
+    cmd = build_ext(distribution)
+    cmd.ensure_finalized()
+    cmd.inplace = True
+    cmd.force = force
+    cmd.verbose = verbose
+    cmd.run()
+
+    outputs = [Path(path) for path in cmd.get_outputs()]
+    for artifact in outputs:
+        if artifact.name.startswith("_ragcore_cpp") and artifact.parent.name == "backends":
+            return artifact
+
+    if outputs:  # pragma: no cover - fallback selection
+        return outputs[0]
+    raise RuntimeError("no build outputs produced for ragcore.backends._ragcore_cpp")
+
+
+__all__ = ["build_extension"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 jinja2
 jsonschema
 numpy
+pybind11
+setuptools
 pyyaml
 pytest
 numpy

--- a/tests/unit/test_cpp_stub_import.py
+++ b/tests/unit/test_cpp_stub_import.py
@@ -1,6 +1,67 @@
-def test_optional_import():
-    try:
-        import ragcore.backends.cpp
-    except ImportError:
-        pass
-    assert True
+"""Tests for the optional C++ backend shim."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+import numpy as np
+import pytest
+
+
+def _reload_cpp_module(monkeypatch: pytest.MonkeyPatch, *, force_missing: bool = False):
+    """Reload ``ragcore.backends.cpp`` with optional native stub control."""
+
+    target_prefix = "ragcore.backends.cpp"
+    for module_name in list(sys.modules):
+        if module_name == target_prefix or module_name.startswith(f"{target_prefix}."):
+            sys.modules.pop(module_name)
+
+    if force_missing:
+        real_import = importlib.import_module
+
+        def fake_import(name: str, package: str | None = None) -> Any:  # pragma: no cover - helper
+            if name in {"ragcore.backends._ragcore_cpp", "_ragcore_cpp"}:
+                raise ModuleNotFoundError(name)
+            return real_import(name, package)
+
+        monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    return importlib.import_module("ragcore.backends.cpp")
+
+
+def test_optional_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _reload_cpp_module(monkeypatch, force_missing=True)
+    assert module.is_available() is False
+    with pytest.raises(RuntimeError):
+        module.ensure_available()
+    with pytest.raises(RuntimeError):
+        module.get_backend()
+
+
+def test_cpp_backend_stub_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _reload_cpp_module(monkeypatch)
+    if not module.is_available():
+        module.build_native(force=True)
+
+    module.ensure_available()
+    backend = module.get_backend()
+    caps = backend.capabilities()
+    assert caps["name"] == "cpp"
+    assert caps["supports_gpu"] is False
+    assert "flat" in caps["kinds"]
+
+    spec = {"backend": "cpp", "kind": "flat", "metric": "l2", "dim": 3}
+    handle = backend.build(spec)
+    assert handle.requires_training() is False
+
+    base = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
+    handle.add(base)
+    result = handle.search(np.array([[1.0, 0.0, 0.0]], dtype=np.float32), k=1)
+
+    assert tuple(result.keys()) == ("ids", "distances")
+    assert result["ids"].shape == (1, 1)
+    assert result["ids"][0, 0] == 0
+    assert result["distances"].shape == (1, 1)
+    assert handle.ntotal() == 2


### PR DESCRIPTION
## Summary
- add a pybind11-based `_ragcore_cpp` stub backend with build scripts and registration hooks
- document and expose the optional native backend build workflow and update Python tests to cover fallback and functionality

## Testing
- pytest -q tests/unit/test_cpp_stub_import.py

------
https://chatgpt.com/codex/tasks/task_e_68d91ad3d8ac832cbd556cbaf52ded11