### PR TITLE
Fix MCP envelope validation regressions

### DIFF
--- a/apps/mcp_server/validation/schema_registry.py
+++ b/apps/mcp_server/validation/schema_registry.py
@@ -59,12 +59,15 @@ class _ToolPayloadValidator:
         self._payload.validate(payload_value)
 
 
+_MODULE_ROOT = Path(__file__).resolve().parent.parent
+
+
 class SchemaRegistry:
     """Load and cache JSON schema validators for envelopes and tool IO."""
 
-    _DEFAULT_ENVELOPE_SCHEMA = Path("apps/mcp_server/schemas/envelope.schema.json")
+    _DEFAULT_ENVELOPE_SCHEMA = _MODULE_ROOT / "schemas" / "mcp" / "envelope.schema.json"
     _DEFAULT_TOOL_IO_SCHEMA = Path("codex/specs/schemas/tool_io.schema.json")
-    _DEFAULT_TOOL_SCHEMA_ROOT = Path("apps/mcp_server/schemas/tools")
+    _DEFAULT_TOOL_SCHEMA_ROOT = _MODULE_ROOT / "schemas" / "tools"
 
     def __init__(
         self,

--- a/codex/specs/schemas/envelope.schema.json
+++ b/codex/specs/schemas/envelope.schema.json
@@ -3,12 +3,14 @@
   "$id": "https://spec.ragx.ai/mcp/envelope.schema.json",
   "title": "RAGX MCP Envelope",
   "type": "object",
+  "$comment": "JSON-RPC requests and notifications share this envelope. Notifications omit 'id'.",
   "additionalProperties": false,
-  "required": ["id", "jsonrpc", "method", "params"],
+  "required": ["jsonrpc", "method", "params"],
   "properties": {
     "id": {
       "description": "Deterministic request identifier (UUID or stable string).",
-      "type": ["string", "integer"]
+      "$comment": "When absent the envelope is treated as a notification.",
+      "type": ["string", "integer", "null"]
     },
     "jsonrpc": {
       "description": "JSON-RPC protocol version indicator.",


### PR DESCRIPTION
## Summary
- point the schema registry at the MCP response envelope schema and resolve paths relative to the module
- rebuild JSON-RPC error payloads from immutable templates to avoid shared state mutation
- relax the JSON-RPC envelope schema so notifications can omit `id`

## Testing
- pytest tests/unit/test_canonical_error_mapping.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a4cae48c832c90f82eb3ebbbc332