### PR TITLE
feat: add Python flat backend and clean CI fixtures

### DIFF
--- a/codex/agents/TASKS/20a-flowscript-spec-and-grammar.yaml
+++ b/codex/agents/TASKS/20a-flowscript-spec-and-grammar.yaml
@@ -17,7 +17,7 @@ deliverables:
   - EBNF grammar file (no parser yet).
   - 5 minimal example programs (.fs) mirroring the example YAML flow.
 acceptance:
-  - "pytest -q -k test_flowscript_spec_links" passes
+  - '"pytest -q -k test_flowscript_spec_links" passes'
   - docs reference anchors resolve to sections in ragx_master_spec.yaml
   - examples compile by placeholder script (no-op) and are referenced in docs
 paths_changed:
@@ -29,4 +29,4 @@ ci:
     - make lint
     - pytest -q
 notes:
-  - Keep wording consistent with 'components: dsl' schemas & node kinds: unit|transform|decision|loop|end
+  - "Keep wording consistent with 'components: dsl' schemas & node kinds: unit|transform|decision|loop|end"

--- a/codex/agents/TASKS/20af_update_ci_job_explicit.yaml
+++ b/codex/agents/TASKS/20af_update_ci_job_explicit.yaml
@@ -1,5 +1,5 @@
 id: FS-20af
-title: CI: add dedicated FlowScript job (idempotent)
+title: "CI: add dedicated FlowScript job (idempotent)"
 intent: |
   Ensure CI includes a focused FlowScript job that installs jsonschema/pyyaml/pytest and runs the tests.
 changes:

--- a/codex/agents/TASKS/20b-flowscript-parser-ast.yaml
+++ b/codex/agents/TASKS/20b-flowscript-parser-ast.yaml
@@ -14,7 +14,7 @@ deliverables:
   - Parser with clear errors (line/col), round-trip golden tests for examples.
   - Typed AST nodes with dataclasses (readability-first naming).
 acceptance:
-  - "pytest -q tests/dsl/test_flowscript_parser.py -q" green
+  - '"pytest -q tests/dsl/test_flowscript_parser.py -q" green'
   - Coverage for parser+ast ≥ 85%
   - Parser rejects malformed inputs with precise diagnostics
 paths_changed:

--- a/codex/agents/TASKS/20c-flowscript-compiler-to-yaml.yaml
+++ b/codex/agents/TASKS/20c-flowscript-compiler-to-yaml.yaml
@@ -16,7 +16,7 @@ deliverables:
 acceptance:
   - Validate generated YAML with jsonschema (existing validator harness)
   - Golden fixtures: any change must update snapshots intentionally
-  - "pytest -q -k compile_equivalence" green
+  - '"pytest -q -k compile_equivalence" green'
 paths_changed:
   - pkgs/dsl/flowscript/*
   - tests/dsl/*

--- a/codex/agents/TASKS/20d-runner-execution-core.yaml
+++ b/codex/agents/TASKS/20d-runner-execution-core.yaml
@@ -17,7 +17,7 @@ deliverables:
 acceptance:
   - Schema validation called prior to run
   - Deterministic outputs for stub adapters
-  - "pytest -q -k runner_sequential" green
+  - '"pytest -q -k runner_sequential" green'
 paths_changed:
   - pkgs/dsl/orchestrator/*
   - tests/dsl/*

--- a/codex/agents/TASKS/20e-policy-and-budget-engine.yaml
+++ b/codex/agents/TASKS/20e-policy-and-budget-engine.yaml
@@ -16,4 +16,4 @@ deliverables:
 acceptance:
   - Unreachable tool calls are blocked; fallbacks triggered and traced
   - Budget breach produces expected stop/error per mode
-  - "pytest -q -k policy_budget_enforcement" green
+  - '"pytest -q -k policy_budget_enforcement" green'

--- a/codex/agents/TASKS/20f-transforms-sandbox.yaml
+++ b/codex/agents/TASKS/20f-transforms-sandbox.yaml
@@ -3,7 +3,7 @@ title: Transform sandbox – jinja/python (shell opt-in via flag)
 owner: codex
 priority: P1
 depends_on: [20d-runner-execution-core]
-goal: Safe execution of transform nodes with resource bounds; default: jinja + python only.
+goal: "Safe execution of transform nodes with resource bounds; default: jinja + python only."
 inputs:
   - codex/specs/ragx_master_spec.yaml
 outputs:
@@ -14,4 +14,4 @@ deliverables:
   - Time/memory guard stubs + network-off default; shell behind explicit allow flag.
 acceptance:
   - Deterministic outputs; stderr/stdout captured for errors
-  - "pytest -q -k transforms_sandbox" green
+  - '"pytest -q -k transforms_sandbox" green'

--- a/codex/agents/TASKS/20g-decisions-and-loops.yaml
+++ b/codex/agents/TASKS/20g-decisions-and-loops.yaml
@@ -16,4 +16,4 @@ deliverables:
 acceptance:
   - Branch selection deterministic on provided inputs
   - Loop halts on iteration/budget as configured
-  - "pytest -q -k decisions_and_loops" green
+  - '"pytest -q -k decisions_and_loops" green'

--- a/codex/agents/TASKS/20h-adapters-and-costing.yaml
+++ b/codex/agents/TASKS/20h-adapters-and-costing.yaml
@@ -15,4 +15,4 @@ deliverables:
 acceptance:
   - Budget checks fire using estimated costs before call
   - Cache hit ratio measurable in trace
-  - "pytest -q -k adapters_costing" green
+  - '"pytest -q -k adapters_costing" green'

--- a/codex/agents/TASKS/20i-dsl-linter-and-ci.yaml
+++ b/codex/agents/TASKS/20i-dsl-linter-and-ci.yaml
@@ -12,9 +12,9 @@ outputs:
   - tests/dsl/test_linter_rules.py
   - .github/workflows/ci.yml (amend)
 deliverables:
-  - CLI: `task-runner lint --spec flows/x.yaml --strict-missing-pricing`
+  - "CLI: `task-runner lint --spec flows/x.yaml --strict-missing-pricing`"
   - Lints: impossible budgets, loop risks, missing pricing, unreachable policies.
 acceptance:
   - Linter flags known-bad fixtures; passes known-good fixtures
   - CI runs linter; PR fails on ERRORs
-  - "pytest -q -k linter_rules" green
+  - '"pytest -q -k linter_rules" green'

--- a/codex/agents/TASKS/20j-example-flows-and-docs.yaml
+++ b/codex/agents/TASKS/20j-example-flows-and-docs.yaml
@@ -15,5 +15,5 @@ deliverables:
   - FlowScript source compiles to YAML; runner executes to completion with stub adapters.
   - Docs page describing the example with policy/budget annotations.
 acceptance:
-  - "pytest -q -k examples_end_to_end" green
+  - '"pytest -q -k examples_end_to_end" green'
   - Linter passes on the compiled YAML

--- a/codex/agents/TASKS/30a-mcp-envelope-and-schema.yaml
+++ b/codex/agents/TASKS/30a-mcp-envelope-and-schema.yaml
@@ -16,5 +16,5 @@ deliverables:
   - Middleware that validates outbound envelopes against schema.
   - Parity tests: same request via HTTP and STDIO yields byte-identical data payloads (excluding meta.traceId).
 acceptance:
-  - pytest -q apps/mcp_server/tests -k "envelope or parity" green
+  - 'pytest -q apps/mcp_server/tests -k "envelope or parity" green'
   - Invalid responses are rejected with 500 + INTERNAL code in envelope.errors

--- a/codex/agents/TASKS/30b-mcp-discovery-and-prompts.yaml
+++ b/codex/agents/TASKS/30b-mcp-discovery-and-prompts.yaml
@@ -12,6 +12,6 @@ deliverables:
   - discover() returns server info, tools[], prompts[], health.
   - get_prompt(domain,name,major) returns body+specRef; 404 → NOT_FOUND envelope.
 acceptance:
-  - pytest -q apps/mcp_server/tests -k "discover or prompts" green
+  - 'pytest -q apps/mcp_server/tests -k "discover or prompts" green'
 
 

--- a/eval/verification/rag_gold_corpus_neuroplasticity/questions.yaml
+++ b/eval/verification/rag_gold_corpus_neuroplasticity/questions.yaml
@@ -3,139 +3,136 @@ meta:
   source: Derived from Neuroplasticity.md upload
   version: v1.0
 questions:
-- id: Q01
-  type: direct
-  question: Define neuroplasticity in one sentence.
-  gold_doc: NP01_definition_scope.md
-  answer: "The brain’s ability to reorganize its structure and function by forming, strengthening, weakening, or rerouting neural connections in response to experience, development, or injury."
-
-- id: Q02
-  type: direct
-  question: Who first reported long-term potentiation (LTP) and in what year?
-  gold_doc: NP04_ltp_ltd.md
-  answer: "Terje Lømo and Tim Bliss, 1973."
-
-- id: Q03
-  type: direct
-  question: Name two cellular mechanisms that underlie synaptic plasticity.
-  gold_doc: NP03_synaptic_plasticity_basics.md
-  answer: "Activity-dependent AMPA receptor trafficking/phosphorylation and changes in presynaptic glutamate release probability via NMDA-Ca²⁺ signaling cascades."
-
-- id: Q04
-  type: direct
-  question: List two therapy modalities that leverage neuroplasticity in stroke or brain-injury rehab.
-  gold_doc: NP06_applications_rehab.md
-  answer: "Constraint-induced movement therapy and functional electrical stimulation."
-
-- id: Q05
-  type: direct
-  question: Which neurotrophic factors increase with aerobic exercise and what domains of cognition often improve?
-  gold_doc: NP10_exercise_bdnf.md
-  answer: "BDNF, IGF-1, and VEGF increase; spatial memory and executive function commonly improve."
-
-- id: Q06
-  type: ambiguous
-  question: Tell me about plasticity from training.
-  gold_doc: NP09_meditation_art_music.md
-  clarify: Do you mean meditation, artistic training, music therapy, or physical exercise?
-  answer: "Meditation, artistic practice, music-supported therapy, and aerobic exercise all induce measurable structural/functional changes in attention, emotion, sensorimotor, and memory networks."
-
-- id: Q07
-  type: ambiguous
-  question: Explain sensory reassignment.
-  gold_doc: NP11_sensory_loss_reassignment.md
-  clarify: Should I focus on deafness, blindness, or human echolocation?
-  answer: "After sensory loss, deprived cortex can be repurposed to process inputs from other senses (cross-modal reassignment), e.g., auditory cortex supporting vision/touch in deafness or visual cortex supporting echolocation in blindness."
-
-- id: Q08
-  type: synthesis
-  question: Contrast structural and functional plasticity and give one example of each.
-  gold_docs:
-  - NP05_structural_vs_functional.md
-  - NP03_synaptic_plasticity_basics.md
-  answer: "Structural plasticity changes anatomy (e.g., gray-matter redistribution or neurogenesis); functional plasticity reroutes information flow (e.g., cross-modal reassignment or map expansion). Examples: hippocampal changes with learning (structural); reassignment after sensory deprivation (functional)."
-
-- id: Q09
-  type: synthesis
-  question: How do meditation and aerobic exercise each relate to brain plasticity?
-  gold_docs:
-  - NP09_meditation_art_music.md
-  - NP10_exercise_bdnf.md
-  answer: "Meditation is linked to thicker/denser cortex in attention–emotion circuits and altered connectivity; aerobic exercise upregulates BDNF/IGF-1/VEGF, enlarges hippocampal/prefrontal structures, and improves executive control and memory."
-
-- id: Q10
-  type: synthesis
-  question: Summarize the sensitive period concept using the cochlear implant case and connect it to functional reassignment.
-  gold_docs:
-  - NP14_cochlear_implants_sensitive_period.md
-  - NP11_sensory_loss_reassignment.md
-  answer: "Early cochlear implantation in prelingually deaf children (≈ first 2–4 years) supports typical language; outside this window, auditory cortex may be repurposed for other modalities, reducing implant benefit—an example of functional reassignment."
-
-- id: Q11
-  type: conflict
-  question: What proportion of amputees experience phantom limb sensations?
-  gold_docs:
-  - NP07_phantom_limb.md
-  - NP15_conflict_range_example.md
-  note: "Expect a range (60–80%) with caveat."
-  answer: "About 60–80% report phantom limb sensations; phantom pain correlates with maladaptive cortical reorganization."
-
-- id: Q12
-  type: freshness
-  question: What is the most up-to-date perspective on adult neurogenesis in humans from this corpus?
-  gold_doc: NP05_structural_vs_functional.md
-  note: "Answer should reflect 'not convincingly demonstrated in humans' in this corpus."
-  answer: "Adult neurogenesis has not been convincingly demonstrated in humans (per this corpus)."
-
-- id: Q13
-  type: direct
-  question: Name two homeostatic processes that stabilize neural network activity during plastic changes.
-  gold_doc: NP03_synaptic_plasticity_basics.md
-  answer: "Synaptic scaling and metaplasticity."
-
-- id: Q14
-  type: direct
-  question: Which proteins correlate with structural stabilization after LTP?
-  gold_doc: NP04_ltp_ltd.md
-  answer: "Increased postsynaptic scaffolds PSD-95 and Homer1c correlate with stabilization of synaptic enlargement after LTP."
-
-- id: Q15
-  type: direct
-  question: Give one cognitive benefit observed in multilinguals and one neural correlate.
-  gold_doc: NP12_multilingualism.md
-  answer: "Improved executive control; increased gray-matter density in inferior parietal cortex (and greater white-matter myelination with active use)."
-
-- id: Q16
-  type: multiturn
-  question: Discuss how plasticity explains recovery after brain injury.
-  gold_doc: NP06_applications_rehab.md
-  followups:
-  - Name one therapy and the likely mechanism.
-  - What evidence or limitations are noted?
-  answer: "Recovery reflects functional reorganization and recruitment of alternate pathways; targeted training (e.g., CIMT, FES) drives use-dependent cortical remapping and network strengthening, though mechanisms and evidence strength vary by modality."
-
-- id: Q17
-  type: synthesis
-  question: Relate chronic pain and phantom limb phenomena to cortical map reorganization.
-  gold_docs:
-  - NP08_chronic_pain.md
-  - NP07_phantom_limb.md
-  answer: "Both involve maladaptive remapping: persistent nociception and central sensitization distort somatotopic maps in chronic pain; post-amputation remapping and reduced representation spacing correlate with phantom sensations/pain."
-
-- id: Q18
-  type: direct
-  question: "Mention two key 20th-century figures or experiments that shaped modern views on plasticity."
-  gold_doc: NP02_history_milestones.md
-  answer: "Hubel & Wiesel’s critical-period work with monocular deprivation; Bliss & Lømo’s discovery of hippocampal LTP."
-
-- id: Q19
-  type: direct
-  question: Define metaplasticity in one sentence.
-  gold_doc: NP03_synaptic_plasticity_basics.md
-  answer: "A higher-order regulation of plasticity that adjusts the thresholds/conditions for inducing LTP or LTD to prevent saturation and stabilize overall activity."
-
-- id: Q20
-  type: direct
-  question: What term has been proposed for compounds that rapidly promote plasticity with therapeutic benefit for depression?
-  gold_doc: NP13_depression_psychoplastogens.md
-  answer: "Psychoplastogens."
+  - id: Q01
+    type: direct
+    question: Define neuroplasticity in one sentence.
+    gold_doc: NP01_definition_scope.md
+    answer: The brain’s ability to reorganize its structure and function by forming, strengthening, weakening, or rerouting
+      neural connections in response to experience, development, or injury.
+  - id: Q02
+    type: direct
+    question: Who first reported long-term potentiation (LTP) and in what year?
+    gold_doc: NP04_ltp_ltd.md
+    answer: Terje Lømo and Tim Bliss, 1973.
+  - id: Q03
+    type: direct
+    question: Name two cellular mechanisms that underlie synaptic plasticity.
+    gold_doc: NP03_synaptic_plasticity_basics.md
+    answer: Activity-dependent AMPA receptor trafficking/phosphorylation and changes in presynaptic glutamate release probability
+      via NMDA-Ca²⁺ signaling cascades.
+  - id: Q04
+    type: direct
+    question: List two therapy modalities that leverage neuroplasticity in stroke or brain-injury rehab.
+    gold_doc: NP06_applications_rehab.md
+    answer: Constraint-induced movement therapy and functional electrical stimulation.
+  - id: Q05
+    type: direct
+    question: Which neurotrophic factors increase with aerobic exercise and what domains of cognition often improve?
+    gold_doc: NP10_exercise_bdnf.md
+    answer: BDNF, IGF-1, and VEGF increase; spatial memory and executive function commonly improve.
+  - id: Q06
+    type: ambiguous
+    question: Tell me about plasticity from training.
+    gold_doc: NP09_meditation_art_music.md
+    clarify: Do you mean meditation, artistic training, music therapy, or physical exercise?
+    answer: Meditation, artistic practice, music-supported therapy, and aerobic exercise all induce measurable structural/functional
+      changes in attention, emotion, sensorimotor, and memory networks.
+  - id: Q07
+    type: ambiguous
+    question: Explain sensory reassignment.
+    gold_doc: NP11_sensory_loss_reassignment.md
+    clarify: Should I focus on deafness, blindness, or human echolocation?
+    answer: After sensory loss, deprived cortex can be repurposed to process inputs from other senses (cross-modal reassignment),
+      e.g., auditory cortex supporting vision/touch in deafness or visual cortex supporting echolocation in blindness.
+  - id: Q08
+    type: synthesis
+    question: Contrast structural and functional plasticity and give one example of each.
+    gold_docs:
+      - NP05_structural_vs_functional.md
+      - NP03_synaptic_plasticity_basics.md
+    answer: 'Structural plasticity changes anatomy (e.g., gray-matter redistribution or neurogenesis); functional plasticity
+      reroutes information flow (e.g., cross-modal reassignment or map expansion). Examples: hippocampal changes with learning
+      (structural); reassignment after sensory deprivation (functional).'
+  - id: Q09
+    type: synthesis
+    question: How do meditation and aerobic exercise each relate to brain plasticity?
+    gold_docs:
+      - NP09_meditation_art_music.md
+      - NP10_exercise_bdnf.md
+    answer: Meditation is linked to thicker/denser cortex in attention–emotion circuits and altered connectivity; aerobic
+      exercise upregulates BDNF/IGF-1/VEGF, enlarges hippocampal/prefrontal structures, and improves executive control and
+      memory.
+  - id: Q10
+    type: synthesis
+    question: Summarize the sensitive period concept using the cochlear implant case and connect it to functional reassignment.
+    gold_docs:
+      - NP14_cochlear_implants_sensitive_period.md
+      - NP11_sensory_loss_reassignment.md
+    answer: Early cochlear implantation in prelingually deaf children (≈ first 2–4 years) supports typical language; outside
+      this window, auditory cortex may be repurposed for other modalities, reducing implant benefit—an example of functional
+      reassignment.
+  - id: Q11
+    type: conflict
+    question: What proportion of amputees experience phantom limb sensations?
+    gold_docs:
+      - NP07_phantom_limb.md
+      - NP15_conflict_range_example.md
+    note: Expect a range (60–80%) with caveat.
+    answer: About 60–80% report phantom limb sensations; phantom pain correlates with maladaptive cortical reorganization.
+  - id: Q12
+    type: freshness
+    question: What is the most up-to-date perspective on adult neurogenesis in humans from this corpus?
+    gold_doc: NP05_structural_vs_functional.md
+    note: Answer should reflect 'not convincingly demonstrated in humans' in this corpus.
+    answer: Adult neurogenesis has not been convincingly demonstrated in humans (per this corpus).
+  - id: Q13
+    type: direct
+    question: Name two homeostatic processes that stabilize neural network activity during plastic changes.
+    gold_doc: NP03_synaptic_plasticity_basics.md
+    answer: Synaptic scaling and metaplasticity.
+  - id: Q14
+    type: direct
+    question: Which proteins correlate with structural stabilization after LTP?
+    gold_doc: NP04_ltp_ltd.md
+    answer: Increased postsynaptic scaffolds PSD-95 and Homer1c correlate with stabilization of synaptic enlargement after
+      LTP.
+  - id: Q15
+    type: direct
+    question: Give one cognitive benefit observed in multilinguals and one neural correlate.
+    gold_doc: NP12_multilingualism.md
+    answer: Improved executive control; increased gray-matter density in inferior parietal cortex (and greater white-matter
+      myelination with active use).
+  - id: Q16
+    type: multiturn
+    question: Discuss how plasticity explains recovery after brain injury.
+    gold_doc: NP06_applications_rehab.md
+    followups:
+      - Name one therapy and the likely mechanism.
+      - What evidence or limitations are noted?
+    answer: Recovery reflects functional reorganization and recruitment of alternate pathways; targeted training (e.g., CIMT,
+      FES) drives use-dependent cortical remapping and network strengthening, though mechanisms and evidence strength vary
+      by modality.
+  - id: Q17
+    type: synthesis
+    question: Relate chronic pain and phantom limb phenomena to cortical map reorganization.
+    gold_docs:
+      - NP08_chronic_pain.md
+      - NP07_phantom_limb.md
+    answer: 'Both involve maladaptive remapping: persistent nociception and central sensitization distort somatotopic maps
+      in chronic pain; post-amputation remapping and reduced representation spacing correlate with phantom sensations/pain.'
+  - id: Q18
+    type: direct
+    question: Mention two key 20th-century figures or experiments that shaped modern views on plasticity.
+    gold_doc: NP02_history_milestones.md
+    answer: Hubel & Wiesel’s critical-period work with monocular deprivation; Bliss & Lømo’s discovery of hippocampal LTP.
+  - id: Q19
+    type: direct
+    question: Define metaplasticity in one sentence.
+    gold_doc: NP03_synaptic_plasticity_basics.md
+    answer: A higher-order regulation of plasticity that adjusts the thresholds/conditions for inducing LTP or LTD to prevent
+      saturation and stabilize overall activity.
+  - id: Q20
+    type: direct
+    question: What term has been proposed for compounds that rapidly promote plasticity with therapeutic benefit for depression?
+    gold_doc: NP13_depression_psychoplastogens.md
+    answer: Psychoplastogens.

--- a/ragcore/backends/__init__.py
+++ b/ragcore/backends/__init__.py
@@ -8,11 +8,13 @@ from .cuvs import CuVSBackend
 from .dummy import DummyBackend
 from .faiss import FaissBackend
 from .hnsw import HnswBackend
+from .pyflat import PyFlatBackend
 
 _backend_classes: list[type[Backend]] = [
     DummyBackend,
     FaissBackend,
     HnswBackend,
+    PyFlatBackend,
     CuVSBackend,
 ]
 
@@ -56,6 +58,7 @@ __all__ = [
     "DEFAULT_BACKENDS",
     "register_default_backends",
     "DummyBackend",
+    "PyFlatBackend",
     "CuVSBackend",
     "FaissBackend",
     "HnswBackend",

--- a/ragcore/backends/cuvs.py
+++ b/ragcore/backends/cuvs.py
@@ -39,6 +39,7 @@ class CuVSBackend:
 class CuVSHandle(VectorIndexHandle):
     def __init__(self, spec: IndexSpec) -> None:
         super().__init__(spec, requires_training=True, supports_gpu=True)
+        self._factory_kwargs = {}
 
 
 __all__ = ["CuVSBackend", "CuVSHandle"]

--- a/ragcore/backends/dummy/__init__.py
+++ b/ragcore/backends/dummy/__init__.py
@@ -34,6 +34,7 @@ class DummyBackend:
 class DummyHandle(VectorIndexHandle):
     def __init__(self, spec: IndexSpec) -> None:
         super().__init__(spec, requires_training=False, supports_gpu=False)
+        self._factory_kwargs = {}
 
 
 __all__ = ["DummyBackend", "DummyHandle"]

--- a/ragcore/backends/hnsw.py
+++ b/ragcore/backends/hnsw.py
@@ -38,6 +38,7 @@ class HnswBackend:
 class HnswHandle(VectorIndexHandle):
     def __init__(self, spec: IndexSpec) -> None:
         super().__init__(spec, requires_training=False, supports_gpu=False)
+        self._factory_kwargs = {}
 
 
 __all__ = ["HnswBackend", "HnswHandle"]

--- a/ragcore/backends/pyflat/__init__.py
+++ b/ragcore/backends/pyflat/__init__.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import numpy as np
+
+from ragcore.interfaces import (
+    FloatArray,
+    IndexSpec,
+    IntArray,
+    SerializedIndex,
+    VectorIndexHandle,
+)
+
+
+class PyFlatBackend:
+    """Pure Python flat index backend with L2 and inner-product metrics."""
+
+    name = "py_flat"
+    _SUPPORTED_KIND = "flat"
+    _SUPPORTED_METRICS = {"l2", "ip"}
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return {
+            "name": self.name,
+            "supports_gpu": False,
+            "kinds": {self._SUPPORTED_KIND: {"requires_training": False}},
+            "metrics": sorted(self._SUPPORTED_METRICS),
+            "description": "Pure Python reference implementation for flat indexes.",
+        }
+
+    def build(self, spec: Mapping[str, Any]) -> PyFlatHandle:
+        parsed = IndexSpec.from_mapping(spec, default_backend=self.name)
+        if parsed.backend != self.name:
+            raise ValueError(f"py_flat backend cannot build for '{parsed.backend}'")
+        if parsed.kind != self._SUPPORTED_KIND:
+            raise ValueError(f"unsupported py_flat kind '{parsed.kind}'")
+        if parsed.metric not in self._SUPPORTED_METRICS:
+            raise ValueError(f"unsupported py_flat metric '{parsed.metric}'")
+        return PyFlatHandle(parsed)
+
+    def deserialize_cpu(
+        self, serialized: SerializedIndex | Mapping[str, Any]
+    ) -> PyFlatHandle:
+        payload = serialized
+        if not isinstance(serialized, SerializedIndex):
+            payload = _serialized_index_from_mapping(serialized)
+        return PyFlatHandle.from_serialized(cast(SerializedIndex, payload))
+
+
+class PyFlatHandle(VectorIndexHandle):
+    def __init__(self, spec: IndexSpec) -> None:
+        super().__init__(spec, requires_training=False, supports_gpu=False)
+        self._factory_kwargs = {}
+
+    @classmethod
+    def from_serialized(cls, serialized: SerializedIndex) -> PyFlatHandle:
+        spec = IndexSpec.from_mapping(serialized.spec, default_backend=PyFlatBackend.name)
+        handle = cls(spec)
+
+        vectors = np.asarray(serialized.vectors, dtype=np.float32)
+        if vectors.ndim == 1:
+            if vectors.size != 0:
+                raise ValueError("serialised vectors must be 2D")
+            vectors = np.empty((0, spec.dim), dtype=np.float32)
+        if vectors.ndim != 2:
+            raise ValueError("serialised vectors must be 2D")
+        if vectors.shape[1] != spec.dim:
+            raise ValueError(
+                "serialised vectors dimension "
+                f"{vectors.shape[1]} does not match spec dim {spec.dim}"
+            )
+
+        ids = np.asarray(serialized.ids, dtype=np.int64)
+        if ids.ndim != 1:
+            raise ValueError("serialised ids must be a 1D array")
+        if ids.shape[0] != vectors.shape[0]:
+            raise ValueError("serialised ids must align with vector rows")
+
+        handle._vectors = cast(FloatArray, vectors.copy())
+        handle._ids = cast(IntArray, ids.copy())
+        handle._next_id = int(ids.max()) + 1 if ids.size else 0
+        handle._is_trained = bool(serialized.is_trained)
+        handle.is_gpu = bool(serialized.is_gpu)
+        handle.device = None
+        return handle
+
+
+def _serialized_index_from_mapping(data: Mapping[str, Any]) -> SerializedIndex:
+    try:
+        spec_mapping = data["spec"]
+        vectors_value = data["vectors"]
+        ids_value = data["ids"]
+    except KeyError as exc:
+        raise ValueError("serialised index mapping missing required keys") from exc
+
+    if not isinstance(spec_mapping, Mapping):
+        raise ValueError("serialised index spec must be a mapping")
+
+    spec_dict = dict(spec_mapping)
+    if "dim" not in spec_dict:
+        raise ValueError("serialised index spec must include 'dim'")
+
+    dim = int(spec_dict["dim"])
+    if dim <= 0:
+        raise ValueError("serialised index dim must be positive")
+
+    vectors = np.asarray(vectors_value, dtype=np.float32)
+    if vectors.ndim == 1:
+        if vectors.size != 0:
+            raise ValueError("serialised vectors must be 2D")
+        vectors = np.empty((0, dim), dtype=np.float32)
+    if vectors.ndim != 2:
+        raise ValueError("serialised vectors must be 2D")
+    if vectors.shape[1] != dim:
+        raise ValueError("serialised vectors dimension mismatch")
+
+    ids = np.asarray(ids_value, dtype=np.int64)
+    if ids.ndim != 1:
+        raise ValueError("serialised ids must be 1D")
+    if ids.shape[0] != vectors.shape[0]:
+        raise ValueError("serialised ids must align with vectors")
+
+    metadata_value = data.get("metadata")
+    metadata = dict(metadata_value) if isinstance(metadata_value, Mapping) else {}
+    is_trained = bool(data.get("is_trained", False))
+    is_gpu = bool(data.get("is_gpu", False))
+
+    return SerializedIndex(
+        spec=spec_dict,
+        vectors=cast(FloatArray, vectors),
+        ids=cast(IntArray, ids),
+        metadata=metadata,
+        is_trained=is_trained,
+        is_gpu=is_gpu,
+    )
+
+
+__all__ = ["PyFlatBackend", "PyFlatHandle"]

--- a/ragcore/cli.py
+++ b/ragcore/cli.py
@@ -150,7 +150,8 @@ def _build_docmap(corpus_dir: Path, documents: Sequence[IngestedDocument]) -> di
 
     for record in documents:
         metadata = dict(record.metadata)
-        doc_id = str(metadata.get("id") or record.path.stem)
+        slug = metadata.get("slug")
+        doc_id = str(metadata.get("id") or slug or record.path.stem)
         counter = seen.get(doc_id)
         if counter is None:
             seen[doc_id] = 0

--- a/ragcore/interfaces.py
+++ b/ragcore/interfaces.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Any, Protocol, TypedDict, TypeAlias, cast, runtime_checkable
+from typing import Any, Protocol, TypeAlias, TypedDict, cast, runtime_checkable
 
 import numpy as np
 from numpy.typing import NDArray

--- a/tests/e2e/test_vectordb_build_and_search_small.py
+++ b/tests/e2e/test_vectordb_build_and_search_small.py
@@ -1,2 +1,91 @@
-def test_placeholder():
-    assert True
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ragcore.backends.pyflat import PyFlatBackend
+
+
+@pytest.fixture(scope="module")
+def _ensure_numpy() -> None:
+    pytest.importorskip("numpy")
+
+
+def _write(tmp_dir: Path, relative: str, content: str) -> Path:
+    path = tmp_dir / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_cli_lists_pyflat_backend(_ensure_numpy: None) -> None:
+    cmd = [sys.executable, "-m", "ragcore.cli", "list"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    names = {entry["name"] for entry in payload}
+    assert "py_flat" in names
+
+
+def test_build_and_search_round_trip(tmp_path: Path, _ensure_numpy: None) -> None:
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+
+    _write(
+        corpus_dir,
+        "doc.md",
+        """title: Example\n---\nExample body\n""",
+    )
+
+    out_dir = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        "-m",
+        "ragcore.cli",
+        "build",
+        "--backend",
+        "py_flat",
+        "--corpus-dir",
+        str(corpus_dir),
+        "--out",
+        str(out_dir),
+        "--accept-format",
+        "md",
+        "--index-kind",
+        "flat",
+        "--metric",
+        "l2",
+        "--dim",
+        "2",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+    spec_path = out_dir / "index_spec.json"
+    assert spec_path.exists(), "index_spec.json should be produced"
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    assert spec["backend"] == "py_flat"
+    assert spec["kind"] == "flat"
+
+    backend = PyFlatBackend()
+    handle = backend.build(spec)
+    handle.add(
+        np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0]], dtype=np.float32),
+        ids=np.array([100, 200, 300], dtype=np.int64),
+    )
+
+    query = np.array([[0.1, 0.9]], dtype=np.float32)
+    results = handle.search(query, k=2)
+    np.testing.assert_allclose(results["ids"], np.array([[200, 100]], dtype=np.int64))
+
+    index_payload = json.loads((out_dir / "index.bin").read_text(encoding="utf-8"))
+    restored = backend.deserialize_cpu(index_payload)
+    assert restored.ntotal() == 0
+    with pytest.raises(RuntimeError):
+        restored.search(query, k=1)

--- a/tests/e2e/test_vectordb_build_and_search_small_fixture.py
+++ b/tests/e2e/test_vectordb_build_and_search_small_fixture.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import pathlib
 
 import numpy as np
 import pytest
-from conftest import skip_if_no_eval
+
+from tests.conftest import skip_if_no_eval
 
 
 def _maybe_import_dummy():
@@ -61,7 +64,7 @@ def test_dummy_pipeline_index_and_search(eval_dir: pathlib.Path):
     # Query with the first text (should rank itself highest)
     q = embed(texts[0])[None, :]
     res = handle.search(q, k=min(5, xb.shape[0]))
-    ids, dists = res["ids"], res["dists"]
+    ids, dists = res["ids"], res["distances"]
     assert ids.shape == dists.shape
     assert ids.shape[0] == 1
     assert ids.shape[1] >= 1

--- a/tests/e2e/test_vectordb_build_md_fixture.py
+++ b/tests/e2e/test_vectordb_build_md_fixture.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+
 import pytest
 
 

--- a/tests/unit/observability/test_ci_tooling.py
+++ b/tests/unit/observability/test_ci_tooling.py
@@ -57,11 +57,16 @@ def test_ci_workflow_runs_linters_typechecks_tests():
     assert setup_python_step.get("with", {}).get("python-version") == "3.11"
 
     run_commands = [step.get("run") for step in steps if step.get("run")]
-    assert "pip install -r requirements.txt || true" in run_commands
-    assert "pip install ruff mypy pytest coverage yamllint || true" in run_commands
-    assert "ruff check . || true" in run_commands
-    assert "mypy . || true" in run_commands
-    assert "pytest --maxfail=1 --disable-warnings || true" in run_commands
+    assert any("pip install -r requirements.txt || true" in cmd for cmd in run_commands)
+    assert any(
+        "pip install pybind11 ruff mypy pytest coverage yamllint || true" in cmd
+        for cmd in run_commands
+    )
+    assert any("ruff check . || true" in cmd for cmd in run_commands)
+    assert any("mypy . || true" in cmd for cmd in run_commands)
+    assert any(
+        "pytest --maxfail=1 --disable-warnings || true" in cmd for cmd in run_commands
+    )
 
 
 def test_makefile_has_ci_targets():

--- a/tests/unit/test_python_flat_index.py
+++ b/tests/unit/test_python_flat_index.py
@@ -1,3 +1,130 @@
-def test_add_and_search_flat():
-    # TODO: implement
-    assert True
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ragcore import registry
+from ragcore.backends import register_default_backends
+from ragcore.backends.pyflat import PyFlatBackend, PyFlatHandle
+
+
+@pytest.fixture()
+def backend() -> PyFlatBackend:
+    pytest.importorskip("numpy")
+    return PyFlatBackend()
+
+
+def test_pyflat_capabilities(backend: PyFlatBackend) -> None:
+    caps = backend.capabilities()
+    assert caps["name"] == "py_flat"
+    assert caps["supports_gpu"] is False
+    assert caps["kinds"]["flat"]["requires_training"] is False
+    assert caps["metrics"] == ["ip", "l2"], "Supported metrics should be sorted"
+
+
+@pytest.mark.parametrize("metric", ["l2", "ip"])
+def test_pyflat_build_validates_spec(metric: str, backend: PyFlatBackend) -> None:
+    spec = {"backend": "py_flat", "kind": "flat", "metric": metric, "dim": 3}
+    handle = backend.build(spec)
+    assert isinstance(handle, PyFlatHandle)
+    assert handle.requires_training() is False
+
+
+def test_pyflat_add_and_search_l2(backend: PyFlatBackend) -> None:
+    handle = backend.build({"backend": "py_flat", "kind": "flat", "metric": "l2", "dim": 3})
+    base = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    handle.add(base)
+
+    queries = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.1, 0.9, 0.0],
+        ],
+        dtype=np.float32,
+    )
+
+    results = handle.search(queries, k=2)
+    assert results["ids"].shape == (2, 2)
+    assert results["distances"].shape == (2, 2)
+
+    np.testing.assert_allclose(results["ids"], np.array([[1, 0], [2, 0]], dtype=np.int64))
+    np.testing.assert_allclose(
+        results["distances"],
+        np.array([[0.0, 1.0], [0.02, 0.82]], dtype=np.float32),
+        atol=1e-6,
+    )
+
+
+def test_pyflat_search_inner_product_orders_descending(backend: PyFlatBackend) -> None:
+    handle = backend.build({"backend": "py_flat", "kind": "flat", "metric": "ip", "dim": 2})
+    vectors = np.array(
+        [
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.5, 0.5],
+        ],
+        dtype=np.float32,
+    )
+    handle.add(vectors)
+
+    queries = np.array(
+        [
+            [0.6, 0.8],
+            [1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+
+    result = handle.search(queries, k=2)
+    np.testing.assert_allclose(result["ids"], np.array([[1, 2], [0, 2]], dtype=np.int64))
+    np.testing.assert_allclose(
+        result["distances"],
+        np.array(
+            [
+                [-0.8, -0.7],
+                [-1.0, -0.5],
+            ],
+            dtype=np.float32,
+        ),
+        atol=1e-6,
+    )
+
+
+def test_pyflat_serialize_and_deserialize_round_trip(
+    tmp_path: Path, backend: PyFlatBackend
+) -> None:
+    handle = backend.build({"backend": "py_flat", "kind": "flat", "metric": "ip", "dim": 2})
+    handle.add(
+        np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.float32),
+        ids=np.array([10, 20], dtype=np.int64),
+    )
+
+    serialised = handle.serialize_cpu()
+    json_path = tmp_path / "index.json"
+    json_path.write_text(json.dumps(serialised.to_dict()), encoding="utf-8")
+
+    restored = backend.deserialize_cpu(json.loads(json_path.read_text(encoding="utf-8")))
+    assert isinstance(restored, PyFlatHandle)
+    assert restored.ntotal() == 2
+
+    query = np.array([[1.0, 0.0]], dtype=np.float32)
+    original = handle.search(query, k=2)
+    round_tripped = restored.search(query, k=2)
+    np.testing.assert_allclose(original["ids"], round_tripped["ids"])
+    np.testing.assert_allclose(original["distances"], round_tripped["distances"])
+
+
+def test_pyflat_registered_with_defaults() -> None:
+    registry._reset_registry()
+    register_default_backends()
+    assert "py_flat" in registry.list_backends()

--- a/tests/unit/test_spec_vectordb_backends.py
+++ b/tests/unit/test_spec_vectordb_backends.py
@@ -23,7 +23,8 @@ def _clear_registry() -> Iterable[None]:
 def test_backends_register_and_list() -> None:
     register_default_backends()
 
-    assert set(list_backends()) == {"faiss", "hnsw", "cuvs"}
+    names = set(list_backends())
+    assert {"dummy", "faiss", "hnsw", "cuvs", "py_flat"}.issubset(names)
 
 
 def test_faiss_ivf_training_and_serialization() -> None:

--- a/tests/unit/test_vectordb_protocols.py
+++ b/tests/unit/test_vectordb_protocols.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 import numpy as np
 import pytest


### PR DESCRIPTION
## Summary
- implement a pure Python `py_flat` backend with serialization helpers and register it alongside the existing backends
- add unit and e2e coverage for the flat backend, update CLI docmap handling, and adjust vector protocol tests
- clean up YAML task definitions and evaluation fixtures so tooling can parse them, and relax CI workflow assertions to match the pipeline

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68d962db0d40832c91fef3e4803fd70d