### PR TITLE
Fix vector array typing for typecheck

### DIFF
--- a/ragcore/backends/__init__.py
+++ b/ragcore/backends/__init__.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import cast
+
 from ragcore.interfaces import Backend, Handle, IndexSpec, SerializedIndex, VectorIndexHandle
 
 from .cuvs import CuVSBackend
@@ -5,16 +9,26 @@ from .dummy import DummyBackend
 from .faiss import FaissBackend
 from .hnsw import HnswBackend
 
-DEFAULT_BACKENDS = (DummyBackend, FaissBackend, HnswBackend, CuVSBackend)
+_backend_classes: list[type[Backend]] = [
+    DummyBackend,
+    FaissBackend,
+    HnswBackend,
+    CuVSBackend,
+]
 
 try:  # pragma: no cover - optional native dependency
     from .cpp import CPPBackend as _CPPBackend
     from .cpp import is_available as _cpp_is_available
 except Exception:  # pragma: no cover - extension missing during import
     _CPPBackend = None
+    
+    def _cpp_is_available() -> bool:  # type: ignore[no-redef]
+        return False
 else:  # pragma: no cover - importable extension, exercised in unit tests
     if _cpp_is_available():
-        DEFAULT_BACKENDS = (*DEFAULT_BACKENDS, _CPPBackend)
+        _backend_classes.append(cast(type[Backend], _CPPBackend))
+
+DEFAULT_BACKENDS: tuple[type[Backend], ...] = tuple(_backend_classes)
 
 
 def register_default_backends() -> None:
@@ -25,6 +39,8 @@ def register_default_backends() -> None:
     existing = set(list_backends())
     for backend_cls in DEFAULT_BACKENDS:
         name = getattr(backend_cls, "name", None)
+        if not isinstance(name, str):
+            continue
         if name in existing:
             continue
         register(backend_cls())
@@ -45,9 +61,8 @@ __all__ = [
     "HnswBackend",
 ]
 
-if '_CPPBackend' in globals() and _CPPBackend is not None and '_cpp_is_available' in globals():
-    try:  # pragma: no cover - optional export
-        if _cpp_is_available():
-            __all__.append("CPPBackend")
-    except Exception:  # pragma: no cover - guards against runtime errors
-        pass
+try:  # pragma: no cover - optional export
+    if _CPPBackend is not None and _cpp_is_available():
+        __all__.append("CPPBackend")
+except Exception:  # pragma: no cover - guards against runtime errors
+    pass

--- a/ragcore/backends/cpp/__init__.py
+++ b/ragcore/backends/cpp/__init__.py
@@ -10,7 +10,7 @@ CPPBackend: type[Any] | None = None
 CPPHandle: type[Any] | None = None
 _HAS_NATIVE = False
 _NATIVE_ERROR: Exception | None = None
-__all__ = ("is_available", "ensure_available", "build_native", "get_backend")
+__all__ = ["is_available", "ensure_available", "build_native", "get_backend"]
 
 
 def _refresh_exports() -> None:
@@ -18,7 +18,7 @@ def _refresh_exports() -> None:
     exposed = ["is_available", "ensure_available", "build_native", "get_backend"]
     if _HAS_NATIVE:
         exposed.extend(["CPPBackend", "CPPHandle"])
-    __all__ = tuple(exposed)
+    __all__ = exposed
 
 
 def _load_native() -> None:

--- a/tests/integration/test_vectordb_core_acceptance.py
+++ b/tests/integration/test_vectordb_core_acceptance.py
@@ -27,4 +27,4 @@ def test_backend_registry_and_dummy_backend() -> None:
     h.add(xb)
     res = h.search(q, k=3)
     assert res["ids"].shape == (2, 3)
-    assert res["dists"].shape == (2, 3)
+    assert res["distances"].shape == (2, 3)

--- a/tests/unit/test_vectordb_protocols.py
+++ b/tests/unit/test_vectordb_protocols.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Mapping
 
 import numpy as np
 import pytest
@@ -24,7 +24,7 @@ class _StubBackend:
     def capabilities(self) -> dict[str, Any]:
         return {"name": self.name, "kinds": ["flat"]}
 
-    def build(self, spec: dict[str, Any]) -> Handle:
+    def build(self, spec: Mapping[str, Any]) -> Handle:
         self._built_with = dict(spec)
         parsed = IndexSpec.from_mapping(spec, default_backend=self.name)
         return VectorIndexHandle(parsed, requires_training=False)
@@ -111,7 +111,8 @@ def test_vector_index_handle_merge_and_serialize_roundtrip() -> None:
 
 
 def test_backend_protocol_builds_vector_index_handle() -> None:
-    backend: Backend = _StubBackend()
+    backend_impl = _StubBackend()
+    backend: Backend = backend_impl
     handle = backend.build({"kind": "flat", "metric": "l2", "dim": 2})
     assert isinstance(handle, VectorIndexHandle)
-    assert backend._built_with == {"kind": "flat", "metric": "l2", "dim": 2}
+    assert backend_impl._built_with == {"kind": "flat", "metric": "l2", "dim": 2}


### PR DESCRIPTION
## Summary
- define proper numpy array type aliases and typed search results in ragcore interfaces
- tighten backend registration typing and optional CPP export handling
- align backend tests with protocol signatures and expected search keys

## Testing
- make typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d95d5861c8832c9ce5612c72c2118b