### PR TITLE
Harden STDIO JSON-RPC parameter validation

### DIFF
--- a/apps/mcp_server/stdio/server.py
+++ b/apps/mcp_server/stdio/server.py
@@ -17,10 +17,33 @@ class JsonRpcStdioServer:
         self._service = service
         self._deterministic_ids = deterministic_ids
 
-    async def handle_request(self, message: Mapping[str, Any]) -> dict[str, Any]:
+    def _error_response(
+        self, *, code: int, message: str, request_id: Any | None
+    ) -> dict[str, Any]:
+        response: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "error": {"code": code, "message": message},
+            "id": request_id if request_id is not None else None,
+        }
+        return response
+
+    async def handle_request(self, message: Mapping[str, Any] | Any) -> dict[str, Any]:
+        if not isinstance(message, Mapping):
+            return self._error_response(code=-32600, message="Invalid request", request_id=None)
+
         method = str(message.get("method", ""))
         request_id = message.get("id")
-        params = message.get("params") or {}
+        raw_params = message.get("params")
+        if raw_params is None:
+            params: Mapping[str, Any] = {}
+        elif isinstance(raw_params, Mapping):
+            params = raw_params
+        else:
+            return self._error_response(
+                code=-32602,
+                message="Invalid params: expected object",
+                request_id=request_id,
+            )
         if method == "mcp.discover":
             context = RequestContext(
                 transport="stdio",
@@ -32,7 +55,49 @@ class JsonRpcStdioServer:
             result = envelope.model_dump(by_alias=True)
             response: dict[str, Any] = {"jsonrpc": "2.0", "result": result}
         elif method == "mcp.prompt.get":
-            prompt_id = str(params.get("promptId", ""))
+            prompt_id_value = params.get("promptId")
+            if prompt_id_value is not None and not isinstance(prompt_id_value, str):
+                return self._error_response(
+                    code=-32602,
+                    message="Invalid params: promptId must be a string",
+                    request_id=request_id,
+                )
+
+            major_value = params.get("major")
+            major: int | None
+            if major_value is None:
+                major = None
+            else:
+                try:
+                    major = int(major_value)
+                except (TypeError, ValueError):
+                    return self._error_response(
+                        code=-32602,
+                        message="Invalid params: major must be an integer",
+                        request_id=request_id,
+                    )
+
+            if prompt_id_value:
+                prompt_id = prompt_id_value if isinstance(prompt_id_value, str) else ""
+                if major is not None:
+                    base_id = prompt_id.split("@", 1)[0]
+                    prompt_id = f"{base_id}@{major}"
+            else:
+                domain = params.get("domain")
+                name = params.get("name")
+                if not (
+                    isinstance(domain, str)
+                    and domain
+                    and isinstance(name, str)
+                    and name
+                    and major is not None
+                ):
+                    return self._error_response(
+                        code=-32602,
+                        message="Invalid params: provide promptId or domain/name/major",
+                        request_id=request_id,
+                    )
+                prompt_id = f"{domain}.{name}@{major}"
             context = RequestContext(
                 transport="stdio",
                 route="prompt",
@@ -44,7 +109,17 @@ class JsonRpcStdioServer:
             response = {"jsonrpc": "2.0", "result": result}
         elif method == "mcp.tool.invoke":
             tool_id = str(params.get("toolId", ""))
-            arguments = params.get("arguments") or {}
+            arguments_value = params.get("arguments")
+            if arguments_value is None:
+                arguments = {}
+            elif isinstance(arguments_value, Mapping):
+                arguments = arguments_value
+            else:
+                return self._error_response(
+                    code=-32602,
+                    message="Invalid params: arguments must be an object",
+                    request_id=request_id,
+                )
             context = RequestContext(
                 transport="stdio",
                 route="tool",
@@ -92,6 +167,13 @@ class JsonRpcStdioServer:
                     "jsonrpc": "2.0",
                     "error": {"code": -32700, "message": "Invalid JSON"},
                 }
+                writer.write((json.dumps(error) + "\n").encode("utf-8"))
+                await writer.drain()
+                continue
+            if not isinstance(message, Mapping):
+                error = self._error_response(
+                    code=-32600, message="Invalid request", request_id=None
+                )
                 writer.write((json.dumps(error) + "\n").encode("utf-8"))
                 await writer.drain()
                 continue

--- a/tests/unit/mcp/test_stdio_transport.py
+++ b/tests/unit/mcp/test_stdio_transport.py
@@ -64,6 +64,19 @@ def test_stdio_tool_invoke(server: JsonRpcStdioServer) -> None:
     assert response["result"]["data"]["result"]["document"]["path"].endswith("sample_article.md")
 
 
+def test_stdio_prompt_get_accepts_string_major(server: JsonRpcStdioServer) -> None:
+    response = asyncio.run(
+        server.handle_request(
+            _request(
+                "mcp.prompt.get",
+                params={"promptId": "core.generic.bootstrap", "major": "1"},
+            )
+        )
+    )
+    assert response["result"]["ok"] is True
+    assert response["result"]["data"]["id"] == "core.generic.bootstrap@1"
+
+
 def test_stdio_cancel_notification(server: JsonRpcStdioServer) -> None:
     response = asyncio.run(
         server.handle_notification(
@@ -71,3 +84,26 @@ def test_stdio_cancel_notification(server: JsonRpcStdioServer) -> None:
         )
     )
     assert response is None
+
+
+def test_stdio_rejects_positional_params(server: JsonRpcStdioServer) -> None:
+    response = asyncio.run(
+        server.handle_request(
+            {"jsonrpc": "2.0", "id": "req-1", "method": "mcp.tool.invoke", "params": ["foo"]}
+        )
+    )
+    assert response["error"]["code"] == -32602
+    assert response["id"] == "req-1"
+
+
+def test_stdio_prompt_get_rejects_non_integer_major(server: JsonRpcStdioServer) -> None:
+    response = asyncio.run(
+        server.handle_request(
+            _request(
+                "mcp.prompt.get",
+                params={"promptId": "core.generic.bootstrap", "major": "foo"},
+            )
+        )
+    )
+    assert response["error"]["code"] == -32602
+    assert response["id"] == "req-1"


### PR DESCRIPTION
## Summary
- guard STDIO JSON-RPC requests against non-object payloads and invalid params
- normalise prompt major selection while returning invalid_params for non-integer values
- extend STDIO transport unit tests to cover positional params and prompt major coercion

## Testing
- pytest tests/unit/mcp/test_stdio_transport.py
- ruff check apps/mcp_server/stdio/server.py tests/unit/mcp/test_stdio_transport.py

------
https://chatgpt.com/codex/tasks/task_e_68e08c8e0408832c83aeb3560cfa2d5a