### PR TITLE
Align MCP canonical errors and log retention

### DIFF
--- a/apps/mcp_server/logging.py
+++ b/apps/mcp_server/logging.py
@@ -111,7 +111,18 @@ class JsonLogWriter:
             key=lambda item: (item.stat().st_mtime, item.name),
         )
         excess = len(files) - self._retention
-        for path in files[:max(excess, 0)]:
+        if excess <= 0:
+            return
+
+        deletions: list[Path] = []
+        for path in files:
+            if path == self._path:
+                continue
+            deletions.append(path)
+            if len(deletions) >= excess:
+                break
+
+        for path in deletions:
             try:
                 path.unlink()
             except OSError:

--- a/apps/mcp_server/service/mcp_service.py
+++ b/apps/mcp_server/service/mcp_service.py
@@ -324,7 +324,7 @@ class McpService:
             prompt = self._prompts.get(prompt_id)
         except KeyError:
             return self._error_response(
-                code="MCP_UNKNOWN_PROMPT",
+                code="NOT_FOUND",
                 message=f"Prompt '{prompt_id}' not found",
                 context=ctx,
                 payload=payload,
@@ -345,7 +345,7 @@ class McpService:
         ctx = self._normalise_context(context, "tool", "mcp.tool.invoke", payload)
         if tool_id not in self._toolpacks:
             return self._error_response(
-                code="MCP_UNKNOWN_TOOL",
+                code="NOT_FOUND",
                 message=f"Tool '{tool_id}' not found",
                 context=ctx,
                 payload=payload,
@@ -375,7 +375,7 @@ class McpService:
             result = self._executor.run_toolpack(toolpack, arguments)
         except ToolpackExecutionError as exc:
             return self._error_response(
-                code="MCP_VALIDATION_ERROR",
+                code="INTERNAL_ERROR",
                 message=str(exc),
                 context=ctx,
                 payload=payload,

--- a/tests/unit/mcp/test_http_transport.py
+++ b/tests/unit/mcp/test_http_transport.py
@@ -59,6 +59,13 @@ def test_http_prompt_endpoint(client: TestClient) -> None:
     assert payload["data"]["id"] == "core.generic.bootstrap@1"
 
 
+def test_http_prompt_not_found_returns_404(client: TestClient) -> None:
+    response = client.get("/mcp/prompt/unknown.prompt@1")
+    assert response.status_code == 404
+    payload = response.json()
+    assert payload["error"]["code"] == "NOT_FOUND"
+
+
 def test_http_tool_endpoint(client: TestClient) -> None:
     fixture_path = Path("tests/fixtures/mcp/docs/sample_article.md")
     response = client.post(
@@ -69,6 +76,23 @@ def test_http_tool_endpoint(client: TestClient) -> None:
     payload = response.json()
     assert payload["ok"] is True
     assert payload["data"]["result"]["document"]["path"].endswith("sample_article.md")
+
+
+def test_http_tool_not_found_returns_404(client: TestClient) -> None:
+    response = client.post("/mcp/tool/mcp.tool:missing.tool", json={"arguments": {}})
+    assert response.status_code == 404
+    payload = response.json()
+    assert payload["error"]["code"] == "NOT_FOUND"
+
+
+def test_http_tool_invalid_payload_returns_400(client: TestClient) -> None:
+    response = client.post(
+        "/mcp/tool/mcp.tool:docs.load.fetch",
+        json={"arguments": {"encoding": "utf-8"}},
+    )
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["error"]["code"] == "INVALID_INPUT"
 
 
 def test_http_health_endpoint(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- use canonical NOT_FOUND and INTERNAL_ERROR codes from the MCP service so HTTP/STDIO transports surface the expected metadata
- expand unit coverage for service and FastAPI transports to assert canonical error codes and status mappings
- ensure JsonLogWriter retention never deletes the freshly opened log file while pruning older runs

## Testing
- ./scripts/ensure_green.sh


------
https://chatgpt.com/codex/tasks/task_e_68e28f33a42c832c9f293760ac09dc01