### PR TITLE
feat: enforce canonical mcp schema validation

### DIFF
--- a/apps/mcp_server/service/mcp_service.py
+++ b/apps/mcp_server/service/mcp_service.py
@@ -282,7 +282,7 @@ class McpService:
             prompt = self._prompts.get(prompt_id)
         except KeyError:
             return self._error_response(
-                code="MCP_UNKNOWN_PROMPT",
+                code="NOT_FOUND",
                 message=f"Prompt '{prompt_id}' not found",
                 context=ctx,
                 payload=payload,
@@ -303,7 +303,7 @@ class McpService:
         ctx = self._normalise_context(context, "tool", "mcp.tool.invoke", payload)
         if tool_id not in self._toolpacks:
             return self._error_response(
-                code="MCP_UNKNOWN_TOOL",
+                code="NOT_FOUND",
                 message=f"Tool '{tool_id}' not found",
                 context=ctx,
                 payload=payload,
@@ -314,7 +314,7 @@ class McpService:
             result = self._executor.run_toolpack(toolpack, arguments)
         except ToolpackExecutionError as exc:
             return self._error_response(
-                code="MCP_VALIDATION_ERROR",
+                code=getattr(exc, "code", "INTERNAL"),
                 message=str(exc),
                 context=ctx,
                 payload=payload,

--- a/tests/e2e/test_mcp_envelope_validation.py
+++ b/tests/e2e/test_mcp_envelope_validation.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+
+from fastapi.testclient import TestClient
+
+from apps.mcp_server.http import create_app
+from apps.mcp_server.service.mcp_service import McpService
+
+SCHEMA_DIR = Path("apps/mcp_server/schemas/mcp")
+TOOLPACKS_DIR = Path("apps/mcp_server/toolpacks")
+PROMPTS_DIR = Path("apps/mcp_server/prompts")
+
+
+def _service(tmp_path: Path) -> McpService:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return McpService.create(
+        toolpacks_dir=TOOLPACKS_DIR,
+        prompts_dir=PROMPTS_DIR,
+        schema_dir=SCHEMA_DIR,
+        log_dir=log_dir,
+    )
+
+
+def test_invalid_tool_payload_returns_invalid_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("RAGX_SEED", "1337")
+    service = _service(tmp_path)
+    client = TestClient(create_app(service))
+
+    response = client.post(
+        "/mcp/tool/mcp.tool:docs.load.fetch",
+        json={"arguments": {"encoding": "utf-8"}},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "INVALID_INPUT"
+    assert payload["meta"]["status"] == "error"

--- a/tests/unit/mcp/test_mcp_service.py
+++ b/tests/unit/mcp/test_mcp_service.py
@@ -121,5 +121,25 @@ def test_invoke_tool_invalid_payload_returns_error(service: McpService) -> None:
     )
     payload = envelope.model_dump(by_alias=True)
     assert payload["ok"] is False
-    assert payload["error"]["code"] == "MCP_VALIDATION_ERROR"
+    assert payload["error"]["code"] == "INVALID_INPUT"
     assert "path" in payload["error"]["message"].lower()
+
+
+def test_invoke_tool_unknown_returns_not_found(service: McpService) -> None:
+    context = _context("tool")
+    envelope = service.invoke_tool(
+        tool_id="mcp.tool:missing",
+        arguments={},
+        context=context,
+    )
+    payload = envelope.model_dump(by_alias=True)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "NOT_FOUND"
+
+
+def test_get_prompt_unknown_returns_not_found(service: McpService) -> None:
+    context = _context("prompt")
+    envelope = service.get_prompt("unknown.prompt@1", context)
+    payload = envelope.model_dump(by_alias=True)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "NOT_FOUND"

--- a/tests/unit/test_envelope_schema_validation.py
+++ b/tests/unit/test_envelope_schema_validation.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+pytest.importorskip("pydantic")
+
+from apps.mcp_server.service.envelope import Envelope, EnvelopeError, EnvelopeMeta
+
+SCHEMA_PATH = Path("apps/mcp_server/schemas/mcp/envelope.schema.json")
+
+
+@pytest.fixture(scope="module")
+def envelope_validator() -> Draft202012Validator:
+    if not SCHEMA_PATH.exists():
+        pytest.fail(f"Envelope schema missing: {SCHEMA_PATH}")
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema)
+    validator.check_schema(schema)
+    return validator
+
+
+def _meta_payload() -> EnvelopeMeta:
+    return EnvelopeMeta(
+        request_id="req-1234",
+        trace_id="trace-1234",
+        span_id="span-1234",
+        schema_version="0.1.0",
+        deterministic=True,
+        transport="http",
+        route="tool",
+        method="mcp.tool.invoke",
+        duration_ms=12.5,
+        status="ok",
+        attempt=1,
+        input_bytes=128,
+        output_bytes=256,
+        tool_id="mcp.tool:example",
+        prompt_id=None,
+    )
+
+
+def test_success_envelope_matches_schema(envelope_validator: Draft202012Validator) -> None:
+    envelope = Envelope.success(data={"result": {}}, meta=_meta_payload())
+    envelope_validator.validate(envelope.model_dump(by_alias=True))
+
+
+def test_error_envelope_matches_schema(envelope_validator: Draft202012Validator) -> None:
+    meta = _meta_payload()
+    error = EnvelopeError(code="INVALID_INPUT", message="invalid request")
+    error_envelope = Envelope.failure(error=error, meta=meta.model_copy(update={"status": "error"}))
+    envelope_validator.validate(error_envelope.model_dump(by_alias=True))
+
+
+def test_schema_rejects_missing_fields(envelope_validator: Draft202012Validator) -> None:
+    with pytest.raises(ValidationError):
+        envelope_validator.validate({"ok": True, "data": {}})


### PR DESCRIPTION
## Summary
- propagate canonical error codes from tool execution and map missing resources to NOT_FOUND in the MCP service
- attach stable error codes to toolpack execution failures for schema and mapping issues
- add unit and e2e coverage to validate the MCP envelope schema and INVALID_INPUT responses

## Testing
- pytest tests/unit/test_envelope_schema_validation.py tests/unit/mcp/test_mcp_service.py tests/e2e/test_mcp_envelope_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68dfdb487adc832cbb7ce7cb770eda24