### PR TITLE
feat: bootstrap MCP server transports

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,3 +1,3 @@
 """Application packages for RAGX."""
 
-__all__ = ["toolpacks"]
+__all__ = ["mcp_server", "toolpacks"]

--- a/apps/mcp_server/__init__.py
+++ b/apps/mcp_server/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from apps.mcp_server.cli import main
+from apps.mcp_server.http_app import create_http_app
+from apps.mcp_server.models import Envelope
+from apps.mcp_server.service import McpService
+from apps.mcp_server.stdio import StdIoServer
+
+__all__ = [
+    "Envelope",
+    "McpService",
+    "StdIoServer",
+    "create_http_app",
+    "main",
+]

--- a/apps/mcp_server/cli.py
+++ b/apps/mcp_server/cli.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from apps.mcp_server.http_app import create_http_app
+from apps.mcp_server.service import McpService
+from apps.mcp_server.stdio import StdIoServer
+
+try:  # pragma: no cover - uvicorn optional during tests
+    import uvicorn
+except Exception:  # pragma: no cover
+    uvicorn = None  # type: ignore[assignment]
+
+__all__ = ["create_parser", "main"]
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="mcp-server")
+    parser.add_argument("--http", action="store_true", help="Run HTTP transport.")
+    parser.add_argument("--stdio", action="store_true", help="Run STDIO JSON-RPC transport.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=3333)
+    parser.add_argument("--max-connections", type=int, default=256)
+    parser.add_argument("--shutdown-grace", type=int, default=10)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = create_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    service = McpService()
+
+    ran = False
+    if args.http:
+        if uvicorn is None:  # pragma: no cover - environment guard
+            raise RuntimeError("uvicorn is required for --http")
+        app = create_http_app(service)
+        config = uvicorn.Config(
+            app,
+            host=args.host,
+            port=args.port,
+            limit_max_requests=args.max_connections,
+            timeout_graceful_shutdown=args.shutdown_grace,
+            log_config=None,
+        )
+        server = uvicorn.Server(config)
+        server.run()
+        ran = True
+
+    if args.stdio:
+        StdIoServer(service).serve_forever()
+        ran = True
+
+    if not ran:
+        parser.error("At least one transport (--http or --stdio) must be selected.")
+
+    return 0

--- a/apps/mcp_server/http_app.py
+++ b/apps/mcp_server/http_app.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+from apps.mcp_server.service import McpService
+
+__all__ = ["create_http_app"]
+
+
+def create_http_app(service: McpService) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/mcp/discover")
+    def discover() -> dict[str, Any]:
+        envelope = service.discover(transport="http")
+        return envelope.model_dump()
+
+    @app.get("/mcp/prompt/{domain}/{name}/{major}")
+    def get_prompt(domain: str, name: str, major: int) -> dict[str, Any]:
+        envelope = service.get_prompt(domain, name, major, transport="http")
+        return envelope.model_dump()
+
+    @app.post("/mcp/tool/{tool_name}")
+    def invoke_tool(tool_name: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        if payload is None:
+            raise HTTPException(status_code=400, detail="Missing JSON payload")
+        envelope = service.invoke_tool(tool_name, payload, transport="http")
+        return envelope.model_dump()
+
+    return app

--- a/apps/mcp_server/models.py
+++ b/apps/mcp_server/models.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+__all__ = ["Envelope"]
+
+
+class Envelope(BaseModel):
+    """Response envelope shared across transports."""
+
+    ok: bool
+    data: dict[str, Any] | None = None
+    meta: dict[str, Any] = Field(default_factory=dict)
+    errors: list[dict[str, Any]] = Field(default_factory=list)
+
+    @classmethod
+    def success(
+        cls,
+        *,
+        data: dict[str, Any] | None = None,
+        transport: str,
+        trace_id: str | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> "Envelope":
+        payload_meta: dict[str, Any] = {"transport": transport, "trace_id": trace_id or str(uuid4())}
+        if meta:
+            payload_meta.update(meta)
+        return cls(ok=True, data=data or {}, meta=payload_meta, errors=[])
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
+        return super().model_dump(*args, **kwargs)

--- a/apps/mcp_server/schemas/envelope.schema.json
+++ b/apps/mcp_server/schemas/envelope.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MCP Envelope",
+  "type": "object",
+  "required": ["ok", "meta", "errors"],
+  "properties": {
+    "ok": {"type": "boolean"},
+    "data": {"type": ["object", "null"]},
+    "meta": {
+      "type": "object",
+      "required": ["transport", "trace_id"],
+      "properties": {
+        "transport": {"type": "string"},
+        "trace_id": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "errors": {
+      "type": "array",
+      "items": {"type": "object"}
+    }
+  },
+  "additionalProperties": false
+}

--- a/apps/mcp_server/service.py
+++ b/apps/mcp_server/service.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+
+from apps.mcp_server.models import Envelope
+
+__all__ = ["McpService"]
+
+
+class McpService:
+    """In-memory placeholder service for MCP transports."""
+
+    def __init__(self, *, service_name: str = "ragx.mcp", version: str = "0.0.0") -> None:
+        self._service_name = service_name
+        self._version = version
+
+    def discover(self, *, transport: str) -> Envelope:
+        data = {
+            "service": self._service_name,
+            "version": self._version,
+            "tools": [],
+            "prompts": [],
+        }
+        return Envelope.success(data=data, transport=transport)
+
+    def get_prompt(self, domain: str, name: str, major: int, *, transport: str) -> Envelope:
+        data = {
+            "domain": domain,
+            "name": name,
+            "major": major,
+            "content": None,
+            "message": "Prompt registry not yet initialised.",
+        }
+        return Envelope.success(data=data, transport=transport)
+
+    def invoke_tool(self, tool_name: str, payload: dict[str, Any], *, transport: str) -> Envelope:
+        data = {
+            "tool": tool_name,
+            "input": payload,
+            "message": "Tool execution not yet implemented.",
+        }
+        return Envelope.success(data=data, transport=transport)

--- a/apps/mcp_server/stdio.py
+++ b/apps/mcp_server/stdio.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from typing import TextIO
+
+from apps.mcp_server.service import McpService
+
+__all__ = ["StdIoServer"]
+
+
+class StdIoServer:
+    """Minimal JSON-RPC STDIO server for MCP."""
+
+    def __init__(
+        self,
+        service: McpService,
+        *,
+        input_stream: TextIO | None = None,
+        output_stream: TextIO | None = None,
+    ) -> None:
+        self._service = service
+        self._input = input_stream
+        self._output = output_stream
+
+    def handle_message(self, raw: str) -> str:
+        request = json.loads(raw)
+        method = request.get("method")
+        request_id = request.get("id")
+        params = request.get("params") or {}
+
+        if method == "mcp.discover":
+            envelope = self._service.discover(transport="stdio")
+        elif method == "mcp.prompt.get":
+            envelope = self._service.get_prompt(
+                params.get("domain", ""),
+                params.get("name", ""),
+                int(params.get("major", 0)),
+                transport="stdio",
+            )
+        elif method == "mcp.tool.invoke":
+            tool_name = params.get("tool") or params.get("name") or "unknown"
+            payload = params.get("arguments") or params.get("input") or {}
+            if isinstance(payload, dict):
+                payload_mapping = payload
+            else:
+                payload_mapping = dict(payload)
+            envelope = self._service.invoke_tool(str(tool_name), payload_mapping, transport="stdio")
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": -32601,
+                    "message": f"Unknown method: {method}",
+                },
+            }
+            return json.dumps(response)
+
+        response = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": envelope.model_dump(),
+        }
+        return json.dumps(response)
+
+    def serve_forever(self) -> None:
+        import sys
+
+        input_stream = self._input or sys.stdin
+        output_stream = self._output or sys.stdout
+
+        for line in input_stream:
+            line = line.strip()
+            if not line:
+                continue
+            response = self.handle_message(line)
+            output_stream.write(response + "\n")
+            output_stream.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,15 @@ addopts = "-q"
 name = "ragx"
 dynamic = ["version"]
 dependencies = [
+    "fastapi",
     "jinja2",
+    "httpx",
     "jsonschema",
     "numpy",
     "packaging",
+    "pydantic",
     "pyyaml",
+    "uvicorn",
 ]
 
 [project.optional-dependencies]

--- a/tests/e2e/test_mcp_server_bootstrap.py
+++ b/tests/e2e/test_mcp_server_bootstrap.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.mcp_server.http_app import create_http_app
+from apps.mcp_server.service import McpService
+from apps.mcp_server.stdio import StdIoServer
+
+
+@pytest.fixture()
+def service() -> McpService:
+    return McpService()
+
+
+@pytest.fixture()
+def http_client(service: McpService) -> TestClient:
+    app = create_http_app(service)
+    return TestClient(app)
+
+
+def assert_envelope_shape(payload: dict[str, Any], *, transport: str) -> None:
+    assert payload["ok"] is True
+    assert isinstance(payload.get("data"), dict)
+    meta = payload.get("meta")
+    assert isinstance(meta, dict)
+    assert meta.get("transport") == transport
+    trace_id = meta.get("trace_id")
+    assert isinstance(trace_id, str) and len(trace_id) >= 8
+    errors = payload.get("errors")
+    assert isinstance(errors, list)
+
+
+def test_http_discover_returns_envelope(http_client: TestClient) -> None:
+    response = http_client.get("/mcp/discover")
+    assert response.status_code == 200
+    payload = response.json()
+    assert_envelope_shape(payload, transport="http")
+    assert payload["data"]["service"] == "ragx.mcp"
+
+
+def test_stdio_discover_matches_http(service: McpService, http_client: TestClient) -> None:
+    http_payload = http_client.get("/mcp/discover").json()
+
+    server = StdIoServer(service)
+    request = {
+        "jsonrpc": "2.0",
+        "id": "req-1",
+        "method": "mcp.discover",
+        "params": {},
+    }
+    response_raw = server.handle_message(json.dumps(request))
+    response = json.loads(response_raw)
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] == "req-1"
+
+    stdio_payload = response["result"]
+    assert_envelope_shape(stdio_payload, transport="stdio")
+    assert stdio_payload["data"] == http_payload["data"]

--- a/tests/unit/apps/mcp_server/test_cli.py
+++ b/tests/unit/apps/mcp_server/test_cli.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from apps.mcp_server.cli import create_parser
+
+
+def test_cli_parser_supports_transports_flags() -> None:
+    parser = create_parser()
+    namespace = parser.parse_args(["--http", "--host", "0.0.0.0", "--port", "9000"])
+    assert namespace.http is True
+    assert namespace.stdio is False
+    assert namespace.host == "0.0.0.0"
+    assert namespace.port == 9000

--- a/tests/unit/apps/mcp_server/test_envelope.py
+++ b/tests/unit/apps/mcp_server/test_envelope.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from apps.mcp_server.models import Envelope
+
+
+def test_envelope_success_generates_trace_id() -> None:
+    envelope = Envelope.success(data={"hello": "world"}, transport="http")
+    assert envelope.ok is True
+    assert envelope.data == {"hello": "world"}
+    assert envelope.meta["transport"] == "http"
+    trace_id = envelope.meta.get("trace_id")
+    assert isinstance(trace_id, str) and len(trace_id) >= 8
+    assert envelope.errors == []


### PR DESCRIPTION
## Summary
- add an Envelope model and McpService placeholders to back HTTP/STDIO transports
- expose FastAPI endpoints, JSON-RPC stdio loop, and CLI wiring for mcp-server
- cover the bootstrap with unit/e2e tests and declare transport dependencies

## Testing
- pytest tests/unit/apps/mcp_server/test_envelope.py tests/unit/apps/mcp_server/test_cli.py tests/e2e/test_mcp_server_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb02de6b8832c91f477ac9a56dac2