### PR TITLE
Fix pybind11 configuration and handle C++ backend import failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,13 @@ jobs:
 
       # Export pybind11_DIR so CMake can find it (portable)
       - name: Export pybind11_DIR
+        id: pybind11
         run: |
-          echo "pybind11_DIR=$(python -m pybind11 --cmakedir)" >> $GITHUB_ENV
-          echo "Using pybind11_DIR=$pybind11_DIR"
+          set -e
+          cmakedir="$(python -m pybind11 --cmakedir)"
+          echo "pybind11_DIR=$cmakedir" >> "$GITHUB_ENV"
+          echo "cmakedir=$cmakedir" >> "$GITHUB_OUTPUT"
+          echo "Using pybind11_DIR=$cmakedir"
 
       # Install ccache (small, fast) so compiler launcher works
       - name: Install ccache
@@ -98,7 +102,7 @@ jobs:
       - name: Configure CMake
         if: ${{ steps.changes.outputs.native == 'true' && hashFiles('cpp/CMakeLists.txt') != '' }}
         env:
-          pybind11_DIR: ${{ env.pybind11_DIR }}
+          pybind11_DIR: ${{ steps.pybind11.outputs.cmakedir }}
         run: |
           mkdir -p ~/.cache/ccache
           ccache --max-size=200M || true

--- a/codex/specs/ragx_master_spec.yaml
+++ b/codex/specs/ragx_master_spec.yaml
@@ -258,7 +258,7 @@ components:
       exports_render_markdown_output: "apps/mcp_server/schemas/tools/exports_render_markdown.output.schema.json"
     toolpacks_dir: "apps/mcp_server/toolpacks/"
     prompts_dir: "apps/mcp_server/prompts/"
-  dependencies: [fastapi, uvicorn, pydantic, jsonschema, jinja2, httpx]
+  dependencies: [fastapi, uvicorn, pydantic, jsonschema, jinja2, httpx, packaging]
   observability:
     logs: [trace_id, transport, tool, version, duration_ms, io_bytes, status, error_code]
     metrics: [mcp_requests_total, mcp_request_duration_seconds_bucket, mcp_errors_total, mcp_io_bytes_total]
@@ -290,7 +290,7 @@ components:
   data_contracts:
     execution_stdin_example: { json: { input: { any: "object" } } }
     execution_stdout_example: { json: { any: "tool_data" } }
-  dependencies: [jinja2, httpx]
+  dependencies: [jinja2, httpx, packaging]
   observability:
     logs: [exec_kind, argv_or_module, exit_code, duration_ms, out_bytes]
   metrics: [toolpack_exec_total, toolpack_timeout_total, toolpack_bytes_out_total]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,24 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+
+[project]
+name = "ragx"
+dynamic = ["version"]
+dependencies = [
+    "jinja2",
+    "jsonschema",
+    "numpy",
+    "pyyaml",
+    "packaging",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "ruff",
+    "mypy",
+    "yamllint",
+    "pybind11",
+]

--- a/ragcore/backends/cpp/__init__.py
+++ b/ragcore/backends/cpp/__init__.py
@@ -65,7 +65,10 @@ else:
         CppFaissBackend = _ExtensionFaissBackend
         CppHandle = _CppHandle
         _HAS_EXTENSION = True
-    except ModuleNotFoundError as exc:  # pragma: no cover - optional extension
+    except Exception as exc:  # pragma: no cover - optional extension
+        # Catch any import-time failure so the Python shim can load and expose the
+        # recorded error via the fallback backend (e.g., ABI mismatch, missing
+        # shared library, or a bad extension build).
         _IMPORT_ERROR = exc
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ jinja2
 jsonschema
 numpy
 pyyaml
+packaging
 pytest
 pytest-cov
 numpy

--- a/tests/unit/test_cpp_stub_import.py
+++ b/tests/unit/test_cpp_stub_import.py
@@ -43,6 +43,25 @@ def test_cpp_backend_import_falls_back_when_extension_missing(
         backend.build({})
 
 
+def test_cpp_backend_import_falls_back_when_extension_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_extension = types.ModuleType("_ragcore_cpp")
+    fake_extension.CppHandle = object
+
+    module = _import_cpp_module(monkeypatch, fake_extension=fake_extension)
+
+    assert module.HAS_CPP_EXTENSION is False
+
+    backend = module.CppBackend()
+    info = backend.capabilities()
+    assert info["available"] is False
+    assert "CppBackend" in info["reason"]
+
+    with pytest.raises(RuntimeError):
+        backend.build({})
+
+
 def test_cpp_backend_uses_extension_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_extension = types.ModuleType("_ragcore_cpp")
 


### PR DESCRIPTION
## Summary
- ensure the CI workflow propagates the discovered `pybind11_DIR` into the CMake configure step via step outputs
- let the C++ backend shim record any import-time failure and add coverage for fallback when the extension raises ImportError
- declare the new `packaging` dependency in requirements, pyproject metadata, and the component spec

## Testing
- pytest tests/unit/test_cpp_stub_import.py

------
https://chatgpt.com/codex/tasks/task_e_68db287569f4832c9e4ce8473fdaecfb