### PR TITLE
Preserve STDIO transport metadata in JSON-RPC responses

### DIFF
--- a/apps/mcp_server/stdio/server.py
+++ b/apps/mcp_server/stdio/server.py
@@ -143,9 +143,6 @@ class JsonRpcStdioServer:
     def _build_response(self, envelope) -> dict[str, Any]:
         payload = envelope.model_dump(by_alias=True)
         response: dict[str, Any]
-        meta = payload.get("meta")
-        if isinstance(meta, dict):
-            meta["transport"] = "http"
         if envelope.error is not None:
             try:
                 error_payload = CanonicalError.to_jsonrpc_error(envelope.error.code)

--- a/tests/unit/mcp/test_stdio_transport.py
+++ b/tests/unit/mcp/test_stdio_transport.py
@@ -45,6 +45,7 @@ def test_stdio_discover(server: JsonRpcStdioServer) -> None:
     assert response["id"] == "req-1"
     assert response["result"]["ok"] is True
     assert response["result"]["data"]["prompts"]
+    assert response["result"]["meta"]["transport"] == "stdio"
 
 
 def test_stdio_tool_invoke(server: JsonRpcStdioServer) -> None:


### PR DESCRIPTION
## Summary
- keep the JsonRpcStdioServer from overwriting the envelope transport metadata so STDIO replies stay tagged as stdio
- cover the regression by asserting the transport metadata in the STDIO unit test

## Testing
- pytest tests/unit/mcp/test_stdio_transport.py


------
https://chatgpt.com/codex/tasks/task_e_68e7b7f0f514832c92ff8203127cd7df