### PR TITLE
Implement DSL policy stack and linter

### DIFF
--- a/pkgs/__init__.py
+++ b/pkgs/__init__.py
@@ -1,0 +1,2 @@
+"""Top-level package marker for RagX Python packages."""
+

--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,0 +1,6 @@
+"""DSL runtime package containing policy evaluation and linting utilities."""
+
+from .policy import PolicyDecision, PolicyEvent, PolicyStack
+
+__all__ = ["PolicyDecision", "PolicyEvent", "PolicyStack"]
+

--- a/pkgs/dsl/linter.py
+++ b/pkgs/dsl/linter.py
@@ -1,0 +1,172 @@
+"""Static linter utilities for DSL policy reachability checks."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .policy import PolicyDecision, PolicyStack
+
+
+@dataclass(slots=True)
+class Issue:
+    """Structured linter issue description."""
+
+    level: str
+    code: str
+    msg: str
+    path: str
+
+
+def lint_unreachable_tools(flow: Mapping[str, Any]) -> list[Issue]:
+    """Detect nodes or decision branches that cannot execute any allowed tool."""
+
+    globals_cfg = flow.get("globals") or {}
+    tools = globals_cfg.get("tools") or {}
+    tool_sets = globals_cfg.get("tool_sets") or {}
+
+    if not tools:
+        return []
+
+    stack = PolicyStack(tools=tools, tool_sets=tool_sets)
+    graph = flow.get("graph") or {}
+    issues: list[Issue] = []
+
+    root_policy = graph.get("policy")
+    if root_policy:
+        stack.push(root_policy, scope="graph")
+
+    nodes: list[Mapping[str, Any]] = list(graph.get("nodes") or [])
+    nodes_by_id: dict[str, Mapping[str, Any]] = {}
+    for node in nodes:
+        node_id = node.get("id")
+        if node_id:
+            nodes_by_id[node_id] = node
+
+    for node in nodes:
+        kind = node.get("kind")
+        if kind == "unit":
+            decision = _evaluate_unit(node, stack)
+            if not decision.allowed:
+                issues.append(
+                    Issue(
+                        level="error",
+                        code="policy.unreachable_tool",
+                        msg=_format_unit_message(node, decision),
+                        path=f"nodes.{node.get('id')}",
+                    )
+                )
+        elif kind == "decision":
+            issues.extend(_lint_decision(node, stack, nodes_by_id))
+
+    if root_policy:
+        stack.pop()
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_unit(node: Mapping[str, Any], stack: PolicyStack) -> PolicyDecision:
+    scope = f"node:{node.get('id')}"
+    pushed = False
+    policy = node.get("policy")
+    if policy:
+        stack.push(policy, scope=scope)
+        pushed = True
+
+    try:
+        candidates = _candidate_tools(node.get("spec") or {})
+        return stack.effective_allowlist(candidates)
+    finally:
+        if pushed:
+            stack.pop()
+
+
+def _candidate_tools(spec: Mapping[str, Any]) -> list[str]:
+    candidates: list[str] = []
+    tool_ref = spec.get("tool_ref")
+    if tool_ref:
+        candidates.append(tool_ref)
+
+    fallback = spec.get("fallback") or {}
+    for name in fallback.get("try", []):
+        if name not in candidates:
+            candidates.append(name)
+    return candidates
+
+
+def _format_unit_message(node: Mapping[str, Any], decision: PolicyDecision) -> str:
+    reasons = "; ".join(f"{tool}: {reason}" for tool, reason in decision.denied.items())
+    if not reasons:
+        reasons = "no tools allowed by policy stack"
+    return f"Node '{node.get('id')}' cannot call any allowed tool ({reasons})."
+
+
+def _lint_decision(
+    node: Mapping[str, Any],
+    stack: PolicyStack,
+    nodes_by_id: Mapping[str, Mapping[str, Any]],
+) -> list[Issue]:
+    issues: list[Issue] = []
+    scope = f"node:{node.get('id')}"
+    pushed_node_policy = False
+    if node.get("policy"):
+        stack.push(node["policy"], scope=scope)
+        pushed_node_policy = True
+
+    try:
+        options = list((node.get("spec") or {}).get("options") or [])
+        for idx, option in enumerate(options):
+            option_scope = f"decision:{node.get('id')}:{option.get('key', idx)}"
+            pushed_option_policy = False
+            if option.get("policy"):
+                stack.push(option["policy"], scope=option_scope)
+                pushed_option_policy = True
+
+            try:
+                target_id = option.get("goto")
+                target = nodes_by_id.get(target_id or "")
+                if not target or target.get("kind") != "unit":
+                    continue
+
+                preview = _evaluate_unit(target, stack)
+                if not preview.allowed:
+                    message = _format_branch_message(node, option, preview)
+                    issues.append(
+                        Issue(
+                            level="error",
+                            code="policy.unreachable_tool",
+                            msg=message,
+                            path=f"nodes.{node.get('id')}.options[{idx}]",
+                        )
+                    )
+            finally:
+                if pushed_option_policy:
+                    stack.pop()
+    finally:
+        if pushed_node_policy:
+            stack.pop()
+
+    return issues
+
+
+def _format_branch_message(
+    node: Mapping[str, Any],
+    option: Mapping[str, Any],
+    decision: PolicyDecision,
+) -> str:
+    reasons = "; ".join(
+        f"{tool}: {reason}" for tool, reason in decision.denied.items()
+    ) or "no tools allowed"
+    return (
+        f"Branch '{option.get('key')}' of decision '{node.get('id')}' cannot execute "
+        f"an allowed tool ({reasons})."
+    )
+
+
+__all__ = ["Issue", "lint_unreachable_tools"]
+

--- a/pkgs/dsl/policy.py
+++ b/pkgs/dsl/policy.py
@@ -1,0 +1,283 @@
+"""Policy engine primitives for the DSL runner.
+
+This module implements the ``PolicyStack`` class described in
+``codex/specs/ragx_master_spec.yaml``.  The stack maintains a sequence of
+policy scopes (graph → decisions → nodes) and can derive an effective
+allowlist of tools respecting allow/deny directives and tags.  Trace
+events are captured in-memory to support deterministic testing and future
+integration with the runner's structured logging.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+PolicyDict = Mapping[str, Any]
+
+
+@dataclass(slots=True)
+class PolicyEvent:
+    """Structured trace emitted by ``PolicyStack`` operations."""
+
+    event: str
+    scope: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class PolicyDecision:
+    """Result of evaluating the effective allowlist for a scope."""
+
+    allowed: set[str]
+    denied: dict[str, str]
+    candidates: list[str]
+    stack_depth: int
+
+    def __post_init__(self) -> None:  # pragma: no cover - defensive guard
+        # Ensure deterministic iteration for payload comparisons in tests.
+        self.candidates = list(self.candidates)
+
+
+@dataclass(slots=True)
+class _PolicyFrame:
+    """Internal representation of a policy pushed on the stack."""
+
+    scope: str
+    policy: dict[str, Any]
+
+
+class PolicyStack:
+    """Maintain hierarchical DSL policies and compute effective allowlists."""
+
+    def __init__(
+        self,
+        *,
+        tools: Mapping[str, Mapping[str, Any]],
+        tool_sets: Mapping[str, Sequence[str]] | None = None,
+    ) -> None:
+        if not tools:
+            raise ValueError("PolicyStack requires at least one registered tool")
+
+        self._tools: dict[str, Mapping[str, Any]] = dict(tools)
+        self._tool_sets: dict[str, Sequence[str]] = dict(tool_sets or {})
+        self.stack: list[_PolicyFrame] = []
+        self.events: list[PolicyEvent] = []
+
+    # ------------------------------------------------------------------
+    # Stack manipulation
+    # ------------------------------------------------------------------
+    def push(self, policy: PolicyDict | None, *, scope: str) -> None:
+        """Push a new policy frame onto the stack and emit a trace event."""
+
+        normalized = self._normalize_policy(policy)
+        self.stack.append(_PolicyFrame(scope=scope, policy=normalized))
+        self._emit("policy_push", scope, {"policy": normalized})
+
+    def pop(self) -> dict[str, Any]:
+        """Pop the most recent policy frame and return it."""
+
+        if not self.stack:
+            raise RuntimeError("PolicyStack.pop() called on empty stack")
+
+        frame = self.stack.pop()
+        self._emit("policy_pop", frame.scope, {"policy": frame.policy})
+        return frame.policy
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+    def effective_allowlist(self, candidates: Sequence[str] | None = None) -> PolicyDecision:
+        """Compute the effective allowlist for the current stack state.
+
+        Args:
+            candidates: Optional iterable of tool names to filter against the
+                allowlist.  When ``None`` all registered tools are
+                considered.
+
+        Returns:
+            ``PolicyDecision`` capturing allowed tool names, denial reasons
+            for candidates and metadata useful for trace payloads.
+        """
+
+        all_tools = sorted(self._tools)
+        state: dict[str, bool] = {tool: True for tool in all_tools}
+        denial_reasons: dict[str, tuple[int, str]] = {}
+
+        for frame in self.stack:
+            policy = frame.policy
+            scope = frame.scope
+
+            self._apply_allow_tools(policy, scope, state, denial_reasons)
+            self._apply_allow_tags(policy, scope, state, denial_reasons)
+            self._apply_deny_tools(policy, scope, state, denial_reasons)
+            self._apply_deny_tags(policy, scope, state, denial_reasons)
+
+        candidate_list = list(candidates) if candidates is not None else list(all_tools)
+        allowed_set = {tool for tool, is_allowed in state.items() if is_allowed}
+        allowed_candidates = allowed_set & set(candidate_list)
+        denied_candidates: dict[str, str] = {}
+
+        for tool in candidate_list:
+            if tool not in self._tools:
+                denied_candidates[tool] = "unknown tool"
+            elif tool not in allowed_set:
+                reason = denial_reasons.get(tool)
+                denied_candidates[tool] = reason[1] if reason else "blocked by upstream policy"
+
+        decision = PolicyDecision(
+            allowed=allowed_candidates,
+            denied=denied_candidates,
+            candidates=candidate_list,
+            stack_depth=len(self.stack),
+        )
+
+        self._emit(
+            "policy_allowlist",
+            self.stack[-1].scope if self.stack else "global",
+            {
+                "candidates": candidate_list,
+                "allowed": sorted(allowed_candidates),
+                "denied": denied_candidates,
+                "stack_depth": len(self.stack),
+            },
+        )
+        return decision
+
+    # ------------------------------------------------------------------
+    # Policy helpers
+    # ------------------------------------------------------------------
+    def _normalize_policy(self, policy: PolicyDict | None) -> dict[str, Any]:
+        if policy is None:
+            return {"allow_tools": [], "deny_tools": [], "allow_tags": [], "deny_tags": []}
+
+        normalized: dict[str, Any] = {
+            "allow_tools": list(policy.get("allow_tools", []) or []),
+            "deny_tools": list(policy.get("deny_tools", []) or []),
+            "allow_tags": list(policy.get("allow_tags", []) or []),
+            "deny_tags": list(policy.get("deny_tags", []) or []),
+        }
+        return normalized
+
+    def _resolve_tool_refs(self, names: Sequence[str], scope: str) -> set[str]:
+        resolved: set[str] = set()
+        for name in names:
+            if name in self._tool_sets:
+                resolved.update(self._tool_sets[name])
+            else:
+                if name not in self._tools:
+                    raise KeyError(
+                        "Unknown tool or tool_set "
+                        f"'{name}' referenced in policy scope '{scope}'"
+                    )
+                resolved.add(name)
+        return resolved
+
+    def _apply_allow_tools(
+        self,
+        policy: Mapping[str, Any],
+        scope: str,
+        state: MutableMapping[str, bool],
+        denial_reasons: MutableMapping[str, tuple[int, str]],
+    ) -> None:
+        allow_tools = policy.get("allow_tools") or []
+        if not allow_tools:
+            return
+
+        resolved = self._resolve_tool_refs(allow_tools, scope)
+        for tool in state:
+            if tool not in resolved:
+                state[tool] = False
+                self._record_reason(
+                    tool,
+                    priority=1,
+                    message=f"filtered by allow_tools {allow_tools} in scope '{scope}'",
+                    denial_reasons=denial_reasons,
+                )
+
+    def _apply_allow_tags(
+        self,
+        policy: Mapping[str, Any],
+        scope: str,
+        state: MutableMapping[str, bool],
+        denial_reasons: MutableMapping[str, tuple[int, str]],
+    ) -> None:
+        allow_tags = set(policy.get("allow_tags") or [])
+        if not allow_tags:
+            return
+
+        for tool in state:
+            tags = set(self._tools[tool].get("tags", []))
+            if allow_tags & tags:
+                continue
+            state[tool] = False
+            self._record_reason(
+                tool,
+                priority=1,
+                message=f"filtered by allow_tags {sorted(allow_tags)} in scope '{scope}'",
+                denial_reasons=denial_reasons,
+            )
+
+    def _apply_deny_tools(
+        self,
+        policy: Mapping[str, Any],
+        scope: str,
+        state: MutableMapping[str, bool],
+        denial_reasons: MutableMapping[str, tuple[int, str]],
+    ) -> None:
+        deny_tools = policy.get("deny_tools") or []
+        if not deny_tools:
+            return
+
+        resolved = self._resolve_tool_refs(deny_tools, scope)
+        for tool in resolved:
+            state[tool] = False
+            self._record_reason(
+                tool,
+                priority=2,
+                message=f"denied by deny_tools {deny_tools} in scope '{scope}'",
+                denial_reasons=denial_reasons,
+            )
+
+    def _apply_deny_tags(
+        self,
+        policy: Mapping[str, Any],
+        scope: str,
+        state: MutableMapping[str, bool],
+        denial_reasons: MutableMapping[str, tuple[int, str]],
+    ) -> None:
+        deny_tags = set(policy.get("deny_tags") or [])
+        if not deny_tags:
+            return
+
+        for tool in state:
+            tags = set(self._tools[tool].get("tags", []))
+            if not (deny_tags & tags):
+                continue
+            state[tool] = False
+            self._record_reason(
+                tool,
+                priority=2,
+                message=f"denied because tag(s) {sorted(deny_tags)} are blocked in scope '{scope}'",
+                denial_reasons=denial_reasons,
+            )
+
+    def _record_reason(
+        self,
+        tool: str,
+        *,
+        priority: int,
+        message: str,
+        denial_reasons: MutableMapping[str, tuple[int, str]],
+    ) -> None:
+        existing = denial_reasons.get(tool)
+        if existing is None or priority >= existing[0]:
+            denial_reasons[tool] = (priority, message)
+
+    # ------------------------------------------------------------------
+    def _emit(self, event: str, scope: str, payload: Mapping[str, Any]) -> None:
+        self.events.append(PolicyEvent(event=event, scope=scope, payload=dict(payload)))
+
+
+__all__ = ["PolicyDecision", "PolicyEvent", "PolicyStack"]
+

--- a/tests/unit/test_linter_unreachable_tools.py
+++ b/tests/unit/test_linter_unreachable_tools.py
@@ -1,0 +1,106 @@
+"""Unit tests for the DSL linter rule that detects unreachable tools/branches."""
+from __future__ import annotations
+
+from pkgs.dsl.linter import lint_unreachable_tools
+
+TOOL_REGISTRY = {
+    "gpt": {"type": "llm", "tags": ["analysis", "internal"]},
+    "web_search": {"type": "tool", "tags": ["search", "external"]},
+    "vector_query": {
+        "type": "tool",
+        "tags": ["retrieval", "internal", "search"],
+    },
+}
+
+TOOL_SETS = {
+    "analysis_only": ["gpt"],
+    "safe_internal": ["vector_query", "gpt"],
+    "search_only": ["web_search"],
+    "retrieval_only": ["vector_query"],
+}
+
+
+def build_flow(nodes: list[dict], policy: dict | None = None) -> dict:
+    return {
+        "globals": {"tools": TOOL_REGISTRY, "tool_sets": TOOL_SETS},
+        "graph": {"nodes": nodes, "policy": policy or {}},
+    }
+
+
+def test_linter_flags_unit_with_no_allowed_tool() -> None:
+    flow = build_flow(
+        [
+            {
+                "id": "search",
+                "kind": "unit",
+                "spec": {"type": "tool", "tool_ref": "web_search"},
+            }
+        ],
+        policy={"allow_tools": ["analysis_only"]},
+    )
+
+    issues = lint_unreachable_tools(flow)
+
+    assert [issue.code for issue in issues] == ["policy.unreachable_tool"]
+    assert "search" in issues[0].msg
+    assert issues[0].path == "nodes.search"
+
+
+def test_linter_accepts_node_with_allowed_fallback() -> None:
+    flow = build_flow(
+        [
+            {
+                "id": "search",
+                "kind": "unit",
+                "spec": {
+                    "type": "tool",
+                    "tool_ref": "web_search",
+                    "fallback": {"try": ["vector_query", "gpt"]},
+                },
+            }
+        ],
+        policy={"allow_tools": ["safe_internal"]},
+    )
+
+    issues = lint_unreachable_tools(flow)
+
+    assert issues == []
+
+
+def test_linter_detects_unreachable_decision_branch() -> None:
+    nodes = [
+        {
+            "id": "route",
+            "kind": "decision",
+            "spec": {
+                "options": [
+                    {
+                        "key": "search",
+                        "goto": "do_search",
+                        "policy": {"allow_tools": ["retrieval_only"]},
+                    },
+                    {"key": "retrieve", "goto": "do_retrieve"},
+                ],
+                "default": "search",
+            },
+        },
+        {
+            "id": "do_search",
+            "kind": "unit",
+            "spec": {"type": "tool", "tool_ref": "web_search"},
+        },
+        {
+            "id": "do_retrieve",
+            "kind": "unit",
+            "spec": {"type": "tool", "tool_ref": "vector_query"},
+        },
+    ]
+
+    flow = build_flow(nodes, policy={"allow_tools": ["safe_internal", "analysis_only"]})
+
+    issues = lint_unreachable_tools(flow)
+
+    assert any(
+        issue.code == "policy.unreachable_tool" and issue.path == "nodes.route.options[0]"
+        for issue in issues
+    ), issues

--- a/tests/unit/test_policy_stack_resolution.py
+++ b/tests/unit/test_policy_stack_resolution.py
@@ -1,0 +1,84 @@
+"""Unit tests for the DSL policy stack resolution logic.
+
+These tests were written first to drive out the PolicyStack implementation
+specified in ``codex/specs/ragx_master_spec.yaml``.  The goal is to
+exercise the behaviour of hierarchical allow/deny rules, tool set
+resolution, candidate filtering and trace emission.
+"""
+from __future__ import annotations
+
+from pkgs.dsl.policy import PolicyEvent, PolicyStack
+
+TOOL_REGISTRY = {
+    "gpt": {"type": "llm", "tags": ["analysis", "internal"]},
+    "web_search": {"type": "tool", "tags": ["search", "external"]},
+    "vector_query": {
+        "type": "tool",
+        "tags": ["retrieval", "internal", "search"],
+    },
+}
+
+TOOL_SETS = {
+    "analysis_only": ["gpt"],
+    "safe_internal": ["vector_query", "gpt"],
+    "search_only": ["web_search"],
+    "retrieval_only": ["vector_query"],
+}
+
+
+def test_effective_allowlist_respects_nested_scopes() -> None:
+    """Nested policies should intersect to produce the effective allowlist."""
+
+    stack = PolicyStack(tools=TOOL_REGISTRY, tool_sets=TOOL_SETS)
+
+    stack.push(
+        {"allow_tools": ["analysis_only", "safe_internal"], "deny_tags": ["external"]},
+        scope="graph",
+    )
+
+    decision = stack.effective_allowlist()
+    assert decision.allowed == {"gpt", "vector_query"}
+    assert decision.denied["web_search"].startswith("denied because tag")
+
+    stack.push({"allow_tags": ["search"]}, scope="branch:search")
+
+    nested = stack.effective_allowlist()
+    assert nested.allowed == {"vector_query"}
+    assert nested.denied["gpt"].startswith("filtered by allow_tags")
+
+    event_types = [event.event for event in stack.events]
+    assert event_types.count("policy_push") == 2
+    assert event_types[-1] == "policy_allowlist"
+
+
+def test_effective_allowlist_filters_candidates_and_records_denials() -> None:
+    """Candidates are filtered and denial reasons are surfaced for debugging."""
+
+    stack = PolicyStack(tools=TOOL_REGISTRY, tool_sets=TOOL_SETS)
+    stack.push(
+        {"allow_tools": ["analysis_only", "safe_internal"], "deny_tags": ["external"]},
+        scope="graph",
+    )
+
+    stack.push({"deny_tools": ["vector_query"]}, scope="node:search")
+
+    decision = stack.effective_allowlist(["vector_query", "gpt"])
+    assert decision.allowed == {"gpt"}
+    assert decision.denied["vector_query"].startswith("denied by deny_tools")
+
+    # The trace should capture the stack depth and candidate evaluation.
+    last_event = stack.events[-1]
+    assert isinstance(last_event, PolicyEvent)
+    assert last_event.payload["candidates"] == ["vector_query", "gpt"]
+    assert last_event.payload["allowed"] == sorted(decision.allowed)
+
+
+def test_pop_emits_trace_event() -> None:
+    """Popping a policy should emit a policy_pop trace event."""
+
+    stack = PolicyStack(tools=TOOL_REGISTRY, tool_sets=TOOL_SETS)
+    stack.push({"allow_tools": ["analysis_only"]}, scope="graph")
+
+    stack.pop()
+
+    assert [event.event for event in stack.events][-1] == "policy_pop"


### PR DESCRIPTION
## Summary
- add DSL policy stack implementation with hierarchical allow/deny resolution and tracing
- add linter helpers to surface unreachable tools and branch policies
- cover behaviour with focused unit tests for policy evaluation and linter outcomes

## Testing
- pytest tests/unit/test_policy_stack_resolution.py tests/unit/test_linter_unreachable_tools.py
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68e7bcd0bde0832ca09acc8a33b82b08