### PR TITLE
Fix doc slug lookup, PyFlat cloning, and FlowScript decisions

### DIFF
--- a/codex/specs/ragx_master_spec.yaml
+++ b/codex/specs/ragx_master_spec.yaml
@@ -812,6 +812,7 @@ tests:
   ci:
     coverage_minimum: 85
 
+flowscript_decisions:
   - id: flowscript_parser_engine
     question: Which runtime parses FlowScript in P1?
     options: [peggy_node_subprocess, lark_python_inproc, tree_sitter_subprocess]

--- a/ragcore/backends/pyflat/__init__.py
+++ b/ragcore/backends/pyflat/__init__.py
@@ -37,26 +37,18 @@ class PyFlatBackend:
 
 
 class PyFlatHandle(VectorIndexHandle):
-    def __init__(
-        self,
-        spec: IndexSpec,
-        *,
-        requires_training: bool | None = None,
-        supports_gpu: bool | None = None,
-        **extra: Any,
-    ) -> None:
-        resolved_requires = False if requires_training is None else requires_training
-        resolved_gpu = False if supports_gpu is None else supports_gpu
+    def __init__(self, spec: IndexSpec, **kwargs: Any) -> None:
+        raw_requires = kwargs.pop("requires_training", None)
+        raw_gpu = kwargs.pop("supports_gpu", None)
+        resolved_requires = False if raw_requires is None else bool(raw_requires)
+        resolved_gpu = False if raw_gpu is None else bool(raw_gpu)
         super().__init__(
             spec,
             requires_training=resolved_requires,
             supports_gpu=resolved_gpu,
         )
-        extras = dict(extra)
-        extras.pop("requires_training", None)
-        extras.pop("supports_gpu", None)
         self._factory_kwargs = {
-            **extras,
+            **kwargs,
             "requires_training": self._requires_training,
             "supports_gpu": self._supports_gpu,
         }

--- a/tests/unit/test_python_flat_index.py
+++ b/tests/unit/test_python_flat_index.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy", reason="PyFlat backend requires numpy")
 
 from ragcore.backends.pyflat import PyFlatBackend
 
@@ -84,6 +85,10 @@ def test_pyflat_clone_handles_gpu_and_merge() -> None:
     assert gpu_clone.ntotal() == handle.ntotal()
     assert gpu_clone.requires_training() is False
     assert gpu_clone.is_gpu is False
+    assert gpu_clone.spec()["backend"] == "py_flat"
+
+    double_clone = gpu_clone.to_gpu()
+    assert double_clone.ntotal() == gpu_clone.ntotal()
 
     other = backend.build(spec)
     other.add(np.array([[1.0, 0.0]], dtype=np.float32))
@@ -93,3 +98,6 @@ def test_pyflat_clone_handles_gpu_and_merge() -> None:
     assert merged.ntotal() == handle.ntotal() + other.ntotal()
     serialized = merged.serialize_cpu()
     assert serialized.ids.shape[0] == merged.ntotal()
+
+    merged_gpu = merged.to_gpu()
+    assert merged_gpu.ntotal() == merged.ntotal()

--- a/tests/unit/test_spec_structure.py
+++ b/tests/unit/test_spec_structure.py
@@ -1,16 +1,24 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest
 import yaml
 
 
-def test_spec_has_components_and_tool_registry() -> None:
+def _load_master_spec() -> dict[str, object]:
     spec_path = Path("codex/specs/ragx_master_spec.yaml")
-    with spec_path.open() as f:
+    with spec_path.open(encoding="utf-8") as handle:
         try:
-            spec = yaml.safe_load(f)
-        except yaml.YAMLError as exc:
+            data = yaml.safe_load(handle)
+        except yaml.YAMLError as exc:  # pragma: no cover - fails until spec valid
             pytest.xfail(f"Master spec not yet valid YAML: {exc}")
+    assert isinstance(data, dict), "master spec must deserialize into a mapping"
+    return data
+
+
+def test_spec_has_components_and_tool_registry() -> None:
+    spec = _load_master_spec()
     assert "components" in spec and isinstance(spec["components"], list)
     assert "tool_registry" in spec and isinstance(spec["tool_registry"], dict)
     # ensure key components exist by id
@@ -20,13 +28,7 @@ def test_spec_has_components_and_tool_registry() -> None:
 
 
 def test_spec_defines_toolpack_class_location() -> None:
-    spec_path = Path("codex/specs/ragx_master_spec.yaml")
-    with spec_path.open() as f:
-        try:
-            spec = yaml.safe_load(f)
-        except yaml.YAMLError as exc:
-            pytest.xfail(f"Master spec not yet valid YAML: {exc}")
-
+    spec = _load_master_spec()
     components = spec.get("components")
     assert isinstance(components, list), "spec.components must be a list"
 
@@ -65,3 +67,38 @@ def test_spec_defines_toolpack_class_location() -> None:
 
     assert toolpack_entry.get("name") == "Toolpack"
     assert toolpack_entry.get("fields"), f"Toolpack spec under {component_id} missing fields"
+
+
+def test_spec_tests_and_flowscript_decisions_structure() -> None:
+    spec = _load_master_spec()
+
+    tests_block = spec.get("tests")
+    assert isinstance(tests_block, dict), "spec.tests must be a mapping"
+    for key in ("unit", "e2e", "ci"):
+        assert key in tests_block, f"spec.tests missing '{key}' section"
+
+    decisions = spec.get("flowscript_decisions")
+    assert isinstance(decisions, list), "spec.flowscript_decisions must be a list"
+    assert all(isinstance(entry, dict) for entry in decisions)
+    assert all("id" in entry for entry in decisions), "each FlowScript decision must have an id"
+
+
+def test_minimal_flowscript_decision_yaml_loads(tmp_path: Path) -> None:
+    snippet = (
+        "tests:\n"
+        "  unit:\n"
+        "    - sample_test\n"
+        "  ci:\n"
+        "    coverage_minimum: 80\n"
+        "flowscript_decisions:\n"
+        "  - id: sample_decision\n"
+        "    question: Example?\n"
+        "    options: [a, b]\n"
+        "    default: a\n"
+    )
+    path = tmp_path / "spec.yaml"
+    path.write_text(snippet, encoding="utf-8")
+
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["tests"]["unit"] == ["sample_test"]
+    assert loaded["flowscript_decisions"][0]["id"] == "sample_decision"


### PR DESCRIPTION
## Summary
- allow ingestion e2e fixture to resolve doc IDs emitted with slug underscores and assert front-matter IDs survive
- relax PyFlatHandle cloning constructor and extend unit coverage for repeated GPU/merge clones
- move FlowScript decisions under a dedicated top-level key and add structure validation tests

## Testing
- pytest tests/e2e/test_vectordb_build_md_fixture.py tests/unit/test_python_flat_index.py tests/unit/test_spec_structure.py

------
https://chatgpt.com/codex/tasks/task_e_68db7e0d1204832cb8adc067c324966c