### PR TITLE
Fix HTTP deterministic IDs and run MCP server on main thread

### DIFF
--- a/apps/mcp_server/http/main.py
+++ b/apps/mcp_server/http/main.py
@@ -9,11 +9,16 @@ from .routes import build_router
 __all__ = ["create_app"]
 
 
-def create_app(service: McpService, *, enable_openapi: bool = False) -> FastAPI:
+def create_app(
+    service: McpService,
+    *,
+    enable_openapi: bool = False,
+    deterministic_ids: bool = False,
+) -> FastAPI:
     """Return a FastAPI application exposing the MCP HTTP endpoints."""
 
     docs_url = "/docs" if enable_openapi else None
     openapi_url = "/openapi.json" if enable_openapi else None
     app = FastAPI(title="RAGX MCP Server", docs_url=docs_url, openapi_url=openapi_url)
-    app.include_router(build_router(service))
+    app.include_router(build_router(service, deterministic_ids=deterministic_ids))
     return app

--- a/apps/mcp_server/http/routes.py
+++ b/apps/mcp_server/http/routes.py
@@ -14,24 +14,32 @@ class ToolInvocationPayload(BaseModel):
     arguments: dict[str, Any] = {}
 
 
-def build_router(service: McpService) -> APIRouter:
+def build_router(service: McpService, *, deterministic_ids: bool = False) -> APIRouter:
     router = APIRouter()
+
+    def _context(route: str, method: str) -> RequestContext:
+        return RequestContext(
+            transport="http",
+            route=route,
+            method=method,
+            deterministic_ids=deterministic_ids,
+        )
 
     @router.get("/mcp/discover")
     def discover() -> dict[str, Any]:
-        context = RequestContext(transport="http", route="discover", method="mcp.discover")
+        context = _context("discover", "mcp.discover")
         envelope = service.discover(context)
         return envelope.model_dump(by_alias=True)
 
     @router.get("/mcp/prompt/{prompt_id}")
     def get_prompt(prompt_id: str) -> dict[str, Any]:
-        context = RequestContext(transport="http", route="prompt", method="mcp.prompt.get")
+        context = _context("prompt", "mcp.prompt.get")
         envelope = service.get_prompt(prompt_id, context)
         return envelope.model_dump(by_alias=True)
 
     @router.post("/mcp/tool/{tool_id}")
     def invoke_tool(tool_id: str, payload: ToolInvocationPayload) -> dict[str, Any]:
-        context = RequestContext(transport="http", route="tool", method="mcp.tool.invoke")
+        context = _context("tool", "mcp.tool.invoke")
         envelope = service.invoke_tool(
             tool_id=tool_id,
             arguments=payload.arguments,
@@ -41,7 +49,7 @@ def build_router(service: McpService) -> APIRouter:
 
     @router.get("/healthz")
     def health() -> dict[str, Any]:
-        context = RequestContext(transport="http", route="health", method="mcp.health")
+        context = _context("health", "mcp.health")
         return service.health(context)
 
     return router


### PR DESCRIPTION
## Summary
- propagate the deterministic ID configuration through the HTTP FastAPI stack so request contexts and envelopes match STDIO behaviour
- expose the deterministic flag on create_app/build_router and add coverage to assert deterministic IDs across transports
- start the uvicorn HTTP server on the main thread when STDIO is disabled to avoid signal handling errors

## Testing
- pytest tests/unit/mcp/test_http_transport.py tests/integration/mcp/test_transport_parity.py tests/integration/mcp/test_http_endpoints_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68e08c3d9f9c832c82746c966ef16466