### PR TITLE
Fix isinstance union checks for Python 3.12 compatibility

### DIFF
--- a/apps/toolpacks/python/core/exports/render_markdown.py
+++ b/apps/toolpacks/python/core/exports/render_markdown.py
@@ -14,7 +14,7 @@ def _render_template(template: str, context: Mapping[str, Any]) -> str:
     def replacer(match: re.Match[str]) -> str:
         key = match.group(1)
         value = context.get(key)
-        if isinstance(value, str | int | float):
+        if isinstance(value, (str, int, float)):
             return str(value)
         if value is None:
             return ""
@@ -39,7 +39,7 @@ def run(payload: Mapping[str, Any]) -> dict[str, Any]:
     front_matter = _front_matter(payload)
     context: dict[str, Any] = {"title": title, "body": body}
     for key, value in front_matter.items():
-        if isinstance(value, str | int | float):
+        if isinstance(value, (str, int, float)):
             context.setdefault(key, value)
     rendered = _render_template(template, context)
 

--- a/scripts/codex_next_tasks.py
+++ b/scripts/codex_next_tasks.py
@@ -47,7 +47,7 @@ def _coerce_title(raw: object, fallback: str) -> str:
 
 
 def _coerce_component_ids(raw: object) -> tuple[str, ...]:
-    if isinstance(raw, Iterable) and not isinstance(raw, str | bytes):
+    if isinstance(raw, Iterable) and not isinstance(raw, (str, bytes)):
         return tuple(str(item) for item in raw)
     return ()
 

--- a/tests/unit/test_toolpacks_exec_python.py
+++ b/tests/unit/test_toolpacks_exec_python.py
@@ -54,7 +54,7 @@ def test_exec_python_toolpack_runs_callable(monkeypatch: pytest.MonkeyPatch) -> 
     def run(payload: dict[str, object]) -> dict[str, object]:
         captured.append(payload)
         value = payload["value"]
-        assert isinstance(value, int | float)
+        assert isinstance(value, (int, float))
         return {"result": value * 2}
 
     module_name = "toolpacks_tests.runtime"


### PR DESCRIPTION
## Summary
- replace union types in `isinstance` checks with tuples to maintain compatibility with Python 3.12 and earlier
- update the codex next tasks script and associated unit test to use tuple-based `isinstance` guards

## Testing
- pytest tests/unit/test_toolpacks_exec_python.py

------
https://chatgpt.com/codex/tasks/task_e_68e088329160832cbcc64f51a43ffb6e