### PR TITLE
Add detailed spec and validation tests for core tools minimal task

### DIFF
--- a/codex/agents/TASKS/06a_core_tools_minimal_subset.yaml
+++ b/codex/agents/TASKS/06a_core_tools_minimal_subset.yaml
@@ -1,14 +1,148 @@
+version: 1
 id: 06a_core_tools_minimal_subset
-title: Core tools minimal subset over Python toolpacks
+title: Core MCP tools minimal subset (Python toolpacks + observability)
+component_ids: [core_tools, toolpacks_runtime, mcp_server, observability_ci]
+depends_on: [05b_toolpacks_executor_python_only, 05c_toolpacks_loader_spec_alignment, 05h_toolpacks_loader_metadata_validation]
 description: >
-  Implement minimal Python toolpacks for exports.render.markdown,
-  vector.query.search (dummy), docs.load.fetch (local).
-
+  Implement the minimal canonical MCP tool set backed by Python toolpacks while
+  adhering to ragx_master_spec component contracts. This task covers
+  JSON Schema authoring, deterministic stub implementations, MCP server wiring,
+  structured observability, and regression-safe log diffing.
+preconditions:
+  - "codex/specs/ragx_master_spec.yaml defines components.core_tools and components.mcp_server.schemas.tools"
+  - "Toolpack loader + executor suite from tasks 05a-05h is green (pytest -k 'toolpacks')"
+  - "deepdiff dependency is available in the development environment"
+artifacts:
+  structured_logs:
+    path: runs/core_tools/minimal.jsonl
+    format: jsonl
+    schema:
+      description: Structured runtime log for minimal core tools execution.
+      required_fields:
+        - ts
+        - agentId
+        - taskId
+        - stepId
+        - event
+        - level
+        - tool
+        - status
+        - retries
+        - durationMs
+        - metadata
+      metadata_fields:
+        - requestId
+        - runId
+        - mcpTransport
+        - toolpackId
+  log_diff:
+    baseline_path: tests/fixtures/mcp/core_tools/minimal_golden.jsonl
+    tool: deepdiff.DeepDiff
+    whitelist_fields:
+      - ts
+      - durationMs
+      - requestId
+      - runId
+      - pid
+    description: >
+      Compare structured logs against the golden baseline while ignoring
+      nondeterministic identifiers.
+deliverables:
+  - path: apps/mcp_server/schemas/tools/exports_render_markdown.input.schema.json
+    description: JSON Schema for exports.render.markdown input aligned with spec.
+  - path: apps/mcp_server/schemas/tools/exports_render_markdown.output.schema.json
+    description: JSON Schema for exports.render.markdown output aligned with spec.
+  - path: apps/mcp_server/schemas/tools/vector_query_search.input.schema.json
+    description: JSON Schema for vector.query.search input (minimal stub fields).
+  - path: apps/mcp_server/schemas/tools/vector_query_search.output.schema.json
+    description: JSON Schema for vector.query.search output (deterministic stub response).
+  - path: apps/mcp_server/schemas/tools/docs_load_fetch.input.schema.json
+    description: JSON Schema for docs.load.fetch input enforcing safe path params.
+  - path: apps/mcp_server/schemas/tools/docs_load_fetch.output.schema.json
+    description: JSON Schema for docs.load.fetch output including content + metadata.
+  - path: apps/mcp_server/toolpacks/core/exports.render.markdown.tool.yaml
+    description: Python toolpack manifest referencing exports.render.markdown schema + module.
+  - path: apps/mcp_server/toolpacks/core/vector.query.search.tool.yaml
+    description: Python toolpack manifest referencing vector.query.search schema + module.
+  - path: apps/mcp_server/toolpacks/core/docs.load.fetch.tool.yaml
+    description: Python toolpack manifest referencing docs.load.fetch schema + module.
+  - path: apps/toolpacks/python/core/exports/render_markdown.py
+    description: Deterministic Markdown renderer (front-matter aware) used by toolpack.
+  - path: apps/toolpacks/python/core/vector/query_search.py
+    description: Deterministic stub returning predictable vector hits for testing.
+  - path: apps/toolpacks/python/core/docs/load_fetch.py
+    description: Local filesystem loader with sandboxed root + retries on missing files.
+  - path: docs/core_tools/minimal.md
+    description: Developer documentation for minimal core tools + logging workflow.
+  - path: scripts/diff_core_tool_logs.py
+    description: CLI helper to run minimal suite and diff logs vs golden baseline.
+actions:
+  - stage: tests
+    summary: Write failing tests for schemas, execution, logging, and diffing before implementation.
+    tests:
+      unit:
+        - path: tests/unit/test_core_tools_schemas.py
+          description: >
+            Expand coverage to load the new schema files, call jsonschema.Draft202012Validator.check_schema,
+            and ensure schema $id values mirror ragx_master_spec paths.
+          assertions:
+            - Schema file exists for each components.mcp_server.schemas.tools reference in the master spec.
+            - Required properties enforce provider, query/path, and metadata fields per spec.
+        - path: tests/unit/test_core_tools_logging_minimal.py
+          description: >
+            Validate structured logging hooks emit JSON objects with required metadata, retries, and
+            status transitions. Use a fake sink/fixture to assert deterministic ordering.
+          assertions:
+            - Every log entry validates against artifacts.structured_logs.schema.
+            - Retry/failure branches emit dedicated events with incrementing stepId and retry counts.
+            - Missing logs raise descriptive AssertionError (fail loud).
+        - path: tests/unit/test_core_tools_log_diff.py
+          description: >
+            Deep-diff runtime logs against the golden fixture using deepdiff with whitelist filtering.
+            Provide helper to update the golden via --update-golden flag.
+          assertions:
+            - Non-whitelisted differences fail with diff context and pointer path.
+            - Whitelisted fields (timestamps, runId, pid) are ignored via whitelist list.
+      e2e:
+        - path: tests/e2e/test_mcp_minimal_core_tools.py
+          description: >
+            Boot the MCP server (inproc or stdio) with minimal toolpacks, invoke each tool, and ensure
+            fallbacks/retries/logs occur as specified. Capture emitted logs for diffing fixture.
+          assertions:
+            - docs.load.fetch reads tests/fixtures/mcp/core_tools/docs/example.md and retries once on missing file.
+            - vector.query.search returns deterministic hits referencing tests fixtures with stable scoring.
+            - exports.render.markdown renders Markdown with title/front-matter + code fence normalization.
+      fixtures:
+        - path: tests/fixtures/mcp/core_tools/minimal_golden.jsonl
+          description: Golden structured log sanitized for deterministic diffing.
+        - path: tests/fixtures/mcp/core_tools/docs/example.md
+          description: Local Markdown fixture with YAML front-matter for docs.load.fetch.
+  - stage: implementation
+    summary: Implement schemas, toolpacks, and Python modules per spec.
+    steps:
+      - Generate JSON Schemas exactly matching ragx_master_spec components.mcp_server.schemas.tools definitions.
+      - Implement Python modules under apps/toolpacks/python/core/* with deterministic behavior and structured logging hooks.
+      - Author toolpack YAML manifests referencing schemas + modules with deterministic flag true and timeout metadata.
+  - stage: integration
+    summary: Wire toolpacks into MCP server registry and executor.
+    steps:
+      - Extend MCP bootstrap to load apps/mcp_server/toolpacks/core directory and register schema URIs.
+      - Ensure McpService.invoke_tool routes through Toolpacks Executor with retries + fallback handling.
+      - Persist structured logs (artifacts.structured_logs.path) during invocation including success/failure events.
+  - stage: observability
+    summary: Provide logging sinks and automated diff tooling.
+    steps:
+      - Implement JSON logger utility writing newline-delimited objects with timestamp + metadata.
+      - Capture logs during e2e run and compare against golden via deepdiff.DeepDiff with whitelist.
+      - Add scripts/diff_core_tool_logs.py to run e2e test, update golden when --update-golden flag set, and print diff summary.
+  - stage: docs
+    summary: Document minimal core tools, schemas, and log diff workflow.
+    steps:
+      - Write docs/core_tools/minimal.md describing tool responsibilities, schema paths, logging fields, and diff whitelist.
+      - Cross-link to ragx_master_spec components.core_tools and observability sections.
 acceptance:
-  - tests/unit/test_core_tools_schemas.py pass
-  - tests/e2e/test_mcp_minimal_core_tools.py pass
-
-steps:
-  - Provide schema files under apps/mcp_server/schemas/tools/.
-  - Implement dummy Python toolpacks.
-  - Wire MCP server to load/serve these.
+  - "pytest tests/unit/test_core_tools_schemas.py tests/unit/test_core_tools_logging_minimal.py tests/unit/test_core_tools_log_diff.py tests/e2e/test_mcp_minimal_core_tools.py"
+  - "Structured log file runs/core_tools/minimal.jsonl exists with >= 3 tool invocation events and passes schema validation."
+  - "scripts/diff_core_tool_logs.py --check (deepdiff) reports no unexpected differences (only whitelist fields allowed)."
+  - "docs/core_tools/minimal.md documents schemas, logging requirements, diff workflow, and fallback semantics."
+  - "Toolpacks loader/executor + MCP server suites remain green (scripts/ensure_green.sh)."

--- a/tests/unit/test_task_spec_06a.py
+++ b/tests/unit/test_task_spec_06a.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+TASK_PATH = Path("codex/agents/TASKS/06a_core_tools_minimal_subset.yaml")
+
+
+def _load_task() -> dict[str, Any]:
+    assert TASK_PATH.exists(), "Task definition for 06a must exist"
+    with TASK_PATH.open(encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    assert isinstance(data, dict), "Task file must deserialize to a mapping"
+    return data
+
+
+def test_metadata_and_dependencies() -> None:
+    task = _load_task()
+    assert task.get("version") == 1, "Task version should be explicitly set to 1"
+    assert task.get("id") == "06a_core_tools_minimal_subset"
+
+    components = task.get("component_ids")
+    assert isinstance(components, list), "component_ids must be a list"
+    expected_components = {"core_tools", "toolpacks_runtime", "mcp_server", "observability_ci"}
+    assert expected_components.issubset(set(components)), "Task must list all relevant components"
+
+    depends_on = task.get("depends_on")
+    assert isinstance(depends_on, list) and depends_on, "depends_on must enumerate prerequisites"
+    for required in [
+        "05b_toolpacks_executor_python_only",
+        "05c_toolpacks_loader_spec_alignment",
+        "05h_toolpacks_loader_metadata_validation",
+    ]:
+        assert required in depends_on, f"Missing dependency {required}"
+
+    actions = task.get("actions")
+    assert isinstance(actions, list) and actions, "actions must be a non-empty list"
+    first_stage = actions[0]
+    assert first_stage.get("stage") == "tests", "First stage must enforce tests-first development"
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["ts", "agentId", "taskId", "stepId", "event", "status", "retries", "durationMs", "metadata"],
+)
+def test_structured_logging_artifacts_define_required_fields(field: str) -> None:
+    task = _load_task()
+    artifacts = task.get("artifacts")
+    assert isinstance(artifacts, dict) and "structured_logs" in artifacts
+
+    logs = artifacts["structured_logs"]
+    assert logs.get("format") == "jsonl"
+    schema = logs.get("schema")
+    assert isinstance(schema, dict) and "required_fields" in schema
+    required_fields = schema["required_fields"]
+    assert isinstance(required_fields, list)
+    assert field in required_fields, f"Structured logs must require '{field}'"
+
+    metadata_fields = schema.get("metadata_fields")
+    assert isinstance(metadata_fields, list), "metadata_fields must be enumerated"
+    for meta_key in ["requestId", "runId", "mcpTransport", "toolpackId"]:
+        assert meta_key in metadata_fields, f"metadata_fields missing {meta_key}"
+
+    log_diff = artifacts.get("log_diff")
+    assert isinstance(log_diff, dict), "log_diff configuration must exist"
+    assert str(log_diff.get("tool", "")).startswith("deepdiff"), "Log diff tool must leverage deepdiff"
+    whitelist = log_diff.get("whitelist_fields")
+    assert isinstance(whitelist, list) and whitelist, "whitelist_fields must be configured"
+    for allowed in ["ts", "durationMs", "requestId", "runId", "pid"]:
+        assert allowed in whitelist, f"Whitelist must contain nondeterministic field '{allowed}'"
+    baseline = log_diff.get("baseline_path")
+    assert isinstance(baseline, str) and baseline.endswith("minimal_golden.jsonl"), "Baseline path must target golden logs"
+
+
+def test_tests_stage_outlines_unit_e2e_and_fixtures() -> None:
+    task = _load_task()
+    actions = task["actions"]
+    tests_stage = next((entry for entry in actions if entry.get("stage") == "tests"), None)
+    assert tests_stage, "Tests stage must be defined"
+
+    tests_section = tests_stage.get("tests")
+    assert isinstance(tests_section, dict), "tests_stage.tests must be a mapping"
+
+    unit_tests = tests_section.get("unit")
+    assert isinstance(unit_tests, list) and unit_tests, "unit tests must be listed"
+    unit_paths = {item.get("path") for item in unit_tests}
+    assert {
+        "tests/unit/test_core_tools_schemas.py",
+        "tests/unit/test_core_tools_logging_minimal.py",
+        "tests/unit/test_core_tools_log_diff.py",
+    }.issubset(unit_paths), "Unit tests must cover schemas, logging, and log diff"
+
+    e2e_tests = tests_section.get("e2e")
+    assert isinstance(e2e_tests, list) and e2e_tests, "e2e tests must be listed"
+    e2e_paths = {item.get("path") for item in e2e_tests}
+    assert "tests/e2e/test_mcp_minimal_core_tools.py" in e2e_paths, "E2E test path missing"
+
+    fixtures = tests_section.get("fixtures")
+    assert isinstance(fixtures, list) and fixtures, "fixtures must be enumerated"
+    fixture_paths = {item.get("path") for item in fixtures}
+    assert {
+        "tests/fixtures/mcp/core_tools/minimal_golden.jsonl",
+        "tests/fixtures/mcp/core_tools/docs/example.md",
+    }.issubset(fixture_paths), "Fixture files must include golden log and markdown fixture"
+
+    logging_test = next((item for item in unit_tests if "logging" in item.get("path", "")), None)
+    assert logging_test and "structured" in logging_test.get("description", "").lower()
+    diff_test = next((item for item in unit_tests if "log_diff" in item.get("path", "")), None)
+    assert diff_test and "deepdiff" in diff_test.get("description", "").lower()
+
+
+def test_acceptance_and_actions_cover_observability() -> None:
+    task = _load_task()
+    acceptance = task.get("acceptance")
+    assert isinstance(acceptance, list) and acceptance, "acceptance criteria must be listed"
+    assert any("deepdiff" in item for item in acceptance), "Acceptance must require deepdiff diff check"
+    assert any("runs/core_tools/minimal.jsonl" in item for item in acceptance), "Acceptance must reference structured logs"
+    assert any("scripts/diff_core_tool_logs.py" in item for item in acceptance), "Acceptance must mention diff script"
+
+    observability_stage = next((entry for entry in task.get("actions", []) if entry.get("stage") == "observability"), None)
+    assert observability_stage is not None, "Observability stage must be explicitly defined"
+    summary = observability_stage.get("summary", "").lower()
+    assert "logging" in summary and "diff" in summary, "Observability summary must mention logging and diff"
+
+    text = TASK_PATH.read_text(encoding="utf-8")
+    for snippet in [
+        "apps/mcp_server/schemas/tools/",
+        "tests/fixtures/mcp/core_tools/minimal_golden.jsonl",
+        "deepdiff.DeepDiff",
+    ]:
+        assert snippet in text, f"Task spec must mention '{snippet}'"


### PR DESCRIPTION
## Summary
- expand the 06a core tools task definition with component dependencies, logging deliverables, and explicit observability requirements
- add a unit test that validates the YAML spec structure, required artifacts, and acceptance criteria for the task

## Testing
- pytest tests/unit/test_task_spec_06a.py


------
https://chatgpt.com/codex/tasks/task_e_68dba12cf0e0832cb8b28448d443c392