### PR TITLE
Fix PyFlat cloning kwargs and toolpack schema refs

### DIFF
--- a/apps/toolpacks/loader.py
+++ b/apps/toolpacks/loader.py
@@ -226,7 +226,7 @@ def _resolve_schema(
             f"Toolpack {tool_id} schema definition must be a mapping"
         )
 
-    resolved = _resolve_refs(schema_spec, base_dir, cache, tool_id)
+    resolved = _resolve_refs(schema_spec, base_dir, cache, tool_id, current_file=None)
     _validate_json_schema(resolved, tool_id)
     return resolved
 
@@ -236,6 +236,8 @@ def _resolve_refs(
     base_dir: Path,
     cache: dict[tuple[Path, str], Any],
     tool_id: str,
+    *,
+    current_file: Path | None,
 ) -> Any:
     if isinstance(node, Mapping):
         if set(node.keys()) == {"$ref"}:
@@ -244,13 +246,22 @@ def _resolve_refs(
                 raise ToolpackValidationError(
                     f"Toolpack {tool_id} schema $ref must be a non-empty string"
                 )
-            return _load_ref(ref, base_dir, cache, tool_id)
+            return _load_ref(ref, base_dir, cache, tool_id, current_file=current_file)
         return {
-            key: _resolve_refs(value, base_dir, cache, tool_id)
+            key: _resolve_refs(
+                value,
+                base_dir,
+                cache,
+                tool_id,
+                current_file=current_file,
+            )
             for key, value in node.items()
         }
     if isinstance(node, list):
-        return [_resolve_refs(item, base_dir, cache, tool_id) for item in node]
+        return [
+            _resolve_refs(item, base_dir, cache, tool_id, current_file=current_file)
+            for item in node
+        ]
     return node
 
 
@@ -259,11 +270,20 @@ def _load_ref(
     base_dir: Path,
     cache: dict[tuple[Path, str], Any],
     tool_id: str,
+    *,
+    current_file: Path | None,
 ) -> Any:
     path_part, fragment = _split_reference(reference)
-    target_path = Path(path_part) if path_part else Path()
-    if not target_path.is_absolute():
-        target_path = (base_dir / target_path).resolve()
+    if path_part:
+        target_path = Path(path_part)
+        if not target_path.is_absolute():
+            target_path = (base_dir / target_path).resolve()
+    else:
+        if current_file is None:
+            raise ToolpackValidationError(
+                f"Toolpack {tool_id} schema reference {reference!r} cannot be resolved without a base file"
+            )
+        target_path = current_file.resolve()
 
     cache_key = (target_path, fragment or "")
     if cache_key in cache:
@@ -296,7 +316,13 @@ def _load_ref(
         ) from exc
 
     fragment_data = _apply_json_pointer(document, fragment) if fragment else document
-    resolved = _resolve_refs(fragment_data, target_path.parent, cache, tool_id)
+    resolved = _resolve_refs(
+        fragment_data,
+        target_path.parent,
+        cache,
+        tool_id,
+        current_file=target_path,
+    )
     cache[cache_key] = copy.deepcopy(resolved)
     return copy.deepcopy(resolved)
 

--- a/ragcore/backends/pyflat/__init__.py
+++ b/ragcore/backends/pyflat/__init__.py
@@ -40,19 +40,22 @@ class PyFlatHandle(VectorIndexHandle):
     def __init__(
         self,
         spec: IndexSpec,
-        *,
-        requires_training: bool | None = None,
-        supports_gpu: bool | None = None,
+        **kwargs: Any,
     ) -> None:
+        requires_training = kwargs.pop("requires_training", False)
+        supports_gpu = kwargs.pop("supports_gpu", False)
         super().__init__(
             spec,
-            requires_training=False if requires_training is None else requires_training,
-            supports_gpu=False if supports_gpu is None else supports_gpu,
+            requires_training=requires_training,
+            supports_gpu=supports_gpu,
         )
         self._factory_kwargs = {
             "requires_training": self._requires_training,
             "supports_gpu": self._supports_gpu,
         }
+        if kwargs:
+            # Preserve any additional subclass kwargs for future clones.
+            self._factory_kwargs.update(kwargs)
 
 
 __all__ = ["PyFlatBackend", "PyFlatHandle"]

--- a/tests/unit/test_spec_structure.py
+++ b/tests/unit/test_spec_structure.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -17,3 +18,73 @@ def test_spec_has_components_and_tool_registry() -> None:
     ids = {c.get("id") for c in spec["components"]}
     for required in ["dsl", "mcp_server", "vector_db_core"]:
         assert required in ids, f"Missing component '{required}' in spec"
+
+
+def test_spec_documents_toolpack_class_location() -> None:
+    spec_path = Path("codex/specs/ragx_master_spec.yaml")
+    with spec_path.open() as handle:
+        try:
+            spec = yaml.safe_load(handle)
+        except yaml.YAMLError as exc:
+            pytest.xfail(f"Master spec not yet valid YAML: {exc}")
+
+    components_raw = spec.get("components", [])
+    assert isinstance(components_raw, list), "Spec components must be a list"
+
+    components: dict[str, Mapping[str, object]] = {}
+    for entry in components_raw:
+        if isinstance(entry, Mapping) and isinstance(entry.get("id"), str):
+            components[entry["id"]] = entry
+
+    search_paths = [
+        ("mcp_server", ("interfaces", "classes")),
+        ("toolpacks_runtime", ("interfaces", "classes")),
+        ("toolpacks_runtime", ("classes",)),
+    ]
+    inspected: list[str] = []
+    toolpack_spec: Mapping[str, object] | None = None
+
+    for component_id, path in search_paths:
+        component = components.get(component_id)
+        if not isinstance(component, Mapping):
+            inspected.append(f"{component_id}:missing")
+            continue
+        current: object = component
+        traversed: list[str] = [component_id]
+        for key in path:
+            traversed.append(key)
+            if not isinstance(current, Mapping) or key not in current:
+                current = None
+                break
+            current = current[key]
+        if not isinstance(current, list):
+            inspected.append("->".join(traversed))
+            continue
+        for candidate in current:
+            if isinstance(candidate, Mapping) and candidate.get("name") == "Toolpack":
+                toolpack_spec = candidate
+                break
+        if toolpack_spec is not None:
+            break
+        inspected.append("->".join(traversed))
+
+    if toolpack_spec is None:
+        detail = "; ".join(inspected) if inspected else "no components examined"
+        pytest.fail(f"Toolpack class spec not found; searched: {detail}")
+
+    fields = toolpack_spec.get("fields") if isinstance(toolpack_spec, Mapping) else None
+    assert isinstance(fields, list), "Toolpack spec must list fields"
+    expected = {
+        "id",
+        "version",
+        "deterministic",
+        "timeoutMs",
+        "limits",
+        "caps",
+        "inputSchema",
+        "outputSchema",
+        "execution",
+        "env",
+        "templating",
+    }
+    assert expected.issubset(set(fields)), "Toolpack spec missing required fields"


### PR DESCRIPTION
## Summary
- allow `PyFlatHandle` to accept capability kwargs during cloning
- resolve fragment-only toolpack schema references against the current schema file
- update spec regression tests to tolerate Toolpack class moving between components

## Testing
- `pytest tests/unit/test_python_flat_index.py tests/unit/test_toolpacks_loader.py::test_toolpack_loader_schema_fragment_only_reference tests/unit/test_spec_structure.py`


------
https://chatgpt.com/codex/tasks/task_e_68db78bc1044832c9ba7cbd01a248c13