### PR TITLE
Implement toolpack loader with schema validation

### DIFF
--- a/apps/toolpacks/__init__.py
+++ b/apps/toolpacks/__init__.py
@@ -1,0 +1,3 @@
+"""Toolpacks runtime package."""
+
+__all__ = ["loader"]

--- a/apps/toolpacks/loader.py
+++ b/apps/toolpacks/loader.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+import yaml
+from jsonschema import validators
+from jsonschema.exceptions import SchemaError
+
+
+class ToolpackValidationError(Exception):
+    """Raised when a Toolpack definition fails validation."""
+
+
+_VALID_EXECUTION_KINDS = {"python", "node", "php", "cli", "http"}
+
+
+@dataclass(frozen=True)
+class Toolpack:
+    """In-memory representation of a Toolpack configuration."""
+
+    id: str
+    version: str
+    deterministic: bool
+    timeout_ms: int
+    limits: Mapping[str, Any]
+    input_schema: Mapping[str, Any]
+    output_schema: Mapping[str, Any]
+    execution: Mapping[str, Any]
+    caps: Mapping[str, Any]
+    env: Mapping[str, Any]
+    templating: Mapping[str, Any]
+    source_path: Path
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any], source_path: Path) -> "Toolpack":
+        if not isinstance(data, Mapping):
+            raise ToolpackValidationError(
+                f"Expected mapping for toolpack {source_path}, got {type(data).__name__}"
+            )
+
+        required_fields = [
+            "id",
+            "version",
+            "deterministic",
+            "timeoutMs",
+            "limits",
+            "inputSchema",
+            "outputSchema",
+            "execution",
+        ]
+        missing = [field for field in required_fields if field not in data]
+        if missing:
+            raise ToolpackValidationError(
+                f"Toolpack {source_path} missing required field(s): {', '.join(missing)}"
+            )
+
+        tool_id = _require_str(data["id"], "id", source_path)
+        version = _require_str(data["version"], "version", source_path)
+        deterministic = data["deterministic"]
+        if not isinstance(deterministic, bool):
+            raise ToolpackValidationError(
+                f"Toolpack {tool_id} deterministic must be a boolean"
+            )
+
+        timeout_ms = data["timeoutMs"]
+        if not isinstance(timeout_ms, int) or timeout_ms <= 0:
+            raise ToolpackValidationError(
+                f"Toolpack {tool_id} timeoutMs must be a positive integer"
+            )
+
+        limits = _require_mapping(data["limits"], "limits", tool_id)
+        for key in ("maxInputBytes", "maxOutputBytes"):
+            if key not in limits:
+                raise ToolpackValidationError(
+                    f"Toolpack {tool_id} limits missing required key '{key}'"
+                )
+            value = limits[key]
+            if not isinstance(value, int) or value <= 0:
+                raise ToolpackValidationError(
+                    f"Toolpack {tool_id} limits['{key}'] must be a positive integer"
+                )
+
+        caps = data.get("caps", {})
+        caps = _require_mapping(caps, "caps", tool_id)
+
+        env = data.get("env", {})
+        env = _require_mapping(env, "env", tool_id)
+
+        templating = data.get("templating", {})
+        templating = _require_mapping(templating, "templating", tool_id)
+
+        input_schema = _resolve_schema(data["inputSchema"], source_path.parent, tool_id)
+        output_schema = _resolve_schema(data["outputSchema"], source_path.parent, tool_id)
+
+        execution = _require_mapping(data["execution"], "execution", tool_id)
+        kind = execution.get("kind")
+        if kind not in _VALID_EXECUTION_KINDS:
+            raise ToolpackValidationError(
+                f"Toolpack {tool_id} execution.kind must be one of {_VALID_EXECUTION_KINDS}"
+            )
+
+        return cls(
+            id=tool_id,
+            version=version,
+            deterministic=deterministic,
+            timeout_ms=timeout_ms,
+            limits=dict(limits),
+            input_schema=input_schema,
+            output_schema=output_schema,
+            execution=dict(execution),
+            caps=dict(caps),
+            env=dict(env),
+            templating=dict(templating),
+            source_path=source_path,
+        )
+
+
+class ToolpackLoader:
+    """Load and expose Toolpack configurations."""
+
+    def __init__(self) -> None:
+        self._toolpacks: Dict[str, Toolpack] = {}
+
+    def load_dir(self, directory: Path | str) -> None:
+        base_dir = Path(directory)
+        if not base_dir.exists():
+            raise ToolpackValidationError(f"Toolpacks directory not found: {base_dir}")
+
+        toolpacks: Dict[str, Toolpack] = {}
+        for path in sorted(base_dir.rglob("*.tool.yaml")):
+            with path.open("r", encoding="utf-8") as handle:
+                try:
+                    data = yaml.safe_load(handle)
+                except yaml.YAMLError as exc:
+                    raise ToolpackValidationError(
+                        f"Failed to parse YAML for toolpack {path}: {exc}"
+                    ) from exc
+
+            toolpack = Toolpack.from_dict(data, path)
+            if toolpack.id in toolpacks:
+                raise ToolpackValidationError(
+                    f"Duplicate toolpack id '{toolpack.id}' found in {path}"
+                )
+            toolpacks[toolpack.id] = toolpack
+
+        self._toolpacks = dict(sorted(toolpacks.items(), key=lambda item: item[0]))
+
+    def list(self) -> List[Toolpack]:
+        return list(self._toolpacks.values())
+
+    def get(self, tool_id: str) -> Toolpack:
+        return self._toolpacks[tool_id]
+
+
+def _require_str(value: Any, field: str, source: Path) -> str:
+    if not isinstance(value, str) or not value:
+        raise ToolpackValidationError(
+            f"Field '{field}' in toolpack {source} must be a non-empty string"
+        )
+    return value
+
+
+def _require_mapping(value: Any, field: str, tool_id: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ToolpackValidationError(
+            f"Toolpack {tool_id} field '{field}' must be a mapping"
+        )
+    return value
+
+
+def _resolve_schema(
+    schema_spec: Any, base_dir: Path, tool_id: str
+) -> Mapping[str, Any]:
+    if not isinstance(schema_spec, Mapping):
+        raise ToolpackValidationError(
+            f"Toolpack {tool_id} schema definition must be a mapping"
+        )
+
+    if "$ref" in schema_spec:
+        ref = schema_spec["$ref"]
+        if not isinstance(ref, str) or not ref:
+            raise ToolpackValidationError(
+                f"Toolpack {tool_id} schema $ref must be a non-empty string"
+            )
+        schema_path = (base_dir / ref).resolve()
+        if not schema_path.is_file():
+            raise ToolpackValidationError(
+                f"Toolpack {tool_id} schema reference not found: {ref}"
+            )
+        try:
+            with schema_path.open("r", encoding="utf-8") as handle:
+                schema = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ToolpackValidationError(
+                f"Toolpack {tool_id} failed to load schema {ref}: {exc}"
+            ) from exc
+    else:
+        schema = dict(schema_spec)
+
+    _validate_json_schema(schema, tool_id)
+    return schema
+
+
+def _validate_json_schema(schema: Mapping[str, Any], tool_id: str) -> None:
+    try:
+        validator_cls = validators.validator_for(schema)
+        validator_cls.check_schema(schema)
+    except SchemaError as exc:
+        raise ToolpackValidationError(
+            f"Toolpack {tool_id} schema failed validation: {exc.message}"
+        ) from exc
+    except Exception as exc:  # pragma: no cover - safeguard for unexpected validator errors
+        raise ToolpackValidationError(
+            f"Toolpack {tool_id} schema failed validation: {exc}"
+        ) from exc

--- a/docs/toolpacks_loader.md
+++ b/docs/toolpacks_loader.md
@@ -1,3 +1,62 @@
 # Toolpacks Loader
 
-TODO
+The Toolpacks loader is responsible for discovering declarative tool definitions
+(`*.tool.yaml`) and preparing them for execution. Its implementation follows the
+contracts in [`codex/specs/ragx_master_spec.yaml`](../codex/specs/ragx_master_spec.yaml)
+and currently focuses on schema resolution and validation.
+
+## Responsibilities
+
+* Recursively walk a directory to find every `*.tool.yaml` file.
+* Parse the YAML definition and materialize it as an in-memory `Toolpack` object.
+* Resolve `$ref` entries under `inputSchema` and `outputSchema` to concrete JSON
+  Schemas relative to the toolpack file.
+* Validate JSON Schemas using `jsonschema`'s `validator_for(...).check_schema` so
+  malformed schemas fail fast.
+* Enforce structural contracts for each toolpack (`id`, `version`,
+  `deterministic`, `timeoutMs`, `limits`, `execution.kind`, etc.).
+* Reject duplicate tool identifiers and expose deterministic ordering via
+  `ToolpackLoader.list()`.
+
+## Public API
+
+```python
+from apps.toolpacks.loader import ToolpackLoader
+
+loader = ToolpackLoader()
+loader.load_dir("apps/mcp_server/toolpacks")
+for pack in loader.list():
+    print(pack.id, pack.execution["kind"])
+```
+
+* `ToolpackLoader.load_dir(path)` resets the loader state and imports the full
+  directory tree (raising `ToolpackValidationError` on any invalid file).
+* `ToolpackLoader.list()` returns the loaded `Toolpack` instances sorted by id.
+* `ToolpackLoader.get(tool_id)` returns the `Toolpack` for a specific id or
+  raises `KeyError` if it is unknown.
+
+## Validation Rules
+
+The loader enforces the following invariants:
+
+* `id`, `version` – non-empty strings.
+* `deterministic` – boolean flag.
+* `timeoutMs` – positive integer.
+* `limits.maxInputBytes` / `limits.maxOutputBytes` – positive integers.
+* `execution.kind` – one of `{python, node, php, cli, http}`.
+* `$ref` schema paths must exist and contain valid JSON Schema documents.
+
+These checks keep downstream components deterministic and guard against loading
+invalid or malformed toolpacks.
+
+## Testing
+
+Unit coverage lives in `tests/unit/test_toolpacks_loader.py` and exercises:
+
+* Success path with multiple toolpacks and nested directories.
+* `$ref` schema resolution.
+* Duplicate id detection and missing field validation.
+* `get()` failure semantics for unknown tool ids.
+
+The suite runs as part of the global `pytest` invocation and must remain green
+before any pull request is considered complete.

--- a/tests/unit/test_toolpacks_loader.py
+++ b/tests/unit/test_toolpacks_loader.py
@@ -1,3 +1,183 @@
-def test_load_toolpacks():
-    # TODO: implement
-    assert True
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from apps.toolpacks.loader import ToolpackLoader, ToolpackValidationError
+
+
+@pytest.fixture
+def schema_dir(tmp_path: Path) -> Path:
+    schema_root = tmp_path / "schemas"
+    schema_root.mkdir(parents=True)
+    return schema_root
+
+
+def _write_schema(path: Path, name: str, schema: dict) -> Path:
+    file_path = path / name
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(json.dumps(schema))
+    return file_path
+
+
+def _write_toolpack(path: Path, name: str, data: dict) -> Path:
+    file_path = path / name
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return file_path
+
+
+def test_load_toolpacks(tmp_path: Path, schema_dir: Path) -> None:
+    input_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+        },
+        "required": ["query"],
+    }
+    output_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "results": {
+                "type": "array",
+                "items": {"type": "string"},
+            }
+        },
+        "required": ["results"],
+    }
+
+    input_schema_path = _write_schema(schema_dir, "search.input.schema.json", input_schema)
+    output_schema_path = _write_schema(schema_dir, "search.output.schema.json", output_schema)
+
+    packs_dir = tmp_path / "toolpacks"
+    packs_dir.mkdir()
+
+    toolpack_data = {
+        "id": "search.query",
+        "version": "1.0.0",
+        "deterministic": True,
+        "timeoutMs": 5000,
+        "limits": {"maxInputBytes": 4096, "maxOutputBytes": 8192},
+        "execution": {"kind": "python", "module": "pkg.tool:run"},
+    }
+    toolpack_data["inputSchema"] = {"$ref": os.path.relpath(input_schema_path, packs_dir)}
+    toolpack_data["outputSchema"] = {"$ref": os.path.relpath(output_schema_path, packs_dir)}
+
+    _write_toolpack(packs_dir, "search.query.tool.yaml", toolpack_data)
+    nested_dir = packs_dir / "beta"
+    nested_toolpack_data = {
+        **toolpack_data,
+        "id": "search.summary",
+        "execution": {"kind": "cli", "cmd": ["echo", "hello"]},
+        "inputSchema": {"$ref": os.path.relpath(input_schema_path, nested_dir)},
+        "outputSchema": {"$ref": os.path.relpath(output_schema_path, nested_dir)},
+    }
+    _write_toolpack(nested_dir, "search.summary.tool.yaml", nested_toolpack_data)
+
+    loader = ToolpackLoader()
+    loader.load_dir(tmp_path)
+
+    ids = [pack.id for pack in loader.list()]
+    assert ids == sorted(ids)
+
+    query_pack = loader.get("search.query")
+    assert query_pack.input_schema == input_schema
+    assert query_pack.output_schema == output_schema
+    assert query_pack.execution["kind"] == "python"
+    assert query_pack.source_path.name == "search.query.tool.yaml"
+
+    summary_pack = loader.get("search.summary")
+    assert summary_pack.execution["kind"] == "cli"
+
+
+def test_missing_required_field(tmp_path: Path, schema_dir: Path) -> None:
+    schema_path = _write_schema(
+        schema_dir,
+        "input.schema.json",
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+        },
+    )
+
+    toolpack_data = {
+        "id": "broken.tool",
+        "version": "1.0.0",
+        "deterministic": True,
+        "timeoutMs": 1000,
+        "limits": {"maxInputBytes": 1, "maxOutputBytes": 1},
+        "inputSchema": {"$ref": os.path.relpath(schema_path, tmp_path)},
+        "outputSchema": {"$ref": os.path.relpath(schema_path, tmp_path)},
+        # missing execution
+    }
+
+    _write_toolpack(tmp_path, "broken.tool.yaml", toolpack_data)
+
+    loader = ToolpackLoader()
+
+    with pytest.raises(ToolpackValidationError):
+        loader.load_dir(tmp_path)
+
+
+def test_duplicate_tool_ids(tmp_path: Path, schema_dir: Path) -> None:
+    schema_path = _write_schema(
+        schema_dir,
+        "schema.json",
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+        },
+    )
+
+    base_data = {
+        "id": "dup.tool",
+        "version": "1.0.0",
+        "deterministic": True,
+        "timeoutMs": 1000,
+        "limits": {"maxInputBytes": 1, "maxOutputBytes": 1},
+        "execution": {"kind": "http", "url": "https://example.com"},
+        "inputSchema": {"$ref": os.path.relpath(schema_path, tmp_path)},
+        "outputSchema": {"$ref": os.path.relpath(schema_path, tmp_path)},
+    }
+
+    _write_toolpack(tmp_path, "one.tool.yaml", base_data)
+    _write_toolpack(tmp_path, "two.tool.yaml", {**base_data, "version": "2.0.0"})
+
+    loader = ToolpackLoader()
+
+    with pytest.raises(ToolpackValidationError):
+        loader.load_dir(tmp_path)
+
+
+def test_get_missing_tool_raises_key_error(tmp_path: Path, schema_dir: Path) -> None:
+    schema_path = _write_schema(
+        schema_dir,
+        "schema.json",
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+        },
+    )
+
+    toolpack_data = {
+        "id": "exists.tool",
+        "version": "1.0.0",
+        "deterministic": True,
+        "timeoutMs": 1000,
+        "limits": {"maxInputBytes": 1, "maxOutputBytes": 1},
+        "execution": {"kind": "python", "module": "pkg.tool:run"},
+        "inputSchema": {"$ref": os.path.relpath(schema_path, tmp_path)},
+        "outputSchema": {"$ref": os.path.relpath(schema_path, tmp_path)},
+    }
+
+    _write_toolpack(tmp_path, "exists.tool.yaml", toolpack_data)
+
+    loader = ToolpackLoader()
+    loader.load_dir(tmp_path)
+
+    with pytest.raises(KeyError):
+        loader.get("missing.tool")


### PR DESCRIPTION
## Summary
- implement the ToolpackLoader with schema resolution and validation logic
- add unit tests covering success, validation failures, and lookup semantics
- document the loader responsibilities and usage

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d96ce71a4c832c917a5565ab2233d4