### PR TITLE
feat(dsl): implement policy stack resolution and linter

### DIFF
--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,0 +1,20 @@
+"""RAGX DSL runtime package."""
+
+from .linter import FlowLinter, Issue  # noqa: F401
+from .policy import (  # noqa: F401
+    PolicyError,
+    PolicyResolution,
+    PolicyStack,
+    PolicyTraceEvent,
+    PolicyTraceRecorder,
+)
+
+__all__ = [
+    "PolicyError",
+    "PolicyResolution",
+    "PolicyStack",
+    "PolicyTraceEvent",
+    "PolicyTraceRecorder",
+    "Issue",
+    "FlowLinter",
+]

--- a/pkgs/dsl/linter.py
+++ b/pkgs/dsl/linter.py
@@ -1,0 +1,119 @@
+"""Static linter checks for RAGX DSL flows."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+from .policy import PolicyResolution, PolicyStack
+
+
+@dataclass(slots=True)
+class Issue:
+    """Structured linter issue."""
+
+    level: str
+    code: str
+    msg: str
+    path: str
+
+
+class FlowLinter:
+    """Collection of linter rules for DSL flows."""
+
+    def find_unreachable_tools(self, flow: Mapping[str, object]) -> list[Issue]:
+        globals_section = flow.get("globals", {}) if isinstance(flow, Mapping) else {}
+        if isinstance(globals_section, Mapping):
+            tools = globals_section.get("tools", {})
+            tool_sets = globals_section.get("tool_sets", {})
+            global_policy = globals_section.get("policy")
+        else:
+            tools = {}
+            tool_sets = {}
+            global_policy = None
+
+        policy_stack = PolicyStack(tools=tools, tool_sets=tool_sets)
+
+        pushed_global = False
+        if isinstance(global_policy, Mapping):
+            policy_stack.push(global_policy, scope="globals", source="globals.policy")
+            pushed_global = True
+
+        issues: list[Issue] = []
+        graph = flow.get("graph", {}) if isinstance(flow, Mapping) else {}
+        if isinstance(graph, Mapping):
+            nodes: Sequence[Mapping[str, object]] = graph.get("nodes", [])
+        else:
+            nodes = []
+
+        for index, node in enumerate(nodes):
+            if not isinstance(node, Mapping):
+                continue
+            scope = f"graph.nodes[{index}]"
+            node_policy = node.get("policy") if isinstance(node, Mapping) else None
+            pushed_node = False
+            if isinstance(node_policy, Mapping):
+                policy_stack.push(node_policy, scope=scope, source=f"{scope}.policy")
+                pushed_node = True
+
+            resolution = policy_stack.effective_allowlist()
+            issue = self._evaluate_node(node, index, resolution)
+            if issue is not None:
+                issues.append(issue)
+
+            if pushed_node:
+                policy_stack.pop(scope=scope)
+
+        if pushed_global:
+            policy_stack.pop(scope="globals")
+
+        return issues
+
+    def _evaluate_node(
+        self,
+        node: Mapping[str, object],
+        index: int,
+        resolution: PolicyResolution,
+    ) -> Issue | None:
+        kind = node.get("kind") if isinstance(node, Mapping) else None
+        if kind != "unit":
+            return None
+
+        spec = node.get("spec") if isinstance(node, Mapping) else None
+        if not isinstance(spec, Mapping):
+            return None
+
+        unit_type = spec.get("type")
+        if unit_type not in {"tool", "llm"}:
+            return None
+
+        tool_ref = spec.get("tool_ref")
+        if not isinstance(tool_ref, str):
+            return None
+
+        candidates: list[str] = [tool_ref]
+        fallback = spec.get("fallback") if isinstance(spec, Mapping) else None
+        if isinstance(fallback, Mapping):
+            tries = fallback.get("try")
+            if isinstance(tries, Iterable) and not isinstance(tries, str | bytes):
+                for entry in tries:
+                    if isinstance(entry, str):
+                        candidates.append(entry)
+
+        reachable = [tool for tool in candidates if resolution.is_allowed(tool)]
+        if reachable:
+            return None
+
+        reasons: dict[str, str] = {}
+        for tool in candidates:
+            if tool in resolution.reasons:
+                reasons[tool] = resolution.reasons[tool]
+            else:
+                reasons[tool] = "unknown_tool"
+
+        node_id = node.get("id", f"graph.nodes[{index}]")
+        path = f"graph.nodes[{index}].spec.tool_ref"
+        msg = (
+            f"Node '{node_id}' has no allowed tools under policy. Candidates: {reasons}."
+        )
+        return Issue(level="error", code="policy.unreachable_tool", msg=msg, path=path)

--- a/pkgs/dsl/policy.py
+++ b/pkgs/dsl/policy.py
@@ -1,0 +1,292 @@
+"""Policy resolution utilities for the RAGX DSL."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+
+class PolicyError(RuntimeError):
+    """Raised when policy definitions are invalid or cannot be resolved."""
+
+
+@dataclass(slots=True)
+class PolicyTraceEvent:
+    """A lightweight trace record emitted when the policy stack mutates."""
+
+    event: str
+    scope: str
+    data: Mapping[str, object]
+
+
+class PolicyTraceRecorder:
+    """Collects policy trace events for later inspection (e.g. tests or logs)."""
+
+    def __init__(self) -> None:
+        self.events: list[PolicyTraceEvent] = []
+
+    def record(self, event: PolicyTraceEvent) -> None:
+        self.events.append(event)
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolMetadata:
+    """Normalized tool metadata required for policy resolution."""
+
+    name: str
+    tags: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDefinition:
+    """Normalized representation of a policy layer."""
+
+    allow_tools: frozenset[str] | None = None
+    deny_tools: frozenset[str] | None = None
+    allow_tags: frozenset[str] | None = None
+    deny_tags: frozenset[str] | None = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Iterable[str]] | None) -> PolicyDefinition:
+        if data is None:
+            return cls()
+
+        def _normalize(key: str) -> frozenset[str] | None:
+            if key not in data:
+                return None
+            value = data[key]
+            if value is None:
+                return frozenset()
+            if not isinstance(value, Iterable) or isinstance(value, str | bytes):
+                raise PolicyError(f"Policy field '{key}' must be an iterable of strings")
+            items: set[str] = set()
+            for entry in value:
+                if not isinstance(entry, str):
+                    raise PolicyError(f"Policy field '{key}' must contain only strings")
+                items.add(entry)
+            return frozenset(items)
+
+        return cls(
+            allow_tools=_normalize("allow_tools"),
+            deny_tools=_normalize("deny_tools"),
+            allow_tags=_normalize("allow_tags"),
+            deny_tags=_normalize("deny_tags"),
+        )
+
+    def to_dict(self) -> Mapping[str, Sequence[str] | None]:
+        return MappingProxyType(
+            {
+                "allow_tools": sorted(self.allow_tools) if self.allow_tools is not None else None,
+                "deny_tools": sorted(self.deny_tools) if self.deny_tools is not None else None,
+                "allow_tags": sorted(self.allow_tags) if self.allow_tags is not None else None,
+                "deny_tags": sorted(self.deny_tags) if self.deny_tags is not None else None,
+            }
+        )
+
+
+@dataclass(slots=True)
+class PolicyResolution:
+    """Effective allowlist and diagnostics for the current policy stack."""
+
+    allowed: frozenset[str]
+    blocked: frozenset[str]
+    reasons: Mapping[str, str]
+
+    def is_allowed(self, tool_name: str) -> bool:
+        return tool_name in self.allowed
+
+
+@dataclass(slots=True)
+class _PolicyLayer:
+    """A single entry in the policy stack."""
+
+    policy: PolicyDefinition
+    scope: str
+    source: str
+
+
+class PolicyStack:
+    """Maintains hierarchical policies and computes effective allowlists."""
+
+    def __init__(
+        self,
+        *,
+        tools: Mapping[str, Mapping[str, object]],
+        tool_sets: Mapping[str, Sequence[str]] | None = None,
+        trace: PolicyTraceRecorder | None = None,
+    ) -> None:
+        if not isinstance(tools, Mapping):
+            raise PolicyError("tools must be a mapping of tool name -> metadata")
+
+        self._tools: dict[str, _ToolMetadata] = {
+            name: _ToolMetadata(name=name, tags=self._normalize_tags(meta))
+            for name, meta in tools.items()
+        }
+        self._tool_sets: dict[str, tuple[str, ...]] = {
+            name: tuple(self._normalize_tool_ref(ref) for ref in refs)
+            for name, refs in (tool_sets or {}).items()
+        }
+        self.trace: PolicyTraceRecorder = trace or PolicyTraceRecorder()
+        self.stack: list[_PolicyLayer] = []
+
+    @staticmethod
+    def _normalize_tags(meta: Mapping[str, object]) -> frozenset[str]:
+        tags = meta.get("tags", []) if isinstance(meta, Mapping) else []
+        if tags is None:
+            return frozenset()
+        if not isinstance(tags, Iterable) or isinstance(tags, str | bytes):
+            raise PolicyError("Tool metadata 'tags' must be an iterable of strings")
+        normalized: set[str] = set()
+        for tag in tags:
+            if not isinstance(tag, str):
+                raise PolicyError("Tool metadata 'tags' must contain only strings")
+            normalized.add(tag)
+        return frozenset(normalized)
+
+    @staticmethod
+    def _normalize_tool_ref(ref: str) -> str:
+        if not isinstance(ref, str) or not ref:
+            raise PolicyError("Tool set entries must be non-empty strings")
+        return ref
+
+    def _expand_tool_refs(
+        self, refs: Iterable[str], *, _stack: tuple[str, ...] = ()
+    ) -> frozenset[str]:
+        expanded: set[str] = set()
+        for ref in refs:
+            if ref in self._tools:
+                expanded.add(ref)
+                continue
+            if ref in self._tool_sets:
+                if ref in _stack:
+                    cycle = " -> ".join((*_stack, ref))
+                    raise PolicyError(f"Detected cycle while expanding tool set '{cycle}'")
+                expanded.update(self._expand_tool_refs(self._tool_sets[ref], _stack=(*_stack, ref)))
+                continue
+            raise PolicyError(f"Unknown policy reference '{ref}'")
+        return frozenset(expanded)
+
+    def push(
+        self,
+        policy_data: Mapping[str, Iterable[str]] | None,
+        *,
+        scope: str,
+        source: str,
+    ) -> None:
+        policy = PolicyDefinition.from_mapping(policy_data)
+        if policy.allow_tools is not None:
+            self._expand_tool_refs(policy.allow_tools)
+        if policy.deny_tools is not None:
+            self._expand_tool_refs(policy.deny_tools)
+        self.stack.append(_PolicyLayer(policy=policy, scope=scope, source=source))
+        self.trace.record(
+            PolicyTraceEvent(
+                event="policy_push",
+                scope=scope,
+                data={"source": source, "policy": policy.to_dict()},
+            )
+        )
+
+    def pop(self, *, scope: str) -> None:
+        if not self.stack:
+            raise PolicyError("Cannot pop from an empty policy stack")
+        layer = self.stack.pop()
+        if layer.scope != scope:
+            raise PolicyError(
+                f"Policy stack scope mismatch: expected to pop '{layer.scope}', got '{scope}'"
+            )
+        self.trace.record(
+            PolicyTraceEvent(
+                event="policy_pop",
+                scope=scope,
+                data={"source": layer.source},
+            )
+        )
+
+    def _resolve_tools_dimension(self, attribute: str) -> frozenset[str] | None:
+        for layer in reversed(self.stack):
+            refs = getattr(layer.policy, attribute)
+            if refs is not None:
+                return self._expand_tool_refs(refs)
+        return None
+
+    def _resolve_tags_dimension(self, attribute: str) -> frozenset[str] | None:
+        for layer in reversed(self.stack):
+            tags = getattr(layer.policy, attribute)
+            if tags is not None:
+                return tags
+        return None
+
+    def _resolve_dimensions(self) -> tuple[
+        frozenset[str] | None,
+        frozenset[str] | None,
+        frozenset[str] | None,
+        frozenset[str] | None,
+    ]:
+        allow_tools = self._resolve_tools_dimension("allow_tools")
+        deny_tools = self._resolve_tools_dimension("deny_tools")
+        allow_tags = self._resolve_tags_dimension("allow_tags")
+        deny_tags = self._resolve_tags_dimension("deny_tags")
+        return allow_tools, deny_tools, allow_tags, deny_tags
+
+    def effective_allowlist(self) -> PolicyResolution:
+        allow_tools, deny_tools, allow_tags, deny_tags = self._resolve_dimensions()
+
+        allowed: set[str] = set()
+        blocked: set[str] = set()
+        reasons: dict[str, str] = {}
+
+        for tool_name, meta in self._tools.items():
+            base_allowed = False
+            if allow_tools is None and allow_tags is None:
+                base_allowed = True
+            else:
+                if allow_tools is not None and tool_name in allow_tools:
+                    base_allowed = True
+                if allow_tags is not None and meta.tags & allow_tags:
+                    base_allowed = True
+
+            if deny_tools is not None and tool_name in deny_tools:
+                blocked.add(tool_name)
+                reasons[tool_name] = f"denied:tool:{tool_name}"
+                continue
+
+            if deny_tags is not None:
+                overlap = meta.tags & deny_tags
+                if overlap:
+                    blocked.add(tool_name)
+                    denied_tag = sorted(overlap)[0]
+                    reasons[tool_name] = f"denied:tag:{denied_tag}"
+                    continue
+
+            if base_allowed:
+                allowed.add(tool_name)
+            else:
+                blocked.add(tool_name)
+                reasons[tool_name] = "not_in_allowlist"
+
+        resolution = PolicyResolution(
+            allowed=frozenset(allowed),
+            blocked=frozenset(blocked),
+            reasons=MappingProxyType(dict(reasons)),
+        )
+        self.trace.record(
+            PolicyTraceEvent(
+                event="policy_resolved",
+                scope="stack",
+                data={
+                    "allowed": sorted(resolution.allowed),
+                    "blocked": sorted(resolution.blocked),
+                    "allow_tools": sorted(allow_tools) if allow_tools is not None else None,
+                    "deny_tools": sorted(deny_tools) if deny_tools is not None else None,
+                    "allow_tags": sorted(allow_tags) if allow_tags is not None else None,
+                    "deny_tags": sorted(deny_tags) if deny_tags is not None else None,
+                },
+            )
+        )
+        return resolution
+
+    @property
+    def tool_names(self) -> frozenset[str]:
+        return frozenset(self._tools.keys())

--- a/tests/unit/test_linter_unreachable_tools.py
+++ b/tests/unit/test_linter_unreachable_tools.py
@@ -1,0 +1,86 @@
+"""Static linter tests for unreachable tool nodes due to policy restrictions."""
+
+from __future__ import annotations
+
+from pkgs.dsl.linter import FlowLinter
+
+
+def _base_flow() -> dict:
+    return {
+        "version": "0.1",
+        "globals": {
+            "tools": {
+                "web_search": {"tags": ["search", "external"]},
+                "internal_search": {"tags": ["search"]},
+                "analysis_only": {"tags": ["internal"]},
+            },
+            "tool_sets": {
+                "search": ["web_search", "internal_search"],
+            },
+            "policy": {
+                "allow_tools": ["analysis_only"],
+                "allow_tags": ["search"],
+                "deny_tags": ["external"],
+            },
+        },
+        "graph": {
+            "nodes": [
+                {
+                    "id": "blocked_search",
+                    "kind": "unit",
+                    "spec": {
+                        "type": "tool",
+                        "tool_ref": "web_search",
+                    },
+                    "outputs": [],
+                },
+                {
+                    "id": "allowed_search",
+                    "kind": "unit",
+                    "spec": {
+                        "type": "tool",
+                        "tool_ref": "internal_search",
+                    },
+                    "outputs": [],
+                },
+                {
+                    "id": "with_fallback",
+                    "kind": "unit",
+                    "spec": {
+                        "type": "tool",
+                        "tool_ref": "web_search",
+                        "fallback": {"try": ["internal_search"]},
+                    },
+                    "outputs": [],
+                },
+                {
+                    "id": "override",
+                    "kind": "unit",
+                    "spec": {
+                        "type": "tool",
+                        "tool_ref": "web_search",
+                    },
+                    "policy": {
+                        "allow_tools": ["web_search"],
+                        "deny_tags": [],
+                    },
+                    "outputs": [],
+                },
+            ],
+        },
+    }
+
+
+def test_linter_flags_nodes_without_allowed_tools() -> None:
+    flow = _base_flow()
+    issues = FlowLinter().find_unreachable_tools(flow)
+
+    assert len(issues) == 1, (
+        "Expected a single unreachable node, got "
+        f"{[issue.path for issue in issues]}"
+    )
+    issue = issues[0]
+    assert issue.code == "policy.unreachable_tool"
+    assert issue.path == "graph.nodes[0].spec.tool_ref"
+    assert "web_search" in issue.msg
+    assert "denied:tag:external" in issue.msg

--- a/tests/unit/test_policy_stack_resolution.py
+++ b/tests/unit/test_policy_stack_resolution.py
@@ -1,0 +1,111 @@
+"""PolicyStack allow/deny resolution behavior tests.
+
+These tests implement the Red stage for task 07a (Policy Engine).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pkgs.dsl.policy import PolicyError, PolicyStack, PolicyTraceRecorder
+
+
+@pytest.fixture()
+def sample_tools() -> dict[str, dict[str, list[str]]]:
+    return {
+        "analysis_only": {"tags": ["internal"]},
+        "bing_search": {"tags": ["search", "external"]},
+        "wikipedia": {"tags": ["search"]},
+        "gpt-4": {"tags": ["llm"]},
+    }
+
+
+@pytest.fixture()
+def sample_tool_sets() -> dict[str, list[str]]:
+    return {"search_tools": ["bing_search", "wikipedia"]}
+
+
+@pytest.fixture()
+def stack(
+    sample_tools: dict[str, dict[str, list[str]]],
+    sample_tool_sets: dict[str, list[str]],
+) -> PolicyStack:
+    trace = PolicyTraceRecorder()
+    policy_stack = PolicyStack(
+        tools=sample_tools,
+        tool_sets=sample_tool_sets,
+        trace=trace,
+    )
+    policy_stack.push(
+        {
+            "allow_tools": ["analysis_only"],
+            "allow_tags": ["search"],
+            "deny_tags": ["external"],
+        },
+        scope="globals",
+        source="globals.policy",
+    )
+    return policy_stack
+
+
+def test_effective_allowlist_merges_allow_tags_and_blocks_denied_tags(
+    stack: PolicyStack,
+) -> None:
+    resolution = stack.effective_allowlist()
+
+    expected_allowed = {"analysis_only", "wikipedia"}
+    assert resolution.allowed == expected_allowed, (
+        "Resolution allowed tools mismatch.\n"
+        f"Expected: {sorted(expected_allowed)}\n"
+        f"Actual:   {sorted(resolution.allowed)}"
+    )
+
+    # bing_search is blocked because of the 'external' tag from the global policy deny list.
+    assert resolution.reasons.get("bing_search") == "denied:tag:external"
+    # The LLM tool is absent from the allow lists entirely.
+    assert resolution.reasons.get("gpt-4") == "not_in_allowlist"
+
+    events = stack.trace.events
+    assert events[0].event == "policy_push"
+    assert events[-1].event == "policy_resolved"
+    assert events[-1].data["allowed"] == sorted(expected_allowed)
+
+
+def test_nearest_policy_overrides_allow_and_deny_settings(stack: PolicyStack) -> None:
+    stack.push(
+        {
+            "allow_tools": ["search_tools"],
+            "deny_tags": [],
+        },
+        scope="node",
+        source="graph.nodes[1].policy",
+    )
+
+    resolution = stack.effective_allowlist()
+    assert resolution.allowed == {"bing_search", "wikipedia"}, (
+        "Node policy should expand allowlist via tool set and clear deny tags."
+    )
+    assert "bing_search" not in resolution.blocked
+    assert resolution.reasons.get("bing_search") is None
+
+    stack.pop(scope="node")
+    back_to_global = stack.effective_allowlist()
+    assert back_to_global.allowed == {"analysis_only", "wikipedia"}
+
+
+def test_invalid_tool_set_reference_raises_policy_error(
+    sample_tools: dict[str, dict[str, list[str]]]
+) -> None:
+    stack = PolicyStack(
+        tools=sample_tools,
+        tool_sets={},
+    )
+
+    with pytest.raises(PolicyError, match="Unknown policy reference 'unknown-set'"):
+        stack.push(
+            {
+                "allow_tools": ["unknown-set"],
+            },
+            scope="node",
+            source="graph.nodes[99].policy",
+        )


### PR DESCRIPTION
## Summary
- implement the PolicyStack runtime with hierarchical allow/deny resolution, trace events, and validation of tool references per the DSL spec
- add a FlowLinter rule that detects unit nodes whose tool references are unreachable under the effective policy and expose structured Issue objects
- cover the new behaviour with dedicated unit tests for policy resolution and the unreachable-tool linter rule

## Testing
- `pytest tests/unit/test_policy_stack_resolution.py tests/unit/test_linter_unreachable_tools.py`
- `./scripts/ensure_green.sh` *(fails: transport parity integration test expects matching transport metadata between HTTP and STDIO responses)*

------
https://chatgpt.com/codex/tasks/task_e_68e7bcd0bde0832ca09acc8a33b82b08