### PR TITLE
Handle ImportError when loading C++ backend shim

### DIFF
--- a/ragcore/backends/cpp/__init__.py
+++ b/ragcore/backends/cpp/__init__.py
@@ -25,7 +25,7 @@ def _load_native() -> None:
     global CPPBackend, CPPHandle, _HAS_NATIVE, _NATIVE_ERROR
     try:
         native = importlib.import_module("ragcore.backends._ragcore_cpp")
-    except ModuleNotFoundError as exc:  # pragma: no cover - import path guard
+    except ImportError as exc:  # pragma: no cover - import path guard
         CPPBackend = None
         CPPHandle = None
         _HAS_NATIVE = False


### PR DESCRIPTION
## Summary
- broaden the ragcore.backends.cpp shim to capture ImportError when loading the native module and record the failure for ensure_available()
- extend the shim regression tests to simulate ImportError failures and assert the stored cause is surfaced

## Testing
- pytest tests/unit/test_cpp_stub_import.py::test_optional_import_handles_import_error -q *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68d92e86fca4832caa0540bc9bf57c27