### PR TITLE
Implement cpp flat index parity and alias support

### DIFF
--- a/cpp/ragcore_cpp_module.cpp
+++ b/cpp/ragcore_cpp_module.cpp
@@ -190,16 +190,10 @@ class CPPHandle {
                 float distance = compute_distance(query_vector, stored_vector, dim_, metric_, query_norm);
                 ranking.emplace_back(distance, vi);
             }
-            std::partial_sort(
+            std::stable_sort(
                 ranking.begin(),
-                ranking.begin() + topk,
                 ranking.end(),
-                [](const auto& lhs, const auto& rhs) {
-                    if (lhs.first == rhs.first) {
-                        return lhs.second < rhs.second;
-                    }
-                    return lhs.first < rhs.first;
-                }
+                [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; }
             );
             for (std::size_t rank = 0; rank < topk; ++rank) {
                 const auto index = ranking[rank].second;
@@ -330,7 +324,7 @@ class CPPBackend {
         py::object parsed = index_spec.attr("from_mapping")(spec, py::arg("default_backend") = "cpp");
 
         std::string backend = py::str(parsed.attr("backend"));
-        if (backend != "cpp") {
+        if (backend != "cpp" && backend != "cpp_faiss") {
             throw std::invalid_argument("CPP backend cannot build other backends");
         }
 

--- a/ragcore/backends/__init__.py
+++ b/ragcore/backends/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import cast
+from collections.abc import Mapping
+from typing import Any, cast
 
 from ragcore.interfaces import Backend, Handle, IndexSpec, SerializedIndex, VectorIndexHandle
 
@@ -23,14 +24,59 @@ try:  # pragma: no cover - optional native dependency
     from .cpp import is_available as _cpp_is_available
 except Exception:  # pragma: no cover - extension missing during import
     _CPPBackend = None
-    
+
     def _cpp_is_available() -> bool:  # type: ignore[no-redef]
         return False
 else:  # pragma: no cover - importable extension, exercised in unit tests
-    if _cpp_is_available():
-        _backend_classes.append(cast(type[Backend], _CPPBackend))
+    pass
 
 DEFAULT_BACKENDS: tuple[type[Backend], ...] = tuple(_backend_classes)
+
+
+def _ensure_cpp_backends_registered() -> None:
+    """Append the native C++ backends when the extension is available."""
+
+    if _CPPBackend is None or not _cpp_is_available():
+        return
+
+    cpp_backend_cls = cast(type[Backend], _CPPBackend)
+    names = {
+        getattr(cls, "name", None)
+        for cls in _backend_classes
+        if hasattr(cls, "name")
+    }
+
+    cpp_name = getattr(cpp_backend_cls, "name", None)
+    if cpp_name not in names and isinstance(cpp_name, str):
+        _backend_classes.append(cpp_backend_cls)
+        names.add(cpp_name)
+
+    if "cpp_faiss" not in names:
+
+        class _CppFaissBackend:
+            """Alias exposing the C++ stub backend under the ``cpp_faiss`` name."""
+
+            name = "cpp_faiss"
+
+            def capabilities(self) -> Mapping[str, Any]:
+                backend = cpp_backend_cls()
+                capabilities = dict(backend.capabilities())
+                capabilities["name"] = self.name
+                return capabilities
+
+            def build(self, spec: Mapping[str, Any]) -> Handle:
+                backend = cpp_backend_cls()
+                adjusted = dict(spec)
+                adjusted["backend"] = self.name
+                return backend.build(adjusted)
+
+        _backend_classes.append(cast(type[Backend], _CppFaissBackend))
+
+    global DEFAULT_BACKENDS
+    DEFAULT_BACKENDS = tuple(_backend_classes)
+
+
+_ensure_cpp_backends_registered()
 
 
 def register_default_backends() -> None:
@@ -38,6 +84,7 @@ def register_default_backends() -> None:
 
     from ragcore.registry import list_backends, register
 
+    _ensure_cpp_backends_registered()
     existing = set(list_backends())
     for backend_cls in DEFAULT_BACKENDS:
         name = getattr(backend_cls, "name", None)

--- a/tests/e2e/test_vectordb_build_and_search_small.py
+++ b/tests/e2e/test_vectordb_build_and_search_small.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import json
 import subprocess
 import sys
@@ -16,6 +17,14 @@ def _ensure_numpy() -> None:
     pytest.importorskip("numpy")
 
 
+@pytest.fixture(scope="module")
+def ensure_cpp_backend() -> None:
+    module = importlib.import_module("ragcore.backends.cpp")
+    if not module.is_available():  # type: ignore[attr-defined]
+        module.build_native(force=True)  # type: ignore[attr-defined]
+    module.ensure_available()  # type: ignore[attr-defined]
+
+
 def _write(tmp_dir: Path, relative: str, content: str) -> Path:
     path = tmp_dir / relative
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -23,13 +32,14 @@ def _write(tmp_dir: Path, relative: str, content: str) -> Path:
     return path
 
 
-def test_cli_lists_pyflat_backend(_ensure_numpy: None) -> None:
+def test_cli_lists_backends(_ensure_numpy: None, ensure_cpp_backend: None) -> None:
     cmd = [sys.executable, "-m", "ragcore.cli", "list"]
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     names = {entry["name"] for entry in payload}
     assert "py_flat" in names
+    assert "cpp_faiss" in names
 
 
 def test_build_and_search_round_trip(tmp_path: Path, _ensure_numpy: None) -> None:
@@ -89,3 +99,64 @@ def test_build_and_search_round_trip(tmp_path: Path, _ensure_numpy: None) -> Non
     assert restored.ntotal() == 0
     with pytest.raises(RuntimeError):
         restored.search(query, k=1)
+
+
+def test_build_and_search_round_trip_cpp_backend(
+    tmp_path: Path, _ensure_numpy: None, ensure_cpp_backend: None
+) -> None:
+    corpus_dir = tmp_path / "corpus_cpp"
+    corpus_dir.mkdir()
+
+    _write(
+        corpus_dir,
+        "doc.md",
+        """title: Example\n---\nExample body\n""",
+    )
+
+    out_dir = tmp_path / "out_cpp"
+    cmd = [
+        sys.executable,
+        "-m",
+        "ragcore.cli",
+        "build",
+        "--backend",
+        "cpp_faiss",
+        "--corpus-dir",
+        str(corpus_dir),
+        "--out",
+        str(out_dir),
+        "--accept-format",
+        "md",
+        "--index-kind",
+        "flat",
+        "--metric",
+        "l2",
+        "--dim",
+        "3",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+    spec_path = out_dir / "index_spec.json"
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    assert spec["backend"] == "cpp_faiss"
+    assert spec["kind"] == "flat"
+
+    cpp_module = importlib.import_module("ragcore.backends.cpp")
+    backend = cpp_module.get_backend()  # type: ignore[attr-defined]
+    handle = backend.build(spec)
+    vectors = np.array(
+        [[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32
+    )
+    ids = np.array([1, 2, 3], dtype=np.int64)
+    handle.add(vectors, ids=ids)
+
+    query = np.array([[0.2, 0.8, 0.0]], dtype=np.float32)
+    results = handle.search(query, k=2)
+    assert results["ids"].shape == (1, 2)
+
+    index_payload = json.loads((out_dir / "index.bin").read_text(encoding="utf-8"))
+    assert index_payload["spec"]["backend"] == "cpp_faiss"
+    assert isinstance(index_payload["metadata"], dict)
+    assert index_payload["vectors"] == []

--- a/tests/unit/test_cpp_flat_parity.py
+++ b/tests/unit/test_cpp_flat_parity.py
@@ -1,3 +1,119 @@
-def test_parity_py_vs_cpp():
-    # TODO: implement
-    assert True
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from ragcore import registry
+from ragcore.backends import register_default_backends
+from ragcore.backends.pyflat import PyFlatBackend
+from ragcore.interfaces import SerializedIndex
+
+
+@pytest.fixture(scope="module")
+def cpp_module() -> object:
+    module = importlib.import_module("ragcore.backends.cpp")
+    if not module.is_available():  # type: ignore[attr-defined]
+        try:
+            module.build_native(force=True)  # type: ignore[attr-defined]
+        except Exception as exc:  # pragma: no cover - environment guard
+            pytest.skip(f"cpp backend unavailable: {exc}")
+    module.ensure_available()  # type: ignore[attr-defined]
+    return module
+
+
+def _example_vectors() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    base = np.array(
+        [
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    ids = np.array([10, 11, 12, 13], dtype=np.int64)
+    queries = np.array(
+        [
+            [0.9, 0.1, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+    return base, ids, queries
+
+
+def test_parity_py_vs_cpp(cpp_module: object) -> None:
+    backend = cpp_module.get_backend()  # type: ignore[attr-defined]
+    py_backend = PyFlatBackend()
+
+    vectors, ids, queries = _example_vectors()
+
+    for metric in ("l2", "ip"):
+        cpp_spec = {"backend": "cpp", "kind": "flat", "metric": metric, "dim": 3}
+        py_spec = {"backend": "py_flat", "kind": "flat", "metric": metric, "dim": 3}
+        cpp_handle = backend.build(cpp_spec)
+        py_handle = py_backend.build(py_spec)
+        cpp_handle.add(vectors, ids=ids)
+        py_handle.add(vectors, ids=ids)
+
+        cpp_results = cpp_handle.search(queries, k=3)
+        py_results = py_handle.search(queries, k=3)
+
+        np.testing.assert_allclose(cpp_results["distances"], py_results["distances"])
+        np.testing.assert_array_equal(cpp_results["ids"], py_results["ids"])
+
+
+def test_cpp_serialize_roundtrip(cpp_module: object) -> None:
+    backend = cpp_module.get_backend()  # type: ignore[attr-defined]
+    vectors, ids, queries = _example_vectors()
+    handle = backend.build({"backend": "cpp", "kind": "flat", "metric": "l2", "dim": 3})
+    handle.add(vectors, ids=ids)
+
+    serialized = handle.serialize_cpu()
+    assert isinstance(serialized, SerializedIndex)
+    assert serialized.vectors.shape == vectors.shape
+    assert serialized.ids.shape == ids.shape
+    assert serialized.metadata["supports_gpu"] is False
+
+    payload = serialized.to_dict()
+    roundtrip = SerializedIndex(
+        spec=payload["spec"],
+        vectors=np.asarray(payload["vectors"], dtype=np.float32),
+        ids=np.asarray(payload["ids"], dtype=np.int64),
+        metadata=payload["metadata"],
+        is_trained=payload["is_trained"],
+        is_gpu=payload["is_gpu"],
+    )
+
+    np.testing.assert_allclose(roundtrip.vectors, serialized.vectors)
+    np.testing.assert_array_equal(roundtrip.ids, serialized.ids)
+
+    results = handle.search(queries, k=2)
+    np.testing.assert_array_equal(results["ids"].shape, (queries.shape[0], 2))
+
+
+def test_cpp_alias_registration(cpp_module: object) -> None:
+    registry._reset_registry()
+    register_default_backends()
+
+    available = set(registry.list_backends())
+    assert "cpp" in available
+    assert "cpp_faiss" in available
+
+    alias_backend = registry.get("cpp_faiss")
+    vectors, ids, queries = _example_vectors()
+    handle = alias_backend.build(
+        {"backend": "cpp_faiss", "kind": "flat", "metric": "l2", "dim": 3}
+    )
+    handle.add(vectors, ids=ids)
+    alias_results = handle.search(queries, k=2)
+
+    cpp_backend = registry.get("cpp")
+    cpp_handle = cpp_backend.build({"backend": "cpp", "kind": "flat", "metric": "l2", "dim": 3})
+    cpp_handle.add(vectors, ids=ids)
+    cpp_results = cpp_handle.search(queries, k=2)
+
+    np.testing.assert_allclose(alias_results["distances"], cpp_results["distances"])
+    np.testing.assert_array_equal(alias_results["ids"], cpp_results["ids"])


### PR DESCRIPTION
## Summary
- align the C++ flat index stub with the Python baseline by using a stable ranking loop and accepting the cpp_faiss alias
- expose the cpp_faiss alias through the backend registry/CLI and ensure native backends are appended when the extension is built
- add regression coverage for cpp vs py parity, serialization, registry aliasing, and CLI build/list flows

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68d96a0d500c832c847feadd0b63712f