### PR TITLE
Implement python toolpack executor

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,3 @@
+"""Application packages for RAGX."""
+
+__all__ = ["toolpacks", "mcp_server"]

--- a/apps/toolpacks/executor.py
+++ b/apps/toolpacks/executor.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import hashlib
+import importlib
+import json
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from jsonschema import validators
+from jsonschema.exceptions import SchemaError, ValidationError
+
+from apps.toolpacks.loader import Toolpack, ToolpackValidationError
+
+__all__ = ["Executor", "ToolpackExecutionError"]
+
+
+class ToolpackExecutionError(Exception):
+    """Raised when executing a Toolpack fails."""
+
+
+class Executor:
+    """Execute Toolpack definitions for supported execution kinds."""
+
+    def __init__(self) -> None:
+        self._cache: dict[str, dict[str, Any]] = {}
+
+    def run_toolpack(self, toolpack: Toolpack, payload: Mapping[str, Any]) -> dict[str, Any]:
+        """Execute ``toolpack`` with ``payload`` and return the validated output."""
+
+        execution_kind = toolpack.execution.get("kind")
+        if execution_kind != "python":
+            raise ToolpackExecutionError(
+                f"Unsupported execution kind '{execution_kind}' for toolpack {toolpack.id}"
+            )
+
+        input_payload = _ensure_mapping(payload, stage="input", toolpack=toolpack)
+        _validate_instance(
+            schema=toolpack.input_schema,
+            instance=input_payload,
+            stage="input",
+            toolpack=toolpack,
+        )
+
+        cache_key = self._cache_key(toolpack, input_payload)
+        if toolpack.deterministic:
+            cached = self._cache.get(cache_key)
+            if cached is not None:
+                return copy.deepcopy(cached)
+
+        runner = self._resolve_python_callable(toolpack)
+        try:
+            result = runner(copy.deepcopy(input_payload))
+            if asyncio.iscoroutine(result):
+                result = asyncio.run(result)
+        except Exception as exc:  # pragma: no cover - execution failure path
+            raise ToolpackExecutionError(
+                f"Toolpack {toolpack.id} execution failed: {exc}"
+            ) from exc
+
+        output_payload = _ensure_mapping(result, stage="output", toolpack=toolpack)
+        _validate_instance(
+            schema=toolpack.output_schema,
+            instance=output_payload,
+            stage="output",
+            toolpack=toolpack,
+        )
+
+        materialised = copy.deepcopy(output_payload)
+        if toolpack.deterministic:
+            self._cache[cache_key] = copy.deepcopy(materialised)
+            return copy.deepcopy(materialised)
+        return materialised
+
+    def _resolve_python_callable(self, toolpack: Toolpack) -> Callable[[Mapping[str, Any]], Any]:
+        execution = toolpack.execution
+        entrypoint = execution.get("module")
+        if not isinstance(entrypoint, str) or not entrypoint:
+            message = (
+                f"Toolpack {toolpack.id} python execution requires module entrypoint "
+                "'pkg.mod:func'"
+            )
+            raise ToolpackExecutionError(message)
+
+        module_name, sep, attr_name = entrypoint.partition(":")
+        if not sep or not module_name or not attr_name:
+            raise ToolpackExecutionError(
+                f"Toolpack {toolpack.id} python module entrypoint must use 'module:callable'"
+            )
+
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as exc:  # pragma: no cover - import errors rely on Python
+            raise ToolpackExecutionError(
+                f"Toolpack {toolpack.id} failed to import module '{module_name}': {exc}"
+            ) from exc
+
+        try:
+            func = getattr(module, attr_name)
+        except AttributeError as exc:
+            raise ToolpackExecutionError(
+                f"Toolpack {toolpack.id} module '{module_name}' has no attribute '{attr_name}'"
+            ) from exc
+
+        if not callable(func):
+            raise ToolpackExecutionError(
+                f"Toolpack {toolpack.id} attribute '{attr_name}' is not callable"
+            )
+
+        return func
+
+    def _cache_key(self, toolpack: Toolpack, payload: Mapping[str, Any]) -> str:
+        envelope = {
+            "id": toolpack.id,
+            "version": toolpack.version,
+            "payload": payload,
+        }
+        try:
+            serialised = json.dumps(envelope, sort_keys=True, separators=(",", ":"))
+        except TypeError as exc:
+            raise ToolpackExecutionError(
+                f"Toolpack {toolpack.id} input is not JSON serialisable for caching"
+            ) from exc
+        return hashlib.sha256(serialised.encode("utf-8")).hexdigest()
+
+
+def _ensure_mapping(value: Any, *, stage: str, toolpack: Toolpack) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ToolpackExecutionError(
+            f"Toolpack {toolpack.id} {stage} payload must be a mapping"
+        )
+    return dict(value)
+
+
+def _validate_instance(
+    *,
+    schema: Mapping[str, Any],
+    instance: Mapping[str, Any],
+    stage: str,
+    toolpack: Toolpack,
+) -> None:
+    try:
+        validator_cls = validators.validator_for(schema)
+        validator_cls.check_schema(schema)
+        validator = validator_cls(schema)
+        validator.validate(instance)
+    except SchemaError as exc:  # pragma: no cover - schema already validated by loader
+        raise ToolpackValidationError(
+            f"Toolpack {toolpack.id} schema failed validation: {exc.message}"
+        ) from exc
+    except ValidationError as exc:
+        raise ToolpackExecutionError(
+            f"Toolpack {toolpack.id} {stage} failed JSON schema validation: {exc.message}"
+        ) from exc

--- a/apps/toolpacks/loader.py
+++ b/apps/toolpacks/loader.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping
+from typing import Any
 
 import yaml
 from jsonschema import validators
@@ -35,7 +36,7 @@ class Toolpack:
     source_path: Path
 
     @classmethod
-    def from_dict(cls, data: Mapping[str, Any], source_path: Path) -> "Toolpack":
+    def from_dict(cls, data: Mapping[str, Any], source_path: Path) -> Toolpack:
         if not isinstance(data, Mapping):
             raise ToolpackValidationError(
                 f"Expected mapping for toolpack {source_path}, got {type(data).__name__}"
@@ -122,14 +123,14 @@ class ToolpackLoader:
     """Load and expose Toolpack configurations."""
 
     def __init__(self) -> None:
-        self._toolpacks: Dict[str, Toolpack] = {}
+        self._toolpacks: dict[str, Toolpack] = {}
 
     def load_dir(self, directory: Path | str) -> None:
         base_dir = Path(directory)
         if not base_dir.exists():
             raise ToolpackValidationError(f"Toolpacks directory not found: {base_dir}")
 
-        toolpacks: Dict[str, Toolpack] = {}
+        toolpacks: dict[str, Toolpack] = {}
         for path in sorted(base_dir.rglob("*.tool.yaml")):
             with path.open("r", encoding="utf-8") as handle:
                 try:
@@ -148,7 +149,7 @@ class ToolpackLoader:
 
         self._toolpacks = dict(sorted(toolpacks.items(), key=lambda item: item[0]))
 
-    def list(self) -> List[Toolpack]:
+    def list(self) -> list[Toolpack]:
         return list(self._toolpacks.values())
 
     def get(self, tool_id: str) -> Toolpack:

--- a/ragcore/interfaces.py
+++ b/ragcore/interfaces.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, TypeAlias, runtime_checkable
 
 import numpy as np
-from numpy.typing import NDArray
+from numpy import ndarray
 
-FloatArray = NDArray[np.float32]
-IntArray = NDArray[np.int64]
+FloatArray: TypeAlias = ndarray[Any, np.dtype[np.float32]]
+IntArray: TypeAlias = ndarray[Any, np.dtype[np.int64]]
 
 
 @runtime_checkable

--- a/scripts/codex_next_tasks.py
+++ b/scripts/codex_next_tasks.py
@@ -47,7 +47,7 @@ def _coerce_title(raw: object, fallback: str) -> str:
 
 
 def _coerce_component_ids(raw: object) -> tuple[str, ...]:
-    if isinstance(raw, Iterable) and not isinstance(raw, (str, bytes)):
+    if isinstance(raw, Iterable) and not isinstance(raw, str | bytes):
         return tuple(str(item) for item in raw)
     return ()
 

--- a/tests/e2e/test_mcp_core_tools_python_only.py
+++ b/tests/e2e/test_mcp_core_tools_python_only.py
@@ -1,2 +1,75 @@
-def test_placeholder():
-    assert True
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from apps.toolpacks.executor import Executor, ToolpackExecutionError
+from apps.toolpacks.loader import ToolpackLoader
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _schema(**properties: object) -> dict[str, object]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": properties,
+        "required": list(properties),
+    }
+
+
+def test_execute_python_toolpack_from_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    schema_dir = tmp_path / "schemas"
+    input_schema = _schema(value={"type": "integer", "minimum": 0})
+    output_schema = _schema(result={"type": "integer"})
+    input_schema_path = schema_dir / "calc.input.schema.json"
+    output_schema_path = schema_dir / "calc.output.schema.json"
+    _write(input_schema_path, json.dumps(input_schema))
+    _write(output_schema_path, json.dumps(output_schema))
+
+    module_root = tmp_path / "toolsrc"
+    module_root.mkdir()
+    _write(module_root / "__init__.py", "")
+    module_code = """
+def run(payload):
+    value = payload["value"]
+    return {"result": value * 3}
+"""
+    _write(module_root / "calc.py", module_code)
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    packs_dir = tmp_path / "toolpacks"
+    packs_dir.mkdir()
+    toolpack_data = {
+        "id": "calc.multiply",
+        "version": "1.0.0",
+        "deterministic": True,
+        "timeoutMs": 2000,
+        "limits": {"maxInputBytes": 1024, "maxOutputBytes": 1024},
+        "inputSchema": {"$ref": os.path.relpath(input_schema_path, packs_dir)},
+        "outputSchema": {"$ref": os.path.relpath(output_schema_path, packs_dir)},
+        "execution": {"kind": "python", "module": "toolsrc.calc:run"},
+    }
+    _write(packs_dir / "calc.multiply.tool.yaml", yaml.safe_dump(toolpack_data, sort_keys=False))
+
+    loader = ToolpackLoader()
+    loader.load_dir(packs_dir)
+    toolpack = loader.get("calc.multiply")
+
+    executor = Executor()
+    result_one = executor.run_toolpack(toolpack, {"value": 7})
+    result_two = executor.run_toolpack(toolpack, {"value": 7})
+
+    assert result_one == result_two == {"result": 21}
+    result_one["result"] = 0
+    assert executor.run_toolpack(toolpack, {"value": 7}) == {"result": 21}
+
+    with pytest.raises(ToolpackExecutionError):
+        executor.run_toolpack(toolpack, {"value": -1})

--- a/tests/unit/test_toolpacks_exec_python.py
+++ b/tests/unit/test_toolpacks_exec_python.py
@@ -1,3 +1,143 @@
-def test_exec_python_toolpack():
-    # TODO: implement
-    assert True
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from apps.toolpacks.executor import Executor, ToolpackExecutionError
+from apps.toolpacks.loader import Toolpack
+
+
+def _make_schema(required: str) -> dict[str, object]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            required: {"type": "number"},
+        },
+        "required": [required],
+    }
+
+
+def _make_toolpack(
+    *,
+    module: str,
+    deterministic: bool = True,
+) -> Toolpack:
+    return Toolpack(
+        id="calc.double",
+        version="1.0.0",
+        deterministic=deterministic,
+        timeout_ms=1000,
+        limits={"maxInputBytes": 4096, "maxOutputBytes": 4096},
+        input_schema=_make_schema("value"),
+        output_schema=_make_schema("result"),
+        execution={"kind": "python", "module": module},
+        caps={},
+        env={},
+        templating={},
+        source_path=Path("calc.double.tool.yaml"),
+    )
+
+
+def _register_module(monkeypatch: pytest.MonkeyPatch, name: str, func) -> None:
+    module = types.ModuleType(name)
+    module.run = func  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, name, module)
+
+
+def test_exec_python_toolpack_runs_callable(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[dict[str, object]] = []
+
+    def run(payload: dict[str, object]) -> dict[str, object]:
+        captured.append(payload)
+        value = payload["value"]
+        assert isinstance(value, int | float)
+        return {"result": value * 2}
+
+    module_name = "toolpacks_tests.runtime"
+    _register_module(monkeypatch, module_name, run)
+    toolpack = _make_toolpack(module=f"{module_name}:run")
+
+    executor = Executor()
+    result = executor.run_toolpack(toolpack, {"value": 4})
+
+    assert result == {"result": 8}
+    assert captured == [{"value": 4}]
+
+
+def test_exec_python_toolpack_validates_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    def run(payload: dict[str, object]) -> dict[str, object]:
+        return {"result": payload.get("value", 0)}
+
+    module_name = "toolpacks_tests.validation"
+    _register_module(monkeypatch, module_name, run)
+    toolpack = _make_toolpack(module=f"{module_name}:run")
+
+    executor = Executor()
+
+    with pytest.raises(ToolpackExecutionError) as excinfo:
+        executor.run_toolpack(toolpack, {})
+
+    assert "input" in str(excinfo.value)
+
+
+def test_exec_python_toolpack_validates_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    def run(payload: dict[str, object]) -> dict[str, object]:
+        return {"unexpected": payload["value"]}
+
+    module_name = "toolpacks_tests.output"
+    _register_module(monkeypatch, module_name, run)
+    toolpack = _make_toolpack(module=f"{module_name}:run")
+
+    executor = Executor()
+
+    with pytest.raises(ToolpackExecutionError) as excinfo:
+        executor.run_toolpack(toolpack, {"value": 1})
+
+    assert "output" in str(excinfo.value)
+
+
+def test_exec_python_toolpack_idempotent_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def run(payload: dict[str, object]) -> dict[str, object]:
+        calls.append(1)
+        return {"result": payload["value"]}
+
+    module_name = "toolpacks_tests.cache"
+    _register_module(monkeypatch, module_name, run)
+    toolpack = _make_toolpack(module=f"{module_name}:run")
+
+    executor = Executor()
+    first = executor.run_toolpack(toolpack, {"value": 3})
+    second = executor.run_toolpack(toolpack, {"value": 3})
+
+    assert calls == [1]
+    assert first == second == {"result": 3}
+
+    first["result"] = 0
+    cached = executor.run_toolpack(toolpack, {"value": 3})
+    assert cached == {"result": 3}
+
+
+def test_exec_python_toolpack_skips_cache_for_non_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int] = []
+
+    def run(payload: dict[str, object]) -> dict[str, object]:
+        calls.append(1)
+        return {"result": payload["value"]}
+
+    module_name = "toolpacks_tests.cache_disabled"
+    _register_module(monkeypatch, module_name, run)
+    toolpack = _make_toolpack(module=f"{module_name}:run", deterministic=False)
+
+    executor = Executor()
+    executor.run_toolpack(toolpack, {"value": 5})
+    executor.run_toolpack(toolpack, {"value": 5})
+
+    assert calls == [1, 1]


### PR DESCRIPTION
## Summary
- add a python toolpack executor that validates schemas and caches deterministic runs
- cover the executor with targeted unit and e2e tests that build toolpacks from YAML
- fix typing issues and package metadata so lint/typecheck stay green

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68d9bd7330b8832c96ccfaa4b48d25fc