### PR TITLE
Align toolpack loader with execution spec

### DIFF
--- a/docs/toolpacks_loader.md
+++ b/docs/toolpacks_loader.md
@@ -44,6 +44,13 @@ The loader enforces the following invariants:
 * `timeoutMs` – positive integer.
 * `limits.maxInputBytes` / `limits.maxOutputBytes` – positive integers.
 * `execution.kind` – one of `{python, node, php, cli, http}`.
+* `execution` fields are validated per kind (e.g. python requires `module` or
+  `script`, CLI requires a `cmd` list, HTTP requires a `url`).
+* `caps.network` (when present) must be a list of non-empty strings.
+* `env.passthrough` (when present) must list non-empty environment variable
+  names.
+* `templating.engine` / `templating.cacheKey` must be non-empty strings if
+  provided.
 * `$ref` schema paths must exist and contain valid JSON Schema documents.
 
 These checks keep downstream components deterministic and guard against loading

--- a/tests/unit/test_toolpacks_loader.py
+++ b/tests/unit/test_toolpacks_loader.py
@@ -29,6 +29,27 @@ def _write_toolpack(path: Path, name: str, data: dict) -> Path:
     return file_path
 
 
+def _make_toolpack_data(
+    tool_dir: Path,
+    schema_path: Path,
+    *,
+    execution: dict,
+    tool_id: str = "sample.tool",
+    version: str = "1.0.0",
+) -> dict:
+    rel_schema = os.path.relpath(schema_path, tool_dir)
+    return {
+        "id": tool_id,
+        "version": version,
+        "deterministic": True,
+        "timeoutMs": 1000,
+        "limits": {"maxInputBytes": 1, "maxOutputBytes": 1},
+        "inputSchema": {"$ref": rel_schema},
+        "outputSchema": {"$ref": rel_schema},
+        "execution": execution,
+    }
+
+
 def test_load_toolpacks(tmp_path: Path, schema_dir: Path) -> None:
     input_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -181,3 +202,183 @@ def test_get_missing_tool_raises_key_error(tmp_path: Path, schema_dir: Path) -> 
 
     with pytest.raises(KeyError):
         loader.get("missing.tool")
+
+
+def test_cli_execution_requires_command_list(tmp_path: Path, schema_dir: Path) -> None:
+    schema_path = _write_schema(
+        schema_dir,
+        "schema.json",
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+        },
+    )
+
+    toolpack_data = _make_toolpack_data(
+        tmp_path,
+        schema_path,
+        execution={"kind": "cli"},
+        tool_id="cli.tool",
+    )
+
+    _write_toolpack(tmp_path, "cli.tool.yaml", toolpack_data)
+
+    loader = ToolpackLoader()
+
+    with pytest.raises(ToolpackValidationError):
+        loader.load_dir(tmp_path)
+
+
+def test_python_module_entrypoint_requires_callable(tmp_path: Path, schema_dir: Path) -> None:
+    schema_path = _write_schema(
+        schema_dir,
+        "schema.json",
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+        },
+    )
+
+    toolpack_data = _make_toolpack_data(
+        tmp_path,
+        schema_path,
+        execution={"kind": "python", "module": "pkg.module"},
+        tool_id="python.tool",
+    )
+
+    _write_toolpack(tmp_path, "python.tool.yaml", toolpack_data)
+
+    loader = ToolpackLoader()
+
+    with pytest.raises(ToolpackValidationError):
+        loader.load_dir(tmp_path)
+
+
+def test_http_execution_requires_url(tmp_path: Path, schema_dir: Path) -> None:
+    schema_path = _write_schema(
+        schema_dir,
+        "schema.json",
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+        },
+    )
+
+    toolpack_data = _make_toolpack_data(
+        tmp_path,
+        schema_path,
+        execution={"kind": "http", "method": "POST"},
+        tool_id="http.tool",
+    )
+
+    _write_toolpack(tmp_path, "http.tool.yaml", toolpack_data)
+
+    loader = ToolpackLoader()
+
+    with pytest.raises(ToolpackValidationError):
+        loader.load_dir(tmp_path)
+
+
+def test_env_passthrough_requires_strings(tmp_path: Path, schema_dir: Path) -> None:
+    schema_path = _write_schema(
+        schema_dir,
+        "schema.json",
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+        },
+    )
+
+    execution = {"kind": "python", "module": "pkg.tool:run"}
+    toolpack_data = _make_toolpack_data(
+        tmp_path,
+        schema_path,
+        execution=execution,
+        tool_id="env.tool",
+    )
+    toolpack_data["env"] = {"passthrough": ["TOKEN", 123]}
+
+    _write_toolpack(tmp_path, "env.tool.yaml", toolpack_data)
+
+    loader = ToolpackLoader()
+
+    with pytest.raises(ToolpackValidationError):
+        loader.load_dir(tmp_path)
+
+
+def test_caps_network_requires_strings(tmp_path: Path, schema_dir: Path) -> None:
+    schema_path = _write_schema(
+        schema_dir,
+        "schema.json",
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+        },
+    )
+
+    execution = {"kind": "python", "module": "pkg.tool:run"}
+    toolpack_data = _make_toolpack_data(
+        tmp_path,
+        schema_path,
+        execution=execution,
+        tool_id="caps.tool",
+    )
+    toolpack_data["caps"] = {"network": ["https", 5]}
+
+    _write_toolpack(tmp_path, "caps.tool.yaml", toolpack_data)
+
+    loader = ToolpackLoader()
+
+    with pytest.raises(ToolpackValidationError):
+        loader.load_dir(tmp_path)
+
+
+def test_valid_optional_sections_are_preserved(tmp_path: Path, schema_dir: Path) -> None:
+    input_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "required": ["query"],
+    }
+    output_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {"results": {"type": "array", "items": {"type": "string"}}},
+        "required": ["results"],
+    }
+
+    input_path = _write_schema(schema_dir, "input.schema.json", input_schema)
+    output_path = _write_schema(schema_dir, "output.schema.json", output_schema)
+
+    toolpack_dir = tmp_path / "packs"
+    execution = {
+        "kind": "http",
+        "url": "https://example.com/run",
+        "method": "POST",
+        "headers": {"Authorization": "Bearer token"},
+    }
+    toolpack_data = {
+        "id": "search.http",
+        "version": "2.0.0",
+        "deterministic": True,
+        "timeoutMs": 5000,
+        "limits": {"maxInputBytes": 4096, "maxOutputBytes": 8192},
+        "inputSchema": {"$ref": os.path.relpath(input_path, toolpack_dir)},
+        "outputSchema": {"$ref": os.path.relpath(output_path, toolpack_dir)},
+        "execution": execution,
+        "caps": {"network": ["https"]},
+        "env": {"passthrough": ["TOKEN"]},
+        "templating": {"engine": "jinja2", "cacheKey": "{{id}}-{{version}}"},
+    }
+
+    _write_toolpack(toolpack_dir, "search.http.tool.yaml", toolpack_data)
+
+    loader = ToolpackLoader()
+    loader.load_dir(tmp_path)
+
+    pack = loader.get("search.http")
+    assert pack.caps["network"] == ["https"]
+    assert pack.env["passthrough"] == ["TOKEN"]
+    assert pack.templating["engine"] == "jinja2"
+    assert pack.execution["method"] == "POST"
+    assert pack.execution["headers"] == {"Authorization": "Bearer token"}


### PR DESCRIPTION
## Summary
- enforce spec-aligned validation for ToolpackLoader across caps, env, templating, and per-kind execution requirements
- add regression tests covering execution kind requirements and optional section validation for toolpacks
- document the expanded validation rules in docs/toolpacks_loader.md

## Testing
- ./scripts/ensure_green.sh


------
https://chatgpt.com/codex/tasks/task_e_68d9e6231498832cb54af93625328a71