### PR TITLE
Enforce MCP envelope schema validation

### DIFF
--- a/apps/mcp_server/http/routes.py
+++ b/apps/mcp_server/http/routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Response, status
 from pydantic import BaseModel
 
 from apps.mcp_server.service.mcp_service import McpService, RequestContext
@@ -14,30 +14,56 @@ class ToolInvocationPayload(BaseModel):
     arguments: dict[str, Any] = {}
 
 
+_ERROR_STATUS: dict[str, int] = {
+    "INVALID_INPUT": status.HTTP_400_BAD_REQUEST,
+    "NOT_FOUND": status.HTTP_404_NOT_FOUND,
+    "RATE_LIMIT": status.HTTP_429_TOO_MANY_REQUESTS,
+    "TIMEOUT": status.HTTP_504_GATEWAY_TIMEOUT,
+    "UNAVAILABLE": status.HTTP_503_SERVICE_UNAVAILABLE,
+    "INTERNAL": status.HTTP_500_INTERNAL_SERVER_ERROR,
+    "NONDETERMINISTIC": status.HTTP_409_CONFLICT,
+    "UNSUPPORTED": status.HTTP_501_NOT_IMPLEMENTED,
+}
+
+
+def _serialise_envelope(response: Response, envelope_payload: dict[str, Any]) -> dict[str, Any]:
+    if not envelope_payload.get("ok", True):
+        error = envelope_payload.get("error") or {}
+        code = error.get("code")
+        if code is not None:
+            response.status_code = _ERROR_STATUS.get(code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+    return envelope_payload
+
+
 def build_router(service: McpService) -> APIRouter:
     router = APIRouter()
 
     @router.get("/mcp/discover")
-    def discover() -> dict[str, Any]:
+    def discover(response: Response) -> dict[str, Any]:
         context = RequestContext(transport="http", route="discover", method="mcp.discover")
         envelope = service.discover(context)
-        return envelope.model_dump(by_alias=True)
+        payload = envelope.model_dump(by_alias=True)
+        return _serialise_envelope(response, payload)
 
     @router.get("/mcp/prompt/{prompt_id}")
-    def get_prompt(prompt_id: str) -> dict[str, Any]:
+    def get_prompt(prompt_id: str, response: Response) -> dict[str, Any]:
         context = RequestContext(transport="http", route="prompt", method="mcp.prompt.get")
         envelope = service.get_prompt(prompt_id, context)
-        return envelope.model_dump(by_alias=True)
+        payload = envelope.model_dump(by_alias=True)
+        return _serialise_envelope(response, payload)
 
     @router.post("/mcp/tool/{tool_id}")
-    def invoke_tool(tool_id: str, payload: ToolInvocationPayload) -> dict[str, Any]:
+    def invoke_tool(
+        tool_id: str, payload: ToolInvocationPayload, response: Response
+    ) -> dict[str, Any]:
         context = RequestContext(transport="http", route="tool", method="mcp.tool.invoke")
         envelope = service.invoke_tool(
             tool_id=tool_id,
             arguments=payload.arguments,
             context=context,
         )
-        return envelope.model_dump(by_alias=True)
+        payload_dict = envelope.model_dump(by_alias=True)
+        return _serialise_envelope(response, payload_dict)
 
     @router.get("/healthz")
     def health() -> dict[str, Any]:

--- a/tests/e2e/test_mcp_envelope_validation.py
+++ b/tests/e2e/test_mcp_envelope_validation.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+
+from fastapi.testclient import TestClient
+
+from apps.mcp_server.http.main import create_app
+from apps.mcp_server.service.mcp_service import McpService
+from apps.mcp_server.stdio.server import JsonRpcStdioServer
+
+SCHEMA_DIR = Path("apps/mcp_server/schemas/mcp")
+TOOLPACKS_DIR = Path("apps/mcp_server/toolpacks")
+PROMPTS_DIR = Path("apps/mcp_server/prompts")
+
+
+@pytest.fixture(autouse=True)
+def _seed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAGX_SEED", "40")
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> McpService:
+    return McpService.create(
+        toolpacks_dir=TOOLPACKS_DIR,
+        prompts_dir=PROMPTS_DIR,
+        schema_dir=SCHEMA_DIR,
+        log_dir=tmp_path / "logs",
+        schema_version="0.1.0",
+    )
+
+
+@pytest.fixture
+def client(service: McpService) -> TestClient:
+    app = create_app(service)
+    return TestClient(app)
+
+
+def test_invalid_tool_payload_returns_invalid_input_across_transports(
+    client: TestClient, service: McpService
+) -> None:
+    response = client.post(
+        "/mcp/tool/mcp.tool:docs.load.fetch",
+        json={"arguments": {"encoding": "utf-8"}},
+    )
+    assert response.status_code == 400
+    http_payload = response.json()
+    assert http_payload["ok"] is False
+    assert http_payload["error"]["code"] == "INVALID_INPUT"
+    assert http_payload["error"]["details"]["stage"] == "input"
+
+    server = JsonRpcStdioServer(service, deterministic_ids=True)
+    stdio_payload = asyncio.run(
+        server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": "req-1",
+                "method": "mcp.tool.invoke",
+                "params": {
+                    "toolId": "mcp.tool:docs.load.fetch",
+                    "arguments": {"encoding": "utf-8"},
+                },
+            }
+        )
+    )
+    assert stdio_payload["result"]["ok"] is False
+    assert stdio_payload["result"]["error"]["code"] == "INVALID_INPUT"
+    assert stdio_payload["result"]["error"]["details"]["stage"] == "input"

--- a/tests/unit/mcp/test_mcp_service.py
+++ b/tests/unit/mcp/test_mcp_service.py
@@ -121,5 +121,7 @@ def test_invoke_tool_invalid_payload_returns_error(service: McpService) -> None:
     )
     payload = envelope.model_dump(by_alias=True)
     assert payload["ok"] is False
-    assert payload["error"]["code"] == "MCP_VALIDATION_ERROR"
+    assert payload["error"]["code"] == "INVALID_INPUT"
+    assert payload["error"]["details"]["stage"] == "input"
+    assert payload["error"]["details"]["missing"] == ["path"]
     assert "path" in payload["error"]["message"].lower()

--- a/tests/unit/test_envelope_schema_validation.py
+++ b/tests/unit/test_envelope_schema_validation.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+pytest.importorskip("pydantic")
+
+from apps.mcp_server.service.envelope import Envelope, EnvelopeMeta
+from apps.mcp_server.service.mcp_service import McpService, RequestContext
+
+SCHEMA_DIR = Path("apps/mcp_server/schemas/mcp")
+TOOLPACKS_DIR = Path("apps/mcp_server/toolpacks")
+PROMPTS_DIR = Path("apps/mcp_server/prompts")
+
+
+@pytest.fixture(autouse=True)
+def _seed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAGX_SEED", "41")
+
+
+@pytest.fixture
+def envelope_validator() -> Draft202012Validator:
+    schema_path = SCHEMA_DIR / "envelope.schema.json"
+    if not schema_path.exists():
+        pytest.fail(f"Missing envelope schema: {schema_path}")
+    with schema_path.open("r", encoding="utf-8") as handle:
+        schema = json.load(handle)
+    validator = Draft202012Validator(schema)
+    validator.check_schema(schema)
+    return validator
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> McpService:
+    return McpService.create(
+        toolpacks_dir=TOOLPACKS_DIR,
+        prompts_dir=PROMPTS_DIR,
+        schema_dir=SCHEMA_DIR,
+        log_dir=tmp_path / "logs",
+        schema_version="0.1.0",
+    )
+
+
+def _context(route: str) -> RequestContext:
+    return RequestContext(
+        transport="http",
+        route=route,
+        method={
+            "discover": "mcp.discover",
+            "prompt": "mcp.prompt.get",
+            "tool": "mcp.tool.invoke",
+        }[route],
+        deterministic_ids=True,
+    )
+
+
+def test_envelope_schema_rejects_negative_duration(envelope_validator: Draft202012Validator) -> None:
+    envelope = Envelope.success(
+        data={"status": "ok"},
+        meta=EnvelopeMeta(
+            request_id="req-123",
+            trace_id="trace-456",
+            span_id="span-789",
+            schema_version="0.1.0",
+            deterministic=True,
+            transport="http",
+            route="tool",
+            method="mcp.tool.invoke",
+            duration_ms=-1.0,
+            status="ok",
+            attempt=0,
+            input_bytes=0,
+            output_bytes=0,
+        ),
+    )
+    payload = envelope.model_dump(by_alias=True)
+    with pytest.raises(ValidationError):
+        envelope_validator.validate(payload)
+
+
+def test_tool_output_schema_violation_returns_internal_error(
+    service: McpService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module_path = "apps.toolpacks.python.core.docs.load_fetch"
+    module = pytest.importorskip(module_path)
+
+    def _invalid_run(payload: Mapping[str, Any]) -> dict[str, Any]:
+        return {"metadata": {}, "stats": {"bytes": 0}}
+
+    monkeypatch.setattr(module, "run", _invalid_run)
+    # Ensure deterministic cache does not return a previously materialised value.
+    service._executor._cache.clear()  # type: ignore[attr-defined]
+
+    fixture_path = Path("tests/fixtures/mcp/docs/sample_article.md")
+    context = _context("tool")
+    envelope = service.invoke_tool(
+        tool_id="mcp.tool:docs.load.fetch",
+        arguments={"path": str(fixture_path)},
+        context=context,
+    )
+
+    payload = envelope.model_dump(by_alias=True)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "INTERNAL"
+    assert payload["error"]["details"]["stage"] == "output"
+    assert "document" in payload["error"]["message"].lower()
+    assert payload["meta"]["status"] == "error"


### PR DESCRIPTION
## Summary
- map MCP schema validation failures to canonical error codes and HTTP statuses while propagating structured details in envelopes
- add a ToolpackValidationFailure exception to capture stage-specific schema errors and feed _error_response
- add unit and end-to-end tests covering envelope schema checks and transport parity for invalid tool payloads

## Testing
- pytest tests/unit/test_envelope_schema_validation.py tests/unit/mcp/test_mcp_service.py tests/e2e/test_mcp_envelope_validation.py
- pytest tests/unit/mcp


------
https://chatgpt.com/codex/tasks/task_e_68dfdb487adc832cbb7ce7cb770eda24