### PR TITLE
Implement MCP server bootstrap skeleton

### DIFF
--- a/apps/mcp_server/__init__.py
+++ b/apps/mcp_server/__init__.py
@@ -1,0 +1,8 @@
+"""RAGX MCP server bootstrap package."""
+
+from apps.mcp_server.app import create_app
+from apps.mcp_server.cli import main
+from apps.mcp_server.models import Envelope
+from apps.mcp_server.service import McpService
+
+__all__ = ["create_app", "main", "Envelope", "McpService"]

--- a/apps/mcp_server/app.py
+++ b/apps/mcp_server/app.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Annotated, Any
+
+from fastapi import Body, FastAPI
+
+from apps.mcp_server.service import McpService
+
+
+def _extract_arguments(payload: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if not payload:
+        return {}
+    for key in ("arguments", "inputs"):
+        value = payload.get(key)
+        if isinstance(value, Mapping):
+            return value
+    return payload if isinstance(payload, Mapping) else {}
+
+
+Payload = Annotated[dict[str, Any] | None, Body()]
+
+
+def create_app(service: McpService) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/mcp/discover")
+    async def discover() -> Any:
+        envelope = service.discover(transport="http")
+        return envelope.to_dict()
+
+    @app.get("/mcp/prompt/{domain}/{name}/{major}")
+    async def get_prompt(domain: str, name: str, major: str) -> Any:
+        envelope = service.get_prompt(domain, name, major, transport="http")
+        return envelope.to_dict()
+
+    @app.post("/mcp/tool/{tool_name}")
+    async def invoke_tool(
+        tool_name: str,
+        payload: Payload = None,
+    ) -> Any:
+        arguments = _extract_arguments(payload)
+        envelope = service.invoke_tool(tool_name, arguments, transport="http")
+        return envelope.to_dict()
+
+    return app

--- a/apps/mcp_server/cli.py
+++ b/apps/mcp_server/cli.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import threading
+from collections.abc import Sequence
+
+import uvicorn
+
+from apps.mcp_server.app import create_app
+from apps.mcp_server.service import McpService
+from apps.mcp_server.transports import McpStdioServer
+
+LOGGER = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="mcp-server", description="RAGX MCP server")
+    parser.add_argument("--http", action="store_true", help="Run HTTP transport.")
+    parser.add_argument("--stdio", action="store_true", help="Run STDIO JSON-RPC transport.")
+    parser.add_argument("--host", default="127.0.0.1", help="HTTP bind host.")
+    parser.add_argument("--port", type=int, default=3333, help="HTTP bind port.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.http and not args.stdio:
+        args.http = True
+
+    service = McpService()
+
+    stdio_thread: threading.Thread | None = None
+    if args.stdio:
+        stdio_server = McpStdioServer(service)
+        stdio_thread = threading.Thread(target=stdio_server.serve_forever, daemon=True)
+        stdio_thread.start()
+        LOGGER.info("STDIO transport started")
+
+    if args.http:
+        app = create_app(service)
+        uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    else:
+        # If only STDIO was requested, block until interrupted.
+        if stdio_thread is not None:
+            stdio_thread.join()
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entry point
+    raise SystemExit(main())

--- a/apps/mcp_server/models.py
+++ b/apps/mcp_server/models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Envelope(BaseModel):
+    """Canonical response envelope for MCP transports."""
+
+    ok: bool = Field(default=True)
+    data: Any = Field(default=None)
+    meta: dict[str, Any] = Field(default_factory=dict)
+    errors: list[dict[str, Any]] = Field(default_factory=list)
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="allow",
+    )
+
+    @classmethod
+    def success(
+        cls,
+        *,
+        data: Any,
+        trace_id: str,
+        transport: str,
+        meta: dict[str, Any] | None = None,
+    ) -> Envelope:
+        payload_meta: dict[str, Any] = {"traceId": trace_id, "transport": transport}
+        if meta:
+            payload_meta.update(meta)
+        return cls(ok=True, data=data, meta=payload_meta, errors=[])
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump()

--- a/apps/mcp_server/service.py
+++ b/apps/mcp_server/service.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from typing import Any
+from uuid import uuid4
+
+from apps.mcp_server.models import Envelope
+
+LOGGER = logging.getLogger(__name__)
+
+
+class McpService:
+    """Bootstrap implementation returning placeholder envelopes."""
+
+    def __init__(self, *, logger: logging.Logger | None = None) -> None:
+        self._logger = logger or LOGGER
+
+    def discover(self, *, transport: str) -> Envelope:
+        trace_id = self._new_trace_id()
+        data = {
+            "version": "0.1.0",
+            "tools": [],
+            "prompts": [],
+        }
+        envelope = Envelope.success(data=data, trace_id=trace_id, transport=transport)
+        self._log("mcp.discover", transport=transport, trace_id=trace_id, status="ok")
+        return envelope
+
+    def get_prompt(
+        self,
+        domain: str,
+        name: str,
+        major: str,
+        *,
+        transport: str,
+    ) -> Envelope:
+        trace_id = self._new_trace_id()
+        prompt = {
+            "domain": domain,
+            "name": name,
+            "major": str(major),
+            "content": (
+                "Placeholder prompt content. Configure prompts under apps/mcp_server/prompts/."
+            ),
+        }
+        envelope = Envelope.success(data=prompt, trace_id=trace_id, transport=transport)
+        self._log("mcp.prompt.get", transport=transport, trace_id=trace_id, status="ok")
+        return envelope
+
+    def invoke_tool(
+        self,
+        tool: str,
+        arguments: Mapping[str, Any] | None,
+        *,
+        transport: str,
+    ) -> Envelope:
+        trace_id = self._new_trace_id()
+        payload = {
+            "tool": tool,
+            "inputs": dict(arguments or {}),
+            "status": "placeholder",
+        }
+        envelope = Envelope.success(data=payload, trace_id=trace_id, transport=transport)
+        self._log("mcp.tool.invoke", transport=transport, trace_id=trace_id, status="ok")
+        return envelope
+
+    def _new_trace_id(self) -> str:
+        return str(uuid4())
+
+    def _log(self, event: str, *, transport: str, trace_id: str, status: str) -> None:
+        record = {
+            "event": event,
+            "traceId": trace_id,
+            "transport": transport,
+            "status": status,
+        }
+        self._logger.info(json.dumps(record, sort_keys=True))

--- a/apps/mcp_server/transports/__init__.py
+++ b/apps/mcp_server/transports/__init__.py
@@ -1,0 +1,5 @@
+"""Transport adapters for the MCP server."""
+
+from .stdio import McpStdioServer
+
+__all__ = ["McpStdioServer"]

--- a/apps/mcp_server/transports/stdio.py
+++ b/apps/mcp_server/transports/stdio.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+from apps.mcp_server.models import Envelope
+from apps.mcp_server.service import McpService
+
+LOGGER = logging.getLogger(__name__)
+
+
+class McpStdioServer:
+    """Minimal JSON-RPC handler for STDIO transport."""
+
+    def __init__(
+        self,
+        service: McpService,
+        *,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._service = service
+        self._logger = logger or LOGGER
+
+    def serve_forever(self) -> None:
+        """Consume JSON-RPC messages from stdin and write responses to stdout."""
+
+        for raw_line in sys.stdin:
+            response = self.process_line(raw_line)
+            if response is None:
+                continue
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+
+    def process_line(self, raw_line: str) -> dict[str, Any] | None:
+        raw_line = raw_line.strip()
+        if not raw_line:
+            return None
+        try:
+            message = json.loads(raw_line)
+        except json.JSONDecodeError:
+            return self._error_response(None, code=-32700, message="Parse error")
+        if not isinstance(message, Mapping):
+            return self._error_response(None, code=-32600, message="Invalid request")
+        if "id" not in message:
+            # Notification, no response expected.
+            return None
+        return self.handle_message(message)
+
+    def handle_message(self, message: Mapping[str, Any]) -> dict[str, Any]:
+        request_id = message.get("id")
+        method = message.get("method")
+        params = message.get("params") if isinstance(message.get("params"), Mapping) else {}
+        try:
+            result = self._dispatch(method, params)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            self._logger.exception("Unhandled MCP STDIO error")
+            return self._error_response(request_id, code=-32603, message=str(exc))
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": result.to_dict(),
+        }
+
+    def _dispatch(self, method: Any, params: Mapping[str, Any]) -> Envelope:
+        if method == "mcp.discover":
+            return self._service.discover(transport="stdio")
+        if method == "mcp.prompt.get":
+            domain = str(params.get("domain", ""))
+            name = str(params.get("name", ""))
+            major = str(params.get("major", ""))
+            return self._service.get_prompt(domain, name, major, transport="stdio")
+        if method == "mcp.tool.invoke":
+            tool = params.get("tool")
+            if not isinstance(tool, str) or not tool:
+                raise ValueError("tool parameter must be provided")
+            arguments = params.get("arguments")
+            if not isinstance(arguments, Mapping):
+                arguments = {}
+            return self._service.invoke_tool(tool, arguments, transport="stdio")
+        raise ValueError(f"Unsupported MCP method: {method}")
+
+    @staticmethod
+    def _error_response(request_id: Any, *, code: int, message: str) -> dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,15 @@ addopts = "-q"
 name = "ragx"
 dynamic = ["version"]
 dependencies = [
+    "fastapi",
+    "httpx",
     "jinja2",
     "jsonschema",
     "numpy",
     "packaging",
+    "pydantic",
     "pyyaml",
+    "uvicorn",
 ]
 
 [project.optional-dependencies]
@@ -39,3 +43,6 @@ dev = [
     "ruff",
     "yamllint",
 ]
+
+[project.scripts]
+mcp-server = "apps.mcp_server.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+uvicorn
+pydantic
+httpx
+fastapi
 jinja2
 jsonschema
 numpy
@@ -5,7 +9,6 @@ pyyaml
 packaging
 pytest
 pytest-cov
-numpy
 ruff
 mypy
 yamllint

--- a/tests/e2e/test_mcp_server_bootstrap.py
+++ b/tests/e2e/test_mcp_server_bootstrap.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.mcp_server.app import create_app
+from apps.mcp_server.service import McpService
+from apps.mcp_server.transports.stdio import McpStdioServer
+
+
+@pytest.fixture()
+def service() -> McpService:
+    return McpService()
+
+
+@pytest.fixture()
+def http_client(service: McpService) -> TestClient:
+    app = create_app(service)
+    return TestClient(app)
+
+
+def _assert_envelope_structure(payload: dict[str, Any]) -> None:
+    assert payload["ok"] is True
+    assert "meta" in payload and isinstance(payload["meta"], dict)
+    meta = payload["meta"]
+    assert "traceId" in meta and isinstance(meta["traceId"], str) and meta["traceId"]
+    assert "data" in payload
+    assert "errors" in payload and isinstance(payload["errors"], list)
+
+
+def test_http_discover_returns_envelope(http_client: TestClient) -> None:
+    response = http_client.get("/mcp/discover")
+    assert response.status_code == 200
+    payload = response.json()
+    _assert_envelope_structure(payload)
+    assert payload["data"]["version"] == "0.1.0"
+    assert payload["data"]["tools"] == []
+    assert payload["data"]["prompts"] == []
+
+
+def test_http_prompt_get_returns_placeholder(http_client: TestClient) -> None:
+    response = http_client.get("/mcp/prompt/core/example/1")
+    assert response.status_code == 200
+    payload = response.json()
+    _assert_envelope_structure(payload)
+    prompt = payload["data"]
+    assert prompt["domain"] == "core"
+    assert prompt["name"] == "example"
+    assert prompt["major"] == "1"
+    assert isinstance(prompt["content"], str) and "placeholder" in prompt["content"].lower()
+
+
+def test_http_tool_invoke_echoes_payload(http_client: TestClient) -> None:
+    request_body = {"inputs": {"query": "hello"}}
+    response = http_client.post("/mcp/tool/demo.tool", json=request_body)
+    assert response.status_code == 200
+    payload = response.json()
+    _assert_envelope_structure(payload)
+    data = payload["data"]
+    assert data["tool"] == "demo.tool"
+    assert data["inputs"] == request_body["inputs"]
+
+
+def test_stdio_discover_returns_envelope(service: McpService) -> None:
+    server = McpStdioServer(service)
+    request = {"jsonrpc": "2.0", "id": "1", "method": "mcp.discover", "params": {}}
+    response = server.handle_message(request)
+    assert response["id"] == "1"
+    assert response["jsonrpc"] == "2.0"
+    result = response["result"]
+    _assert_envelope_structure(result)
+    assert result["data"]["version"] == "0.1.0"
+
+
+def test_stdio_prompt_get_returns_envelope(service: McpService) -> None:
+    server = McpStdioServer(service)
+    request = {
+        "jsonrpc": "2.0",
+        "id": "2",
+        "method": "mcp.prompt.get",
+        "params": {"domain": "core", "name": "demo", "major": "1"},
+    }
+    response = server.handle_message(request)
+    prompt = response["result"]["data"]
+    assert prompt["domain"] == "core"
+    assert prompt["name"] == "demo"
+    assert prompt["major"] == "1"
+
+
+def test_stdio_tool_invoke_returns_envelope(service: McpService) -> None:
+    server = McpStdioServer(service)
+    request = {
+        "jsonrpc": "2.0",
+        "id": "3",
+        "method": "mcp.tool.invoke",
+        "params": {"tool": "demo.tool", "arguments": {"foo": "bar"}},
+    }
+    response = server.handle_message(request)
+    data = response["result"]["data"]
+    assert data["tool"] == "demo.tool"
+    assert data["inputs"] == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- add an Envelope model and placeholder McpService covering discover, prompt, and tool methods from the `mcp_server` component spec
- expose FastAPI HTTP routes, a STDIO JSON-RPC handler, and an `mcp-server` CLI wiring the documented transport flags
- add e2e coverage for the new HTTP/STDIO behaviour and declare FastAPI stack dependencies

## Testing
- pytest tests/e2e/test_mcp_server_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb02de6b8832c91f477ac9a56dac2