### PR TITLE
Avoid shared executor stats across tool invocations

### DIFF
--- a/apps/mcp_server/service/mcp_service.py
+++ b/apps/mcp_server/service/mcp_service.py
@@ -425,7 +425,7 @@ class McpService:
                         tool_id=tool_id,
                     )
         try:
-            result = self._executor.run_toolpack(toolpack, arguments)
+            result, stats = self._executor.run_toolpack_with_stats(toolpack, arguments)
         except ToolpackExecutionError as exc:
             return self._error_response(
                 code="INTERNAL_ERROR",
@@ -433,14 +433,6 @@ class McpService:
                 context=ctx,
                 payload=payload,
                 tool_id=tool_id,
-            )
-        stats = self._executor.last_run_stats()
-        if stats is None:
-            stats = ExecutionStats(
-                duration_ms=_duration_ms(ctx.start_time),
-                input_bytes=ids["input_bytes"],
-                output_bytes=_payload_size(result),
-                cache_hit=False,
             )
         effective_timeout = min(self._limits.timeout_ms, toolpack.timeout_ms)
         if stats.duration_ms > effective_timeout:

--- a/docs/toolpacks_executor.md
+++ b/docs/toolpacks_executor.md
@@ -20,6 +20,14 @@ result = executor.run_toolpack(pack, {"text": "hello"})
 print(result["text"])
 ```
 
+To capture execution metrics alongside the payload, use
+`run_toolpack_with_stats`:
+
+```python
+result, stats = executor.run_toolpack_with_stats(pack, {"text": "hello"})
+print(result["text"], stats.duration_ms)
+```
+
 ## Behaviour
 
 - Only `execution.kind: python` toolpacks are supported. Other kinds raise
@@ -30,6 +38,8 @@ print(result["text"])
 - Deterministic toolpacks (`deterministic: true`) are cached by a SHA-256 hash
   of `id`, `version`, and the normalised input payload. Each cache hit returns a
   fresh deep copy, keeping results immutable to the caller.
+- `run_toolpack_with_stats` returns an `ExecutionStats` instance describing the
+  duration, payload sizes, and cache-hit status for the invocation.
 - Non-deterministic toolpacks bypass the cache entirely.
 - Handlers are resolved via the `execution.module` field using the
   `module:callable` convention. Invalid formats, missing modules, missing

--- a/tests/unit/mcp/test_mcp_service.py
+++ b/tests/unit/mcp/test_mcp_service.py
@@ -154,7 +154,7 @@ def test_invoke_tool_execution_error_returns_internal_error(
     def _raise(*_: Any, **__: Any) -> None:
         raise ToolpackExecutionError("boom")
 
-    monkeypatch.setattr(service._executor, "run_toolpack", _raise)
+    monkeypatch.setattr(service._executor, "run_toolpack_with_stats", _raise)
     fixture_path = Path("tests/fixtures/mcp/docs/sample_article.md")
     envelope = service.invoke_tool(
         tool_id="mcp.tool:docs.load.fetch",

--- a/tests/unit/mcp/test_mcp_service_guardrails.py
+++ b/tests/unit/mcp/test_mcp_service_guardrails.py
@@ -77,22 +77,23 @@ class _ServerLogStub:
 class _QueueExecutor:
     def __init__(self) -> None:
         self._queue: list[tuple[dict[str, Any], ExecutionStats]] = []
-        self._last_stats: ExecutionStats | None = None
         self.calls: list[tuple[Toolpack, Mapping[str, Any]]] = []
 
     def queue(self, result: Mapping[str, Any], stats: ExecutionStats) -> None:
         self._queue.append((dict(result), stats))
 
-    def run_toolpack(self, toolpack: Toolpack, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    def run_toolpack_with_stats(
+        self, toolpack: Toolpack, payload: Mapping[str, Any]
+    ) -> tuple[Mapping[str, Any], ExecutionStats]:
         self.calls.append((toolpack, dict(payload)))
         if not self._queue:
             raise AssertionError("Executor queue exhausted")
         result, stats = self._queue.pop(0)
-        self._last_stats = stats
-        return result
+        return result, stats
 
-    def last_run_stats(self) -> ExecutionStats | None:
-        return self._last_stats
+    def run_toolpack(self, toolpack: Toolpack, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        result, _ = self.run_toolpack_with_stats(toolpack, payload)
+        return result
 
 
 @pytest.fixture

--- a/tests/unit/toolpacks/test_executor_stats.py
+++ b/tests/unit/toolpacks/test_executor_stats.py
@@ -54,11 +54,10 @@ def test_executor_records_duration_and_bytes(sample_toolpack: Toolpack) -> None:
     executor = Executor()
     payload = {"text": "hello"}
 
-    result = executor.run_toolpack(sample_toolpack, payload)
+    result, stats = executor.run_toolpack_with_stats(sample_toolpack, payload)
 
     assert result["echo"]["text"] == "hello"
 
-    stats = executor.last_run_stats()
     assert isinstance(stats, ExecutionStats)
     assert stats.cache_hit is False
     assert stats.input_bytes == _canonical_size(payload)
@@ -70,18 +69,16 @@ def test_executor_reports_cache_hit_on_deterministic_toolpack(sample_toolpack: T
     executor = Executor()
     payload = {"text": "cached"}
 
-    first = executor.run_toolpack(sample_toolpack, payload)
-    first_stats = executor.last_run_stats()
+    first, first_stats = executor.run_toolpack_with_stats(sample_toolpack, payload)
     assert isinstance(first_stats, ExecutionStats)
     assert first_stats.cache_hit is False
 
     # Sleep to ensure measurable elapsed time even for cached hits.
     time.sleep(0.01)
 
-    second = executor.run_toolpack(sample_toolpack, payload)
+    second, second_stats = executor.run_toolpack_with_stats(sample_toolpack, payload)
     assert second == first
 
-    second_stats = executor.last_run_stats()
     assert isinstance(second_stats, ExecutionStats)
     assert second_stats.cache_hit is True
     assert second_stats.input_bytes == first_stats.input_bytes


### PR DESCRIPTION
## Summary
- add an Executor.run_toolpack_with_stats helper that returns per-invocation metrics without shared state
- update the MCP service and associated tests to consume the returned stats directly
- document how to access execution metrics alongside tool outputs

## Testing
- pytest tests/unit/toolpacks/test_executor_stats.py tests/unit/mcp/test_mcp_service_guardrails.py tests/unit/mcp/test_mcp_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e79ea1df38832cb288d0c575bb52c6