### PR TITLE
Implement MCP server bootstrap

### DIFF
--- a/apps/mcp_server/__main__.py
+++ b/apps/mcp_server/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from apps.mcp_server.cli import main
+
+if __name__ == "__main__":  # pragma: no cover - manual entrypoint
+    raise SystemExit(main())

--- a/apps/mcp_server/cli.py
+++ b/apps/mcp_server/cli.py
@@ -1,0 +1,60 @@
+"""Command line interface for the MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import threading
+from collections.abc import Sequence
+
+import uvicorn
+
+from apps.mcp_server.runtime import McpService, McpStdIoServer, create_http_app
+
+__all__ = ["build_parser", "main"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="mcp-server", description="Run the RAGX MCP server")
+    parser.add_argument("--http", action="store_true", help="Run HTTP transport.")
+    parser.add_argument("--stdio", action="store_true", help="Run STDIO JSON-RPC transport.")
+    parser.add_argument("--host", default="127.0.0.1", help="Host for HTTP transport.")
+    parser.add_argument("--port", type=int, default=3333, help="Port for HTTP transport.")
+    return parser
+
+
+def _run_http(service: McpService, *, host: str, port: int) -> None:
+    app = create_http_app(service)
+    uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.http and not args.stdio:
+        args.http = True
+
+    service = McpService()
+
+    http_thread: threading.Thread | None = None
+    if args.http:
+        http_thread = threading.Thread(
+            target=_run_http,
+            args=(service,),
+            kwargs={"host": args.host, "port": args.port},
+            daemon=args.stdio,
+        )
+        http_thread.start()
+
+    if args.stdio:
+        server = McpStdIoServer(service=service)
+        server.serve_forever()
+
+    if http_thread and not args.stdio:
+        http_thread.join()
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution path
+    raise SystemExit(main())

--- a/apps/mcp_server/models/__init__.py
+++ b/apps/mcp_server/models/__init__.py
@@ -1,0 +1,5 @@
+"""Data models used by the MCP server runtime."""
+
+from .envelope import Envelope, EnvelopeMeta
+
+__all__ = ["Envelope", "EnvelopeMeta"]

--- a/apps/mcp_server/models/envelope.py
+++ b/apps/mcp_server/models/envelope.py
@@ -1,0 +1,86 @@
+"""Envelope models for MCP responses."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["Envelope", "EnvelopeMeta"]
+
+
+class EnvelopeMeta(BaseModel):
+    """Metadata associated with every MCP envelope."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tool: str
+    version: str = Field(default="0.1.0")
+    durationMs: int = Field(default=0, ge=0)
+    traceId: str = Field(default_factory=lambda: str(uuid4()))
+    warnings: list[str] = Field(default_factory=list)
+
+
+class Envelope(BaseModel):
+    """Uniform response envelope emitted by the MCP server."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+    data: dict[str, Any]
+    meta: EnvelopeMeta
+    errors: list[dict[str, Any]] = Field(default_factory=list)
+
+    @classmethod
+    def success(
+        cls,
+        *,
+        data: Mapping[str, Any] | None,
+        tool: str,
+        version: str = "0.1.0",
+        duration_ms: int = 0,
+        trace_id: str | None = None,
+        warnings: Iterable[str] | None = None,
+    ) -> Envelope:
+        """Create a successful envelope with deterministic defaults."""
+
+        meta = EnvelopeMeta(
+            tool=tool,
+            version=version,
+            durationMs=duration_ms,
+            traceId=trace_id or str(uuid4()),
+            warnings=list(warnings or ()),
+        )
+        payload = dict(data or {})
+        return cls(ok=True, data=payload, meta=meta, errors=[])
+
+    @classmethod
+    def failure(
+        cls,
+        *,
+        tool: str,
+        errors: Iterable[Mapping[str, Any]],
+        data: Mapping[str, Any] | None = None,
+        version: str = "0.1.0",
+        duration_ms: int = 0,
+        trace_id: str | None = None,
+        warnings: Iterable[str] | None = None,
+    ) -> Envelope:
+        """Create an error envelope (placeholder for future tasks)."""
+
+        meta = EnvelopeMeta(
+            tool=tool,
+            version=version,
+            durationMs=duration_ms,
+            traceId=trace_id or str(uuid4()),
+            warnings=list(warnings or ()),
+        )
+        payload = dict(data or {})
+        return cls(ok=False, data=payload, meta=meta, errors=[dict(item) for item in errors])
+
+    def to_serialisable(self) -> dict[str, Any]:
+        """Return an envelope as a plain serialisable mapping."""
+
+        return self.model_dump()

--- a/apps/mcp_server/runtime/__init__.py
+++ b/apps/mcp_server/runtime/__init__.py
@@ -1,1 +1,13 @@
 """Runtime components for the MCP server."""
+
+from .http import create_http_app
+from .service import McpService
+from .stdio import JsonRpcRequest, JsonRpcResponse, McpStdIoServer
+
+__all__ = [
+    "create_http_app",
+    "McpService",
+    "JsonRpcRequest",
+    "JsonRpcResponse",
+    "McpStdIoServer",
+]

--- a/apps/mcp_server/runtime/http.py
+++ b/apps/mcp_server/runtime/http.py
@@ -1,0 +1,41 @@
+"""HTTP transport for the MCP server."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, status
+from fastapi.responses import JSONResponse
+
+from apps.mcp_server.models import Envelope
+from apps.mcp_server.runtime.service import McpService
+
+__all__ = ["create_http_app"]
+
+
+def _serialise(envelope: Envelope) -> JSONResponse:
+    return JSONResponse(envelope.to_serialisable(), status_code=status.HTTP_200_OK)
+
+
+def create_http_app(service: McpService) -> FastAPI:
+    """Create a FastAPI application exposing the MCP HTTP surface."""
+
+    app = FastAPI(title="RAGX MCP Server", version="0.1.0")
+
+    @app.get("/mcp/discover")
+    def discover() -> JSONResponse:
+        envelope = service.discover()
+        return _serialise(envelope)
+
+    @app.get("/mcp/prompt/{domain}/{name}/{major}")
+    def get_prompt(domain: str, name: str, major: int) -> JSONResponse:
+        envelope = service.get_prompt(domain=domain, name=name, major=major)
+        return _serialise(envelope)
+
+    @app.post("/mcp/tool/{tool_name}")
+    def invoke_tool(tool_name: str, body: dict[str, object] | None = None) -> JSONResponse:
+        arguments = {}
+        if body and isinstance(body, dict):
+            arguments = dict(body.get("arguments", {}))
+        envelope = service.invoke_tool(tool_name=tool_name, arguments=arguments)
+        return _serialise(envelope)
+
+    return app

--- a/apps/mcp_server/runtime/service.py
+++ b/apps/mcp_server/runtime/service.py
@@ -1,0 +1,116 @@
+"""Service layer powering the MCP server transports."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from apps.mcp_server.models import Envelope
+
+__all__ = ["McpService"]
+
+
+class McpService:
+    """Implements the core MCP RPCs with placeholder payloads."""
+
+    def __init__(
+        self,
+        *,
+        server_name: str = "ragx.mcp",
+        server_version: str = "0.1.0",
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._server_name = server_name
+        self._server_version = server_version
+        self._start_time = datetime.now(tz=UTC)
+        self._logger = logger or logging.getLogger("ragx.mcp.server")
+        if not self._logger.handlers:
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter("%(message)s")
+            handler.setFormatter(formatter)
+            self._logger.addHandler(handler)
+        self._logger.setLevel(logging.INFO)
+
+    def discover(self) -> Envelope:
+        """Return placeholder discovery metadata."""
+
+        uptime = int((datetime.now(tz=UTC) - self._start_time).total_seconds())
+        payload = {
+            "server": {"name": self._server_name, "version": self._server_version},
+            "tools": [],
+            "prompts": [],
+            "health": {"status": "ok", "uptimeSec": uptime},
+        }
+        envelope = Envelope.success(
+            data=payload,
+            tool="mcp.discover",
+            trace_id=self._new_trace_id(),
+        )
+        self._emit_log("discover", envelope)
+        return envelope
+
+    def get_prompt(self, domain: str, name: str, major: int | str) -> Envelope:
+        """Return a placeholder prompt payload."""
+
+        prompt_id = f"{domain}/{name}"
+        payload = {
+            "prompt": {
+                "id": prompt_id,
+                "version": {"major": int(major), "description": "placeholder"},
+                "body": "",
+                "spec": {
+                    "ref": None,
+                    "notes": "prompt registry not implemented",
+                },
+            }
+        }
+        envelope = Envelope.success(
+            data=payload,
+            tool="mcp.prompt.get",
+            trace_id=self._new_trace_id(),
+        )
+        self._emit_log("prompt", envelope, extra={"prompt_id": prompt_id})
+        return envelope
+
+    def invoke_tool(self, tool_name: str, arguments: Mapping[str, Any] | None = None) -> Envelope:
+        """Return a placeholder tool invocation response."""
+
+        payload = {
+            "echo": {
+                "tool": tool_name,
+                "arguments": dict(arguments or {}),
+                "message": "tool execution not yet implemented",
+            }
+        }
+        envelope = Envelope.success(
+            data=payload,
+            tool="mcp.tool.invoke",
+            trace_id=self._new_trace_id(),
+        )
+        self._emit_log("tool", envelope, extra={"tool": tool_name})
+        return envelope
+
+    def _emit_log(
+        self,
+        event: str,
+        envelope: Envelope,
+        *,
+        extra: Mapping[str, Any] | None = None,
+    ) -> None:
+        record = {
+            "event": event,
+            "traceId": envelope.meta.traceId,
+            "tool": envelope.meta.tool,
+            "ok": envelope.ok,
+        }
+        if extra:
+            record.update(dict(extra))
+        self._logger.info(json.dumps(record, sort_keys=True))
+
+    @staticmethod
+    def _new_trace_id() -> str:
+        return str(uuid4())

--- a/apps/mcp_server/runtime/stdio.py
+++ b/apps/mcp_server/runtime/stdio.py
@@ -1,0 +1,111 @@
+"""STDIO JSON-RPC transport for the MCP server."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any, TextIO
+
+from apps.mcp_server.runtime.service import McpService
+
+__all__ = ["JsonRpcRequest", "JsonRpcResponse", "McpStdIoServer"]
+
+
+@dataclass(slots=True)
+class JsonRpcRequest:
+    """Incoming JSON-RPC request."""
+
+    id: str | int
+    method: str
+    params: dict[str, Any]
+
+
+@dataclass(slots=True)
+class JsonRpcResponse:
+    """Outgoing JSON-RPC response."""
+
+    id: str | int
+    result: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+    jsonrpc: str = "2.0"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "jsonrpc": self.jsonrpc,
+            "id": self.id,
+            "result": self.result,
+            "error": self.error,
+        }
+
+
+class McpStdIoServer:
+    """Minimal STDIO server handling a subset of MCP JSON-RPC calls."""
+
+    def __init__(
+        self,
+        *,
+        service: McpService,
+        input_stream: TextIO | None = None,
+        output_stream: TextIO | None = None,
+    ) -> None:
+        self._service = service
+        self._input = input_stream or sys.stdin
+        self._output = output_stream or sys.stdout
+
+    def handle_request(self, request: JsonRpcRequest) -> JsonRpcResponse:
+        """Handle a structured JSON-RPC request."""
+
+        try:
+            if request.method == "mcp.discover":
+                envelope = self._service.discover()
+            elif request.method == "mcp.prompt.get":
+                envelope = self._service.get_prompt(
+                    domain=request.params["domain"],
+                    name=request.params["name"],
+                    major=request.params.get("major", 1),
+                )
+            elif request.method == "mcp.tool.invoke":
+                envelope = self._service.invoke_tool(
+                    tool_name=request.params["tool"],
+                    arguments=request.params.get("arguments", {}),
+                )
+            else:
+                return JsonRpcResponse(
+                    id=request.id,
+                    error={"code": -32601, "message": "Method not found"},
+                )
+        except KeyError as exc:
+            return JsonRpcResponse(
+                id=request.id,
+                error={"code": -32602, "message": f"Missing parameter: {exc.args[0]}"},
+            )
+
+        return JsonRpcResponse(id=request.id, result=envelope.to_serialisable())
+
+    def handle_line(self, payload: str) -> JsonRpcResponse:
+        """Parse a JSON line and return the corresponding response."""
+
+        message = json.loads(payload)
+        request = JsonRpcRequest(
+            id=message["id"],
+            method=message["method"],
+            params=dict(message.get("params", {})),
+        )
+        return self.handle_request(request)
+
+    def dumps_response(self, response: JsonRpcResponse) -> str:
+        """Serialise a response to a JSON string."""
+
+        return json.dumps(response.to_dict(), separators=(",", ":"))
+
+    def serve_forever(self) -> None:  # pragma: no cover - requires IO integration tests
+        """Run the STDIO loop until EOF."""
+
+        for raw in self._input:
+            line = raw.strip()
+            if not line:
+                continue
+            response = self.handle_line(line)
+            self._output.write(self.dumps_response(response) + "\n")
+            self._output.flush()

--- a/apps/mcp_server/schemas/envelope.schema.json
+++ b/apps/mcp_server/schemas/envelope.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ragx.dev/schemas/mcp/envelope.json",
+  "title": "RAGX MCP Envelope",
+  "type": "object",
+  "required": ["ok", "data", "meta", "errors"],
+  "properties": {
+    "ok": {"type": "boolean"},
+    "data": {"type": "object"},
+    "meta": {
+      "type": "object",
+      "required": ["tool", "version", "durationMs", "traceId", "warnings"],
+      "properties": {
+        "tool": {"type": "string"},
+        "version": {"type": "string"},
+        "durationMs": {"type": "integer", "minimum": 0},
+        "traceId": {"type": "string"},
+        "warnings": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      },
+      "additionalProperties": false
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "numpy",
     "packaging",
     "pyyaml",
+    "fastapi",
+    "uvicorn",
 ]
 
 [project.optional-dependencies]
@@ -38,4 +40,5 @@ dev = [
     "pytest-cov",
     "ruff",
     "yamllint",
+    "httpx",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ mypy
 yamllint
 pybind11
 deepdiff>=6.7.0
+fastapi
+uvicorn
+httpx

--- a/tests/e2e/test_mcp_server_bootstrap.py
+++ b/tests/e2e/test_mcp_server_bootstrap.py
@@ -1,0 +1,109 @@
+"""Acceptance tests for MCP server bootstrap implementation."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.mcp_server.runtime.http import create_http_app
+from apps.mcp_server.runtime.service import McpService
+from apps.mcp_server.runtime.stdio import JsonRpcRequest, McpStdIoServer
+
+
+@pytest.fixture()
+def mcp_service() -> McpService:
+    return McpService()
+
+
+def assert_envelope_structure(payload: dict[str, Any], *, tool: str) -> None:
+    """Helper asserting the shape of an envelope response."""
+
+    assert payload["ok"] is True
+    assert isinstance(payload["data"], dict)
+    assert "meta" in payload and isinstance(payload["meta"], dict)
+    meta = payload["meta"]
+    assert meta["tool"] == tool
+    assert isinstance(meta["traceId"], str) and meta["traceId"]
+    assert meta["version"] == "0.1.0"
+    assert isinstance(meta["durationMs"], int)
+    assert isinstance(meta["warnings"], list)
+    assert payload["errors"] == []
+
+
+def test_http_discover_returns_envelope(mcp_service: McpService) -> None:
+    app = create_http_app(mcp_service)
+    client = TestClient(app)
+    response = client.get("/mcp/discover")
+    assert response.status_code == 200
+    payload = response.json()
+    assert_envelope_structure(payload, tool="mcp.discover")
+    assert payload["data"]["server"]["name"] == "ragx.mcp"
+
+
+def test_stdio_discover_matches_http_envelope(mcp_service: McpService) -> None:
+    server = McpStdIoServer(service=mcp_service)
+    request = JsonRpcRequest(id="1", method="mcp.discover", params={})
+    response = server.handle_request(request)
+    assert response.error is None
+    assert response.result is not None
+
+    http_payload = TestClient(create_http_app(mcp_service)).get("/mcp/discover").json()
+    assert response.result["ok"] is http_payload["ok"] is True
+    assert response.result["data"] == http_payload["data"]
+    assert response.result["errors"] == http_payload["errors"] == []
+    assert response.result["meta"]["tool"] == http_payload["meta"]["tool"]
+    assert response.result["meta"]["version"] == http_payload["meta"]["version"]
+    assert response.result["meta"]["warnings"] == http_payload["meta"]["warnings"]
+
+
+def test_prompt_endpoint_placeholder(mcp_service: McpService) -> None:
+    app = create_http_app(mcp_service)
+    client = TestClient(app)
+    response = client.get("/mcp/prompt/test/domain/1")
+    assert response.status_code == 200
+    payload = response.json()
+    assert_envelope_structure(payload, tool="mcp.prompt.get")
+    assert payload["data"]["prompt"]["id"] == "test/domain"
+
+
+def test_tool_endpoint_placeholder(mcp_service: McpService) -> None:
+    app = create_http_app(mcp_service)
+    client = TestClient(app)
+    body = {"arguments": {"query": "ping"}}
+    response = client.post("/mcp/tool/echo", json=body)
+    assert response.status_code == 200
+    payload = response.json()
+    assert_envelope_structure(payload, tool="mcp.tool.invoke")
+    assert payload["data"]["echo"]["tool"] == "echo"
+
+
+def test_stdio_tool_invocation_matches_http(mcp_service: McpService) -> None:
+    server = McpStdIoServer(service=mcp_service)
+    request = JsonRpcRequest(
+        id="2",
+        method="mcp.tool.invoke",
+        params={"tool": "echo", "arguments": {"value": 42}},
+    )
+    response = server.handle_request(request)
+    assert response.error is None
+    assert response.result is not None
+
+    http_payload = TestClient(create_http_app(mcp_service)).post(
+        "/mcp/tool/echo", json={"arguments": {"value": 42}}
+    ).json()
+    assert response.result["data"] == http_payload["data"]
+    assert response.result["errors"] == http_payload["errors"] == []
+    assert response.result["meta"]["tool"] == http_payload["meta"]["tool"]
+
+
+def test_stdio_round_trip_serialisation(mcp_service: McpService) -> None:
+    server = McpStdIoServer(service=mcp_service)
+    request = JsonRpcRequest(id="42", method="mcp.discover", params={})
+    serialised = server.dumps_response(server.handle_request(request))
+    parsed = json.loads(serialised)
+    assert parsed["id"] == "42"
+    assert parsed["jsonrpc"] == "2.0"
+    assert parsed["result"]["meta"]["tool"] == "mcp.discover"


### PR DESCRIPTION
## Summary
- add a Pydantic envelope model and JSON schema for placeholder responses
- implement an MCP service with HTTP and STDIO transports plus CLI entrypoints
- add e2e coverage that exercises the HTTP routes and JSON-RPC loop

## Testing
- pytest tests/e2e/test_mcp_server_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb02de6b8832c91f477ac9a56dac2