### PR TITLE
Implement Python flat vector backend baseline

### DIFF
--- a/ragcore/backends/__init__.py
+++ b/ragcore/backends/__init__.py
@@ -1,14 +1,16 @@
 from ragcore.interfaces import Backend, Handle, IndexSpec, SerializedIndex, VectorIndexHandle
+
 from .cuvs import CuVSBackend
 from .dummy import DummyBackend
 from .faiss import FaissBackend
 from .hnsw import HnswBackend
+from .pyflat import PyFlatBackend
 
-
-DEFAULT_BACKENDS = (DummyBackend, FaissBackend, HnswBackend, CuVSBackend)
+DEFAULT_BACKENDS = (DummyBackend, PyFlatBackend, FaissBackend, HnswBackend, CuVSBackend)
 
 try:  # pragma: no cover - optional native dependency
-    from .cpp import CPPBackend as _CPPBackend, is_available as _cpp_is_available
+    from .cpp import CPPBackend as _CPPBackend
+    from .cpp import is_available as _cpp_is_available
 except Exception:  # pragma: no cover - extension missing during import
     _CPPBackend = None
 else:  # pragma: no cover - importable extension, exercised in unit tests
@@ -39,6 +41,7 @@ __all__ = [
     "DEFAULT_BACKENDS",
     "register_default_backends",
     "DummyBackend",
+    "PyFlatBackend",
     "CuVSBackend",
     "FaissBackend",
     "HnswBackend",

--- a/ragcore/backends/pyflat/__init__.py
+++ b/ragcore/backends/pyflat/__init__.py
@@ -1,0 +1,65 @@
+"""Pure-Python flat (brute-force) vector index backend."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ragcore.interfaces import IndexSpec, SerializedIndex, VectorIndexHandle
+
+
+class PyFlatBackend:
+    """Backend that performs brute-force search in Python/NumPy."""
+
+    name = "py_flat"
+
+    _SUPPORTED_KINDS = {"flat"}
+    _METRICS = {"ip", "l2"}
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return {
+            "name": self.name,
+            "supports_gpu": False,
+            "kinds": {
+                "flat": {
+                    "requires_training": False,
+                }
+            },
+            "metrics": sorted(self._METRICS),
+        }
+
+    def build(self, spec: Mapping[str, Any]) -> PyFlatHandle:
+        config = IndexSpec.from_mapping(spec, default_backend=self.name)
+        if config.backend != self.name:
+            raise ValueError(f"py_flat backend cannot build for '{config.backend}'")
+        if config.kind not in self._SUPPORTED_KINDS:
+            raise ValueError(f"unsupported py_flat kind '{config.kind}'")
+        if config.metric not in self._METRICS:
+            raise ValueError(f"unsupported py_flat metric '{config.metric}'")
+        return PyFlatHandle(config)
+
+
+class PyFlatHandle(VectorIndexHandle):
+    """Concrete handle for the Python flat backend."""
+
+    def __init__(self, spec: IndexSpec) -> None:
+        super().__init__(spec, requires_training=False, supports_gpu=False)
+
+    @classmethod
+    def from_serialized(cls, payload: SerializedIndex) -> PyFlatHandle:
+        """Reconstruct a handle instance from :meth:`serialize_cpu` output."""
+
+        spec = IndexSpec.from_mapping(payload.spec, default_backend=PyFlatBackend.name)
+        if spec.backend != PyFlatBackend.name:
+            raise ValueError("serialized payload was not produced by py_flat backend")
+
+        handle = cls(spec)
+        if payload.vectors.size:
+            handle.add(payload.vectors, ids=payload.ids)
+        handle._is_trained = payload.is_trained  # type: ignore[attr-defined]
+        handle.is_gpu = payload.is_gpu
+        return handle
+
+
+__all__ = ["PyFlatBackend", "PyFlatHandle"]
+

--- a/tests/e2e/test_vectordb_build_and_search_small.py
+++ b/tests/e2e/test_vectordb_build_and_search_small.py
@@ -1,2 +1,73 @@
-def test_placeholder():
-    assert True
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from ragcore import registry
+from ragcore.backends import register_default_backends
+from ragcore.backends.pyflat import PyFlatHandle
+from ragcore.cli import main as cli_main
+
+
+def setup_module() -> None:
+    registry._reset_registry()
+
+
+def teardown_module() -> None:
+    registry._reset_registry()
+
+
+def test_pyflat_cli_build_and_search(tmp_path: Path) -> None:
+    register_default_backends()
+
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    (corpus_dir / "doc.md").write_text("# Title\nBody text.", encoding="utf-8")
+
+    out_dir = tmp_path / "out"
+
+    exit_code = cli_main(
+        [
+            "build",
+            "--backend",
+            "py_flat",
+            "--corpus-dir",
+            str(corpus_dir),
+            "--out",
+            str(out_dir),
+            "--index-kind",
+            "flat",
+            "--metric",
+            "ip",
+            "--dim",
+            "3",
+        ]
+    )
+
+    assert exit_code == 0
+
+    spec_path = out_dir / "index_spec.json"
+    docmap_path = out_dir / "docmap.json"
+    assert spec_path.exists()
+    assert docmap_path.exists()
+
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    assert spec["backend"] == "py_flat"
+    assert spec["kind"] == "flat"
+    assert spec["metric"] == "ip"
+
+    backend = registry.get("py_flat")
+    handle = backend.build(spec)
+
+    base = np.eye(3, dtype="float32")
+    handle.add(base)
+
+    results = handle.search(base, k=1)
+    assert np.array_equal(results["ids"].ravel(), np.arange(3))
+
+    serialized = handle.serialize_cpu()
+    clone = PyFlatHandle.from_serialized(serialized)
+    round_trip = clone.search(np.array([[0.0, 1.0, 0.0]], dtype="float32"), k=1)
+    assert np.array_equal(round_trip["ids"], np.array([[1]]))

--- a/tests/unit/test_python_flat_index.py
+++ b/tests/unit/test_python_flat_index.py
@@ -1,3 +1,77 @@
-def test_add_and_search_flat():
-    # TODO: implement
-    assert True
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import numpy as np
+import pytest
+
+from ragcore.backends.pyflat import PyFlatBackend, PyFlatHandle
+from ragcore.registry import _reset_registry
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> Iterable[None]:
+    """Ensure a clean backend registry for each test."""
+
+    _reset_registry()
+    yield
+    _reset_registry()
+
+
+def test_capabilities_and_build() -> None:
+    backend = PyFlatBackend()
+
+    capabilities = backend.capabilities()
+    assert capabilities["name"] == "py_flat"
+    assert capabilities["supports_gpu"] is False
+    assert capabilities["kinds"]["flat"]["requires_training"] is False
+    assert set(capabilities["metrics"]) == {"ip", "l2"}
+
+    handle = backend.build({"kind": "flat", "metric": "ip", "dim": 4})
+    assert isinstance(handle, PyFlatHandle)
+    assert handle.requires_training() is False
+    assert handle.ntotal() == 0
+
+
+@pytest.mark.parametrize("metric", ["ip", "l2"])
+def test_add_and_search_deterministic(metric: str) -> None:
+    backend = PyFlatBackend()
+    handle = backend.build({"kind": "flat", "metric": metric, "dim": 3})
+
+    rng = np.random.default_rng(seed=1234)
+    base = rng.normal(size=(6, 3)).astype("float32")
+    queries = base[:2]
+
+    handle.add(base)
+
+    results = handle.search(queries, k=3)
+    assert results["ids"].shape == (2, 3)
+    assert results["distances"].shape == (2, 3)
+
+    if metric == "ip":
+        expected = np.argsort(-(queries @ base.T), axis=1)[:, :3]
+    else:  # l2
+        diffs = queries[:, None, :] - base[None, :, :]
+        expected = np.argsort(np.sum(diffs * diffs, axis=2), axis=1)[:, :3]
+
+    assert np.array_equal(results["ids"], expected)
+
+
+def test_serialize_round_trip_preserves_vectors() -> None:
+    backend = PyFlatBackend()
+    handle = backend.build({"kind": "flat", "metric": "ip", "dim": 2})
+
+    vectors = np.array([[1.0, 0.0], [0.0, 1.0]], dtype="float32")
+    ids = np.array([10, 11], dtype="int64")
+    handle.add(vectors, ids=ids)
+
+    serialized = handle.serialize_cpu()
+    assert serialized.is_trained is True
+    assert serialized.is_gpu is False
+    np.testing.assert_allclose(serialized.vectors, vectors)
+    np.testing.assert_array_equal(serialized.ids, ids)
+
+    clone = PyFlatHandle.from_serialized(serialized)
+    assert clone.ntotal() == 2
+    round_trip = clone.search(np.array([[1.0, 0.0]], dtype="float32"), k=1)
+    assert np.array_equal(round_trip["ids"], np.array([[10]]))


### PR DESCRIPTION
## Summary
- implement the pure-Python flat backend and register it with the vector DB core registry so it is available through the CLI (components/vector_db_core)
- add serialization round-trip support for the backend and expose it via the registry defaults (components/vector_db_core)
- add deterministic unit and e2e coverage for IP/L2 search plus CLI build flow (tests.vectordb_build_and_search_small_fixture)

## Testing
- pytest tests/unit/test_python_flat_index.py tests/e2e/test_vectordb_build_and_search_small.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d939580904832c98fc42ee1c25fd2f