### PR TITLE
Add telemetry metadata and guardrails to MCP tool transport

### DIFF
--- a/apps/mcp_server/cli.py
+++ b/apps/mcp_server/cli.py
@@ -66,6 +66,24 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="runs",
         help="Directory for structured logs",
     )
+    parser.add_argument(
+        "--max-input-bytes",
+        type=int,
+        default=None,
+        help="Global maximum allowed input payload size in bytes",
+    )
+    parser.add_argument(
+        "--max-output-bytes",
+        type=int,
+        default=None,
+        help="Global maximum allowed output payload size in bytes",
+    )
+    parser.add_argument(
+        "--timeout-ms",
+        type=int,
+        default=None,
+        help="Global timeout budget per tool invocation",
+    )
     return parser.parse_args(argv)
 
 
@@ -108,6 +126,9 @@ async def _run_server(args: argparse.Namespace) -> None:
         schema_dir=schema_dir,
         log_dir=log_dir,
         deterministic_logs=args.deterministic_ids,
+        max_input_bytes=args.max_input_bytes,
+        max_output_bytes=args.max_output_bytes,
+        timeout_ms=args.timeout_ms,
     )
 
     if args.once:

--- a/apps/mcp_server/schemas/envelope.schema.json
+++ b/apps/mcp_server/schemas/envelope.schema.json
@@ -34,7 +34,9 @@
         "status",
         "attempt",
         "inputBytes",
-        "outputBytes"
+        "outputBytes",
+        "execution",
+        "idempotency"
       ],
       "properties": {
         "requestId": {"type": "string"},
@@ -51,7 +53,26 @@
         "inputBytes": {"type": "integer", "minimum": 0},
         "outputBytes": {"type": "integer", "minimum": 0},
         "toolId": {"type": ["string", "null"]},
-        "promptId": {"type": ["string", "null"]}
+        "promptId": {"type": ["string", "null"]},
+        "execution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["durationMs", "inputBytes", "outputBytes"],
+          "properties": {
+            "durationMs": {"type": "number", "minimum": 0},
+            "inputBytes": {"type": "integer", "minimum": 0},
+            "outputBytes": {"type": "integer", "minimum": 0}
+          }
+        },
+        "idempotency": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["cacheHit"],
+          "properties": {
+            "cacheHit": {"type": "boolean"},
+            "cacheKey": {"type": ["string", "null"]}
+          }
+        }
       }
     }
   },

--- a/apps/mcp_server/schemas/mcp/envelope.schema.json
+++ b/apps/mcp_server/schemas/mcp/envelope.schema.json
@@ -34,7 +34,9 @@
         "status",
         "attempt",
         "inputBytes",
-        "outputBytes"
+        "outputBytes",
+        "execution",
+        "idempotency"
       ],
       "properties": {
         "requestId": {"type": "string"},
@@ -51,7 +53,26 @@
         "inputBytes": {"type": "integer", "minimum": 0},
         "outputBytes": {"type": "integer", "minimum": 0},
         "toolId": {"type": ["string", "null"]},
-        "promptId": {"type": ["string", "null"]}
+        "promptId": {"type": ["string", "null"]},
+        "execution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["durationMs", "inputBytes", "outputBytes"],
+          "properties": {
+            "durationMs": {"type": "number", "minimum": 0},
+            "inputBytes": {"type": "integer", "minimum": 0},
+            "outputBytes": {"type": "integer", "minimum": 0}
+          }
+        },
+        "idempotency": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["cacheHit"],
+          "properties": {
+            "cacheHit": {"type": "boolean"},
+            "cacheKey": {"type": ["string", "null"]}
+          }
+        }
       }
     }
   },

--- a/apps/mcp_server/service/errors.py
+++ b/apps/mcp_server/service/errors.py
@@ -83,6 +83,14 @@ class CanonicalError:
             -32603,
             "Internal server error",
         ),
+        _CanonicalSpec(
+            "TIMEOUT",
+            "Tool invocation exceeded its allotted time budget",
+            True,
+            504,
+            -32005,
+            "Timeout",
+        ),
     )
 
     _HTTP_STATUS_MAP: dict[str, int] = {spec.code: spec.http_status for spec in _SPECS}

--- a/tests/integration/mcp/test_tool_invocation_guardrails.py
+++ b/tests/integration/mcp/test_tool_invocation_guardrails.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+
+from apps.mcp_server.service.mcp_service import McpService, RequestContext
+
+SCHEMA_DIR = Path("apps/mcp_server/schemas/mcp")
+TOOLPACKS_DIR = Path("apps/mcp_server/toolpacks")
+PROMPTS_DIR = Path("apps/mcp_server/prompts")
+
+
+@pytest.fixture(autouse=True)
+def _seed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAGX_SEED", "7")
+
+
+@pytest.fixture
+def limited_service(tmp_path: Path) -> McpService:
+    return McpService.create(
+        toolpacks_dir=TOOLPACKS_DIR,
+        prompts_dir=PROMPTS_DIR,
+        schema_dir=SCHEMA_DIR,
+        log_dir=tmp_path / "runs",
+        schema_version="0.1.0",
+        deterministic_logs=True,
+        max_input_bytes=128,
+        max_output_bytes=128,
+        timeout_ms=25,
+    )
+
+
+def _context() -> RequestContext:
+    return RequestContext(
+        transport="http",
+        route="tool",
+        method="mcp.tool.invoke",
+        deterministic_ids=True,
+    )
+
+
+def test_invoke_tool_rejects_oversized_input(limited_service: McpService) -> None:
+    arguments = {
+        "title": "Telemetry",
+        "template": "{{ title }}" + "x" * 512,
+    }
+    envelope = limited_service.invoke_tool(
+        tool_id="mcp.tool:exports.render.markdown",
+        arguments=arguments,
+        context=_context(),
+    )
+
+    assert envelope.ok is False
+    assert envelope.error is not None
+    assert envelope.error.code == "INVALID_INPUT"
+    meta = envelope.model_dump(by_alias=True)["meta"]
+    assert meta["execution"]["inputBytes"] > 128
+    assert meta["execution"]["outputBytes"] == 0
+    assert meta["idempotency"]["cacheHit"] is False
+
+
+def test_invoke_tool_clamps_oversized_output(
+    limited_service: McpService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stats = types.SimpleNamespace(
+        duration_ms=4.0,
+        input_bytes=24,
+        output_bytes=512,
+        cache_hit=False,
+        cache_key="stub",
+    )
+
+    class StubExecutor:
+        def run_toolpack(self, toolpack, payload):  # type: ignore[no-untyped-def]
+            return {"ok": True}
+
+        def last_run_stats(self):  # type: ignore[no-untyped-def]
+            return stats
+
+    monkeypatch.setattr(limited_service, "_executor", StubExecutor())
+
+    envelope = limited_service.invoke_tool(
+        tool_id="mcp.tool:docs.load.fetch",
+        arguments={"path": "ignored"},
+        context=_context(),
+    )
+
+    assert envelope.ok is False
+    assert envelope.error is not None
+    assert envelope.error.code == "INVALID_OUTPUT"
+    meta = envelope.model_dump(by_alias=True)["meta"]
+    assert meta["execution"]["outputBytes"] == stats.output_bytes
+    assert meta["idempotency"]["cacheHit"] is False
+
+
+def test_invoke_tool_flags_timeouts(
+    limited_service: McpService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stats = types.SimpleNamespace(
+        duration_ms=128.0,
+        input_bytes=24,
+        output_bytes=16,
+        cache_hit=False,
+        cache_key="slow",
+    )
+
+    class SlowExecutor:
+        def run_toolpack(self, toolpack, payload):  # type: ignore[no-untyped-def]
+            return {"ok": True}
+
+        def last_run_stats(self):  # type: ignore[no-untyped-def]
+            return stats
+
+    monkeypatch.setattr(limited_service, "_executor", SlowExecutor())
+
+    envelope = limited_service.invoke_tool(
+        tool_id="mcp.tool:docs.load.fetch",
+        arguments={"path": "ignored"},
+        context=_context(),
+    )
+
+    assert envelope.ok is False
+    assert envelope.error is not None
+    assert envelope.error.code == "TIMEOUT"
+    meta = envelope.model_dump(by_alias=True)["meta"]
+    assert meta["execution"]["durationMs"] == pytest.approx(stats.duration_ms)
+    assert meta["idempotency"]["cacheHit"] is False

--- a/tests/unit/mcp/test_envelope_schema.py
+++ b/tests/unit/mcp/test_envelope_schema.py
@@ -8,7 +8,13 @@ from jsonschema import Draft202012Validator
 
 pytest.importorskip("pydantic")
 
-from apps.mcp_server.service.envelope import Envelope, EnvelopeError, EnvelopeMeta
+from apps.mcp_server.service.envelope import (
+    Envelope,
+    EnvelopeError,
+    EnvelopeMeta,
+    ExecutionMeta,
+    IdempotencyMeta,
+)
 
 SCHEMA_PATH = Path("apps/mcp_server/schemas/mcp/envelope.schema.json")
 
@@ -44,6 +50,8 @@ def test_envelope_success_matches_schema() -> None:
             attempt=0,
             input_bytes=0,
             output_bytes=0,
+            execution=ExecutionMeta(durationMs=12.5, inputBytes=0, outputBytes=0),
+            idempotency=IdempotencyMeta(cacheHit=False, cacheKey=None),
         ),
     )
     payload = envelope.model_dump(by_alias=True)
@@ -70,6 +78,8 @@ def test_envelope_error_includes_details() -> None:
             attempt=0,
             input_bytes=0,
             output_bytes=0,
+            execution=ExecutionMeta(durationMs=3.4, inputBytes=0, outputBytes=0),
+            idempotency=IdempotencyMeta(cacheHit=False, cacheKey=None),
         ),
     )
     payload = envelope.model_dump(by_alias=True)
@@ -98,6 +108,8 @@ def test_envelope_serialises_optional_metadata() -> None:
             input_bytes=0,
             output_bytes=0,
             prompt_id="core.generic.welcome@1",
+            execution=ExecutionMeta(durationMs=1.23, inputBytes=0, outputBytes=0),
+            idempotency=IdempotencyMeta(cacheHit=False, cacheKey=None),
         ),
     )
     payload = envelope.model_dump(by_alias=True)

--- a/tests/unit/test_canonical_error_mapping.py
+++ b/tests/unit/test_canonical_error_mapping.py
@@ -11,6 +11,7 @@ EXPECTED_CODES = [
     "NOT_FOUND",
     "UNAUTHORIZED",
     "INTERNAL_ERROR",
+    "TIMEOUT",
 ]
 
 HTTP_STATUS_EXPECTATIONS = {
@@ -19,6 +20,7 @@ HTTP_STATUS_EXPECTATIONS = {
     "NOT_FOUND": 404,
     "UNAUTHORIZED": 401,
     "INTERNAL_ERROR": 500,
+    "TIMEOUT": 504,
 }
 
 JSONRPC_EXPECTATIONS = {
@@ -27,6 +29,7 @@ JSONRPC_EXPECTATIONS = {
     "NOT_FOUND": (-32004, "not found"),
     "UNAUTHORIZED": (-32001, "unauthorized"),
     "INTERNAL_ERROR": (-32603, "internal server error"),
+    "TIMEOUT": (-32005, "timeout"),
 }
 
 


### PR DESCRIPTION
## Summary
- capture execution metrics in the toolpack executor and surface cache hits
- enrich MCP envelopes/logs with execution/idempotency metadata while enforcing byte/time limits
- extend CLI flags and add transport parity plus guardrail tests for the unified MCP transport

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68e7909aaf28832caf13523c0d2a6881