### PR TITLE
Define 06a core tools minimal subset task contract

### DIFF
--- a/codex/agents/TASKS/06a_core_tools_minimal_subset.yaml
+++ b/codex/agents/TASKS/06a_core_tools_minimal_subset.yaml
@@ -1,14 +1,137 @@
 id: 06a_core_tools_minimal_subset
 title: Core tools minimal subset over Python toolpacks
-description: >
-  Implement minimal Python toolpacks for exports.render.markdown,
-  vector.query.search (dummy), docs.load.fetch (local).
-
+owner: codex
+priority: P0
+phase: P0
+depends_on:
+  - 05a_toolpacks_loader_minimal
+  - 05b_toolpacks_executor_python_only
+  - 05c_toolpacks_loader_spec_alignment
+  - 05d_toolpacks_executor_python_only_plus
+  - 05h_toolpacks_loader_metadata_validation
+spec_refs:
+  components:
+    - core_tools
+    - toolpacks_runtime
+    - mcp_server
+  arg_spec:
+    - mcp_server
+    - task_runner
+summary: >
+  Bootstrap the MCP core tool surface with deterministic Python toolpacks for
+  docs.load.fetch, vector.query.search, and exports.render.markdown while
+  capturing structured JSON logs for every decision and tool invocation.
+motivation: >
+  The runner, planner, and downstream components depend on a minimal core tool
+  contract to unblock early flows and enable observability work (components:
+  core_tools, mcp_server). This task supplies contract-compliant schemas,
+  toolpacks, and logging so later tasks can extend coverage without reworking
+  foundations.
+scope:
+  must_include:
+    - JSON Schemas for docs.load.fetch, vector.query.search, exports.render.markdown
+      inputs/outputs under apps/mcp_server/schemas/tools/.
+    - Python toolpacks implementing deterministic stub behaviors using recorded
+      fixtures only (no external network calls).
+    - Wiring inside the MCP server loader so the minimal tool set is auto-loaded
+      and surfaced over STDIO/HTTP.
+    - Structured JSON logging emitted for every agent decision, tool invocation,
+      retry, and failure with timestamps, agent_id, task_id, and step_id fields.
+    - Golden log capture + diffing harness guarding regressions in the structured
+      log stream.
+  must_not:
+    - Ship non-deterministic integrations (live web search, remote APIs).
+    - Introduce new CLI flags beyond ragx_master_spec.yaml.
+    - Skip JSON schema validation or rely on unchecked dicts.
+non_goals:
+  - Implementing the citations.audit.check or web.search.query tools.
+  - Integrating vector backends beyond the dummy search stub.
+  - Shipping production-ready markdown rendering (basic deterministic renderer
+    only).
+deliverables:
+  code:
+    - apps/mcp_server/toolpacks/docs.load.fetch.tool.yaml
+    - apps/mcp_server/toolpacks/vector.query.search.tool.yaml
+    - apps/mcp_server/toolpacks/exports.render.markdown.tool.yaml
+    - apps/mcp_server/schemas/tools/*.schema.json
+    - apps/mcp_server/runtime/core_tools_minimal.py
+  tests:
+    - tests/unit/test_core_tools_minimal_subset_schemas.py
+    - tests/unit/test_core_tools_structured_logging.py
+    - tests/integration/test_core_tools_log_diff.py
+    - tests/e2e/test_mcp_minimal_core_tools.py
+  docs:
+    - docs/toolpacks/core_tools_minimal.md
+  logs:
+    - runs/golden/core_tools_minimal.jsonl
 acceptance:
-  - tests/unit/test_core_tools_schemas.py pass
-  - tests/e2e/test_mcp_minimal_core_tools.py pass
-
-steps:
-  - Provide schema files under apps/mcp_server/schemas/tools/.
-  - Implement dummy Python toolpacks.
-  - Wire MCP server to load/serve these.
+  - tests/unit/test_core_tools_minimal_subset_schemas.py
+  - tests/unit/test_core_tools_structured_logging.py
+  - tests/integration/test_core_tools_log_diff.py
+  - tests/e2e/test_mcp_minimal_core_tools.py
+  - ./scripts/ensure_green.sh
+observability_requirements:
+  - Structured JSON logs MUST include timestamp, agent_id, task_id, and step_id
+    for every event and persist to runs/{run_id}/core_tools_minimal.jsonl.
+  - Each log entry MUST capture tool_id, decision, retries, failure reasons, and
+    completion status for diffability.
+  - Logging pipeline MUST be resilient to tool errors (no dropped events) and
+    flush on shutdown for postmortem diffing.
+structured_logging_contract:
+  format: jsonl
+  event_fields:
+    - timestamp
+    - agent_id
+    - task_id
+    - step_id
+    - event
+    - tool_id
+    - status
+    - duration_ms
+    - retries
+    - error
+  storage_path: runs/{run_id}/core_tools_minimal.jsonl
+  retention: keep-last-20
+log_diff_strategy:
+  tool: python.deepdiff
+  baseline_artifact: runs/golden/core_tools_minimal.jsonl
+  whitelist_fields:
+    - timestamp
+    - run_id
+    - trace_id
+    - duration_ms
+  notes: >
+    Use DeepDiff to compare structured logs against the golden baseline while
+    ignoring whitelisted temporal/id fields. Surface any unexpected diffs with
+    human-readable explanations in pytest output.
+test_plan:
+  - Author pytest coverage for schema validation (input/output schema checks).
+  - Add logging-focused unit tests asserting JSON structure, required fields,
+    retry/fallback coverage, and golden log regeneration workflow.
+  - Provide integration tests exercising MCP server tool execution and golden
+    log diffing, including controlled retry scenarios.
+  - Ensure fallbacks trigger deterministic logs when dummy vector search raises
+    errors.
+  - Document golden log regeneration protocol inside docs/toolpacks/core_tools_minimal.md.
+ci:
+  run:
+    - make lint
+    - make typecheck
+    - make test
+    - ./scripts/ensure_green.sh
+risks:
+  - Missing logging fields causing observability regressions.
+  - Golden fixtures drifting due to timestamps or randomized IDs.
+mitigations:
+  - Enforce schema + log diff tests that fail loudly when keys disappear.
+  - Whitelist only volatile fields (timestamp, run_id, trace_id, duration_ms) in
+    DeepDiff comparisons.
+artifacts:
+  - docs/toolpacks/core_tools_minimal.md
+  - runs/golden/core_tools_minimal.jsonl
+  - docs/diagrams/06a_core_tools_minimal_flow.md
+validation_hooks:
+  - Ensure tests/unit/test_core_tools_structured_logging.py seeds deterministic
+    UUID/time providers.
+  - Provide CLI snippet in docs for regenerating golden logs with `task-runner
+    run --trace runs/tmp.jsonl` followed by DeepDiff comparison.

--- a/tests/codex/tasks/test_task_06a_core_tools_spec.py
+++ b/tests/codex/tasks/test_task_06a_core_tools_spec.py
@@ -1,0 +1,70 @@
+import pathlib
+import yaml
+
+TASK_FILE = pathlib.Path("codex/agents/TASKS/06a_core_tools_minimal_subset.yaml")
+
+
+def load_task():
+    text = TASK_FILE.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise AssertionError("Task YAML must parse to a mapping")
+    return data
+
+
+def test_task_includes_required_metadata_keys():
+    task = load_task()
+    for key in ("id", "title", "owner", "priority", "phase", "depends_on", "spec_refs"):
+        assert key in task, f"missing required key: {key}"
+    assert task["owner"] == "codex", "owner must be codex per spec guidelines"
+    assert task["priority"] == "P0", "priority must be P0 for core tools bootstrap"
+    assert isinstance(task["depends_on"], list) and task["depends_on"], "depends_on must be non-empty list"
+
+
+def test_spec_refs_cover_core_components():
+    task = load_task()
+    spec_refs = task.get("spec_refs", {})
+    components = set(spec_refs.get("components", []))
+    expected = {"core_tools", "toolpacks_runtime", "mcp_server"}
+    missing = expected - components
+    assert not missing, f"spec_refs.components missing: {sorted(missing)}"
+    arg_refs = set(spec_refs.get("arg_spec", []))
+    assert {"mcp_server", "task_runner"}.issubset(arg_refs), "arg_spec refs must include MCP server + task runner flags"
+
+
+def test_acceptance_includes_logging_and_diff_tests():
+    task = load_task()
+    acceptance = task.get("acceptance", [])
+    required = {
+        "tests/unit/test_core_tools_minimal_subset_schemas.py",
+        "tests/unit/test_core_tools_structured_logging.py",
+        "tests/integration/test_core_tools_log_diff.py",
+        "tests/e2e/test_mcp_minimal_core_tools.py",
+        "./scripts/ensure_green.sh",
+    }
+    missing = required - set(acceptance)
+    assert not missing, f"acceptance criteria missing entries: {sorted(missing)}"
+
+
+def test_observability_requirements_call_out_json_logs():
+    task = load_task()
+    requirements = "\n".join(task.get("observability_requirements", []))
+    for token in ("json", "timestamp", "agent_id", "task_id", "step_id", "persist"):
+        assert token in requirements, f"observability requirements must mention '{token}'"
+
+
+def test_log_diff_strategy_uses_deepdiff_and_has_whitelist():
+    task = load_task()
+    strategy = task.get("log_diff_strategy", {})
+    assert strategy.get("tool") == "python.deepdiff", "log diff strategy must use python.deepdiff"
+    whitelist = strategy.get("whitelist_fields")
+    assert isinstance(whitelist, list) and whitelist, "log diff whitelist_fields must be present"
+    for field in ("timestamp", "run_id", "trace_id"):
+        assert field in whitelist, f"log diff whitelist must include {field}"
+
+
+def test_test_plan_includes_schema_logging_and_retry_checks():
+    task = load_task()
+    plan = "\n".join(task.get("test_plan", []))
+    for token in ("schema", "logging", "retry", "fallback", "golden log"):
+        assert token in plan, f"test plan must cover {token}"


### PR DESCRIPTION
## Summary
- expand the 06a core tools minimal subset task definition with dependencies, observability mandates, and deep diff guidance referencing components.core_tools, components.toolpacks_runtime, and components.mcp_server from codex/specs/ragx_master_spec.yaml
- specify deliverables, acceptance criteria, and CI requirements covering schemas, structured logging, and golden log diffs
- add a regression test that enforces the new task contract and required log/diff expectations

## Testing
- pytest tests/codex/tasks/test_task_06a_core_tools_spec.py


------
https://chatgpt.com/codex/tasks/task_e_68dba12cf0e0832cb8b28448d443c392