### PR TITLE
Fix pybind11 env propagation and cpp shim fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,13 @@ jobs:
 
       # Export pybind11_DIR so CMake can find it (portable)
       - name: Export pybind11_DIR
+        id: pybind11
         run: |
-          echo "pybind11_DIR=$(python -m pybind11 --cmakedir)" >> $GITHUB_ENV
-          echo "Using pybind11_DIR=$pybind11_DIR"
+          set -e
+          cmakedir="$(python -m pybind11 --cmakedir)"
+          echo "pybind11_DIR=$cmakedir" >> "$GITHUB_ENV"
+          echo "cmakedir=$cmakedir" >> "$GITHUB_OUTPUT"
+          echo "Using pybind11_DIR=$cmakedir"
 
       # Install ccache (small, fast) so compiler launcher works
       - name: Install ccache
@@ -98,7 +102,7 @@ jobs:
       - name: Configure CMake
         if: ${{ steps.changes.outputs.native == 'true' && hashFiles('cpp/CMakeLists.txt') != '' }}
         env:
-          pybind11_DIR: ${{ env.pybind11_DIR }}
+          pybind11_DIR: ${{ steps.pybind11.outputs.cmakedir }}
         run: |
           mkdir -p ~/.cache/ccache
           ccache --max-size=200M || true

--- a/codex/specs/ragx_master_spec.yaml
+++ b/codex/specs/ragx_master_spec.yaml
@@ -258,7 +258,7 @@ components:
       exports_render_markdown_output: "apps/mcp_server/schemas/tools/exports_render_markdown.output.schema.json"
     toolpacks_dir: "apps/mcp_server/toolpacks/"
     prompts_dir: "apps/mcp_server/prompts/"
-  dependencies: [fastapi, uvicorn, pydantic, jsonschema, jinja2, httpx]
+  dependencies: [fastapi, uvicorn, pydantic, jsonschema, jinja2, httpx, packaging]
   observability:
     logs: [trace_id, transport, tool, version, duration_ms, io_bytes, status, error_code]
     metrics: [mcp_requests_total, mcp_request_duration_seconds_bucket, mcp_errors_total, mcp_io_bytes_total]
@@ -290,7 +290,7 @@ components:
   data_contracts:
     execution_stdin_example: { json: { input: { any: "object" } } }
     execution_stdout_example: { json: { any: "tool_data" } }
-  dependencies: [jinja2, httpx]
+  dependencies: [jinja2, httpx, packaging]
   observability:
     logs: [exec_kind, argv_or_module, exit_code, duration_ms, out_bytes]
   metrics: [toolpack_exec_total, toolpack_timeout_total, toolpack_bytes_out_total]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,24 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+
+[project]
+name = "ragx"
+dynamic = ["version"]
+dependencies = [
+    "jinja2",
+    "jsonschema",
+    "numpy",
+    "packaging",
+    "pyyaml",
+]
+
+[project.optional-dependencies]
+dev = [
+    "mypy",
+    "pybind11",
+    "pytest",
+    "pytest-cov",
+    "ruff",
+    "yamllint",
+]

--- a/ragcore/backends/cpp/__init__.py
+++ b/ragcore/backends/cpp/__init__.py
@@ -65,7 +65,11 @@ else:
         CppFaissBackend = _ExtensionFaissBackend
         CppHandle = _CppHandle
         _HAS_EXTENSION = True
-    except ModuleNotFoundError as exc:  # pragma: no cover - optional extension
+    except Exception as exc:  # pragma: no cover - optional extension
+        # Catch any import-time failure so the Python shim remains importable even
+        # if the compiled extension exists but cannot be loaded (e.g., ABI
+        # mismatch or missing shared libraries). The recorded error is exposed
+        # via the fallback backend's capabilities() for observability.
         _IMPORT_ERROR = exc
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ jinja2
 jsonschema
 numpy
 pyyaml
+packaging
 pytest
 pytest-cov
 numpy

--- a/scripts/codex_next_tasks.py
+++ b/scripts/codex_next_tasks.py
@@ -47,7 +47,7 @@ def _coerce_title(raw: object, fallback: str) -> str:
 
 
 def _coerce_component_ids(raw: object) -> tuple[str, ...]:
-    if isinstance(raw, Iterable) and not isinstance(raw, (str, bytes)):
+    if isinstance(raw, Iterable) and not isinstance(raw, str | bytes):
         return tuple(str(item) for item in raw)
     return ()
 

--- a/tests/unit/test_cpp_stub_import.py
+++ b/tests/unit/test_cpp_stub_import.py
@@ -43,6 +43,25 @@ def test_cpp_backend_import_falls_back_when_extension_missing(
         backend.build({})
 
 
+def test_cpp_backend_import_falls_back_when_extension_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_extension = types.ModuleType("_ragcore_cpp")
+    fake_extension.CppHandle = object
+
+    module = _import_cpp_module(monkeypatch, fake_extension=fake_extension)
+
+    assert module.HAS_CPP_EXTENSION is False
+
+    backend = module.CppBackend()
+    info = backend.capabilities()
+    assert info["available"] is False
+    assert "CppBackend" in info["reason"]
+
+    with pytest.raises(RuntimeError):
+        backend.build({})
+
+
 def test_cpp_backend_uses_extension_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_extension = types.ModuleType("_ragcore_cpp")
 


### PR DESCRIPTION
## Summary
- expose the pybind11 cmake directory through a step output so the configure job receives the resolved path
- tolerate native extension import failures in the C++ backend shim and add regression coverage for the fallback path
- declare the new packaging dependency across requirements, project metadata, and the spec to keep fresh installs working
- update the Codex next-task helper to satisfy Ruff's modern isinstance guidance and keep the harness lint-clean

## Testing
- `ruff check .`
- `mypy .`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68db75320208832c9294e7ea4ed2ad80