### PR TITLE
Implement DSL policy stack and linter

### DIFF
--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,0 +1,19 @@
+"""DSL runtime primitives defined by :mod:`codex.specs.ragx_master_spec`.
+
+This package exposes stable imports for the policy engine and related models so
+other packages (and tests) can rely on them without reaching into private
+modules. Only minimal functionality required for the policy engine is exposed
+at this stage of the project.
+"""
+
+from __future__ import annotations
+
+from .models import ToolDescriptor
+from .policy import PolicyDecision, PolicyResolution, PolicyStack
+
+__all__ = [
+    "PolicyDecision",
+    "PolicyResolution",
+    "PolicyStack",
+    "ToolDescriptor",
+]

--- a/pkgs/dsl/linter.py
+++ b/pkgs/dsl/linter.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+from .models import ToolDescriptor
+from .policy import PolicyDecision, PolicyStack
+
+
+@dataclass(frozen=True, slots=True)
+class LinterIssue:
+    level: str
+    code: str
+    msg: str
+    path: str
+
+
+def lint_unreachable_tools(flow: Mapping[str, object]) -> list[LinterIssue]:
+    """Detect nodes whose required tools cannot be reached under any policy path."""
+
+    globals_section = _as_mapping(flow.get("globals"))
+    tools_section = _as_mapping(globals_section.get("tools"))
+    tool_sets_section = globals_section.get("tool_sets", {})
+    tool_sets: dict[str, Sequence[str]] = {}
+    for set_name, members in _iterate_items(tool_sets_section):
+        tool_sets[set_name] = tuple(str(member) for member in _ensure_iterable(members))
+
+    tools: dict[str, ToolDescriptor] = {}
+    for name, descriptor in _iterate_items(tools_section):
+        if isinstance(descriptor, ToolDescriptor):
+            tools[name] = descriptor
+        elif isinstance(descriptor, Mapping):
+            tools[name] = ToolDescriptor.from_mapping(name, descriptor)
+
+    graph_section = _as_mapping(flow.get("graph"))
+    graph_policy = _as_mapping(graph_section.get("policy"))
+    nodes = list(_ensure_iterable(graph_section.get("nodes", ())))
+    control_nodes = list(_ensure_iterable(graph_section.get("control", ())))
+
+    loop_policies = _index_loop_policies(control_nodes)
+    branch_policies = _index_branch_policies(nodes)
+
+    issues: list[LinterIssue] = []
+    for index, node in enumerate(nodes):
+        node_map = _as_mapping(node)
+        if node_map.get("kind") != "unit":
+            continue
+        spec = _as_mapping(node_map.get("spec"))
+        tool_ref = spec.get("tool_ref")
+        if not isinstance(tool_ref, str) or tool_ref not in tools:
+            continue
+
+        contexts = _build_policy_contexts(
+            node_id=str(node_map.get("id", f"<node-{index}>")),
+            graph_policy=graph_policy,
+            loop_policies=loop_policies,
+            branch_policies=branch_policies,
+            node_policy=_as_mapping(node_map.get("policy")),
+            tool_sets=tool_sets,
+        )
+
+        allowed = False
+        denial_reasons: list[str] = []
+        for stack in contexts:
+            resolution = stack.effective_allowlist(tools)
+            decision = resolution.decisions.get(tool_ref)
+            if decision is None:
+                denial_reasons.append("tool-not-registered")
+                continue
+            if decision.allowed:
+                allowed = True
+                break
+            denial_reasons.append(_format_decision(decision))
+
+        if allowed:
+            continue
+
+        reason_text = ", ".join(denial_reasons) or "no-policy-path"
+        node_id = node_map.get("id", f"nodes[{index}]")
+        msg = (
+            f"Node '{node_id}' tool '{tool_ref}' is unreachable under active policies"
+            f" ({reason_text})."
+        )
+        path = f"graph.nodes[{index}]"
+        issues.append(LinterIssue("error", "policy.unreachable_tool", msg, path))
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_policy_contexts(
+    *,
+    node_id: str,
+    graph_policy: Mapping[str, object] | None,
+    loop_policies: Mapping[str, list[tuple[Mapping[str, object], str]]],
+    branch_policies: Mapping[str, list[tuple[Mapping[str, object], str]]],
+    node_policy: Mapping[str, object] | None,
+    tool_sets: Mapping[str, Sequence[str]],
+) -> list[PolicyStack]:
+    base_stack = PolicyStack(tool_sets=tool_sets)
+    base_stack.push(graph_policy, scope="graph")
+    for policy, scope in loop_policies.get(node_id, []):
+        base_stack.push(policy, scope=scope)
+    base_stack.push(node_policy, scope=f"node:{node_id}")
+
+    contexts: list[PolicyStack] = [base_stack]
+    for policy, scope in branch_policies.get(node_id, []):
+        branch_stack = base_stack.clone()
+        branch_stack.push(policy, scope=scope)
+        contexts.append(branch_stack)
+    return contexts
+
+
+def _index_loop_policies(
+    control_nodes: Sequence[object],
+) -> dict[str, list[tuple[Mapping[str, object], str]]]:
+    loop_map: dict[str, list[tuple[Mapping[str, object], str]]] = defaultdict(list)
+    for loop in control_nodes:
+        loop_map_entry = _as_mapping(loop)
+        if loop_map_entry.get("kind") != "loop":
+            continue
+        policy = _as_mapping(loop_map_entry.get("policy"))
+        scope = f"loop:{loop_map_entry.get('id', '<loop>')}"
+        targets = _ensure_iterable(loop_map_entry.get("target_subgraph", ()))
+        for target in targets:
+            target_id = str(target)
+            loop_map[target_id].append((policy, scope))
+    return loop_map
+
+
+def _index_branch_policies(
+    nodes: Sequence[object],
+) -> dict[str, list[tuple[Mapping[str, object], str]]]:
+    branch_map: dict[str, list[tuple[Mapping[str, object], str]]] = defaultdict(list)
+    for node in nodes:
+        node_map = _as_mapping(node)
+        if node_map.get("kind") != "decision":
+            continue
+        decision_id = str(node_map.get("id", "<decision>"))
+        options = _ensure_iterable(_as_mapping(node_map.get("spec")).get("options", ()))
+        for option in options:
+            option_map = _as_mapping(option)
+            policy = _as_mapping(option_map.get("policy"))
+            goto = option_map.get("goto")
+            if not goto:
+                continue
+            key = option_map.get("key", goto)
+            scope = f"decision:{decision_id}:{key}"
+            branch_map[str(goto)].append((policy, scope))
+    return branch_map
+
+
+def _format_decision(decision: PolicyDecision) -> str:
+    detail = f"/{decision.detail}" if decision.detail else ""
+    return f"{decision.source}{detail}@{decision.scope}"
+
+
+def _iterate_items(obj: object | None) -> Iterable[tuple[str, object]]:
+    mapping = _as_mapping(obj)
+    return mapping.items()
+
+
+def _ensure_iterable(obj: object | None) -> Iterable[object]:
+    if obj is None:
+        return ()
+    if isinstance(obj, list | tuple | set | frozenset):
+        return obj
+    if isinstance(obj, dict):
+        return obj.values()
+    return (obj,)
+
+
+def _as_mapping(obj: object | None) -> Mapping[str, object]:
+    if obj is None:
+        return {}
+    if isinstance(obj, Mapping):
+        return obj
+    raise TypeError(f"Expected mapping, received {type(obj)!r}")

--- a/pkgs/dsl/models.py
+++ b/pkgs/dsl/models.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ToolDescriptor:
+    """Minimal representation of a tool defined in the DSL globals section.
+
+    The master specification only requires tags for policy resolution in this
+    phase, so the descriptor intentionally stays small.  Additional fields can
+    be added later without breaking callers.
+    """
+
+    name: str
+    tags: tuple[str, ...]
+
+    @classmethod
+    def from_mapping(cls, name: str, data: Mapping[str, object]) -> ToolDescriptor:
+        """Construct a descriptor from a mapping loaded from YAML.
+
+        Missing or non-iterable ``tags`` entries default to an empty tuple.
+        """
+
+        raw_tags = data.get("tags", ()) if isinstance(data, dict) else ()
+        if isinstance(raw_tags, str):
+            tags_iter: Iterable[str] = (raw_tags,)
+        elif isinstance(raw_tags, Iterable):
+            tags_iter = (str(tag) for tag in raw_tags)
+        else:  # pragma: no cover - defensive fallback
+            tags_iter = ()
+        tags: tuple[str, ...] = tuple(tags_iter)
+        return cls(name=name, tags=tags)

--- a/pkgs/dsl/policy.py
+++ b/pkgs/dsl/policy.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, MutableSequence, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from .models import ToolDescriptor
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyTraceEvent:
+    """Structured record describing stack mutations or violations."""
+
+    event: str
+    scope: str
+    payload: Mapping[str, object] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDecision:
+    """Result of evaluating a tool against the active policy stack."""
+
+    allowed: bool
+    source: str
+    scope: str
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyResolution:
+    """Summary of an allowlist evaluation for the current stack state."""
+
+    allowed: frozenset[str]
+    denied: frozenset[str]
+    decisions: Mapping[str, PolicyDecision]
+
+
+@dataclass(frozen=True, slots=True)
+class _PolicyFrame:
+    scope: str
+    allow_tools: Mapping[str, str]
+    deny_tools: Mapping[str, str]
+    allow_tags: frozenset[str]
+    deny_tags: frozenset[str]
+    raw: Mapping[str, object]
+
+
+class PolicyStack:
+    """Hierarchical allow/deny evaluator for DSL policies.
+
+    The stack processes policies in the order they are pushed.  The closest
+    (most recent) policy wins when directives conflict, which matches the
+    ``scoping_order`` contract in the specification (``globals < loop <
+    decision-option < node``).
+    """
+
+    def __init__(
+        self,
+        *,
+        tool_sets: Mapping[str, Sequence[str]] | None = None,
+        trace: MutableSequence[PolicyTraceEvent] | None = None,
+    ) -> None:
+        self._tool_sets: Mapping[str, tuple[str, ...]] = (
+            {
+                name: tuple(values)
+                for name, values in (tool_sets or {}).items()
+            }
+        )
+        self.stack: list[_PolicyFrame] = []
+        self.trace: MutableSequence[PolicyTraceEvent] = trace or []
+
+    # ------------------------------------------------------------------
+    # Stack mutations
+    # ------------------------------------------------------------------
+    def push(self, policy: Mapping[str, object] | None, *, scope: str) -> None:
+        """Push a policy frame onto the stack.
+
+        ``None`` policies are ignored so callers can forward optional
+        directives without additional checks.
+        """
+
+        if not policy:
+            return
+
+        frame = self._build_frame(policy, scope=scope)
+        self.stack.append(frame)
+        self.trace.append(PolicyTraceEvent("policy_push", scope, frame.raw))
+
+    def pop(self) -> None:
+        if not self.stack:
+            raise IndexError("PolicyStack.pop() called on empty stack")
+        frame = self.stack.pop()
+        self.trace.append(PolicyTraceEvent("policy_pop", frame.scope, frame.raw))
+
+    def clone(self) -> PolicyStack:
+        clone = PolicyStack(tool_sets=self._tool_sets, trace=list(self.trace))
+        clone.stack = list(self.stack)
+        return clone
+
+    # ------------------------------------------------------------------
+    # Resolution
+    # ------------------------------------------------------------------
+    def effective_allowlist(
+        self, tools: Mapping[str, ToolDescriptor | Mapping[str, object]]
+    ) -> PolicyResolution:
+        """Return the allow/deny decision for every tool in ``tools``."""
+
+        descriptors: dict[str, ToolDescriptor] = {}
+        for name, descriptor in tools.items():
+            if isinstance(descriptor, ToolDescriptor):
+                descriptors[name] = descriptor
+            elif isinstance(descriptor, Mapping):
+                descriptors[name] = ToolDescriptor.from_mapping(name, descriptor)
+            else:  # pragma: no cover - defensive guard for unexpected input
+                raise TypeError(
+                    f"Unsupported tool descriptor for '{name}': {type(descriptor)!r}"
+                )
+
+        any_allow_directive = any(
+            frame.allow_tools or frame.allow_tags for frame in self.stack
+        )
+
+        decisions: dict[str, PolicyDecision] = {}
+        allowed: set[str] = set()
+        denied: set[str] = set()
+        for name, descriptor in descriptors.items():
+            decision = self._resolve_tool(
+                descriptor, any_allow_directive=any_allow_directive
+            )
+            decisions[name] = decision
+            (allowed if decision.allowed else denied).add(name)
+
+        return PolicyResolution(
+            allowed=frozenset(allowed),
+            denied=frozenset(denied),
+            decisions=MappingProxyType(decisions),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _resolve_tool(
+        self, descriptor: ToolDescriptor, *, any_allow_directive: bool
+    ) -> PolicyDecision:
+        tags = set(descriptor.tags)
+        for frame in reversed(self.stack):
+            if descriptor.name in frame.deny_tools:
+                detail = frame.deny_tools[descriptor.name]
+                return PolicyDecision(False, "deny_tools", frame.scope, detail)
+            if descriptor.name in frame.allow_tools:
+                detail = frame.allow_tools[descriptor.name]
+                return PolicyDecision(True, "allow_tools", frame.scope, detail)
+
+            deny_match = self._match_tags(tags, frame.deny_tags)
+            if deny_match:
+                return PolicyDecision(False, "deny_tags", frame.scope, deny_match)
+
+            allow_match = self._match_tags(tags, frame.allow_tags)
+            if allow_match:
+                return PolicyDecision(True, "allow_tags", frame.scope, allow_match)
+
+        if any_allow_directive:
+            return PolicyDecision(False, "implicit_deny", "effective", None)
+        return PolicyDecision(True, "implicit_allow", "effective", None)
+
+    def _build_frame(
+        self, policy: Mapping[str, object], *, scope: str
+    ) -> _PolicyFrame:
+        allow_tools = self._expand_tool_entries(policy.get("allow_tools"))
+        deny_tools = self._expand_tool_entries(policy.get("deny_tools"))
+        allow_tags = frozenset(self._string_iter(policy.get("allow_tags")))
+        deny_tags = frozenset(self._string_iter(policy.get("deny_tags")))
+        raw = MappingProxyType(dict(policy))
+        return _PolicyFrame(
+            scope=scope,
+            allow_tools=MappingProxyType(allow_tools),
+            deny_tools=MappingProxyType(deny_tools),
+            allow_tags=allow_tags,
+            deny_tags=deny_tags,
+            raw=raw,
+        )
+
+    def _expand_tool_entries(
+        self, entries: object
+    ) -> dict[str, str]:  # mapping tool -> origin
+        tools: dict[str, str] = {}
+        for entry in self._string_iter(entries):
+            expanded = self._tool_sets.get(entry, (entry,))
+            for tool_name in expanded:
+                tools[tool_name] = entry
+        return tools
+
+    @staticmethod
+    def _string_iter(entries: object | None) -> Iterable[str]:
+        if entries is None:
+            return ()
+        if isinstance(entries, str):
+            return (entries,)
+        if isinstance(entries, Iterable):
+            return (str(item) for item in entries)
+        raise TypeError(f"Policy entries must be strings or iterables, got {type(entries)!r}")
+
+    @staticmethod
+    def _match_tags(tags: set[str], policy_tags: frozenset[str]) -> str | None:
+        if not tags or not policy_tags:
+            return None
+        intersection = sorted(tags.intersection(policy_tags))
+        if not intersection:
+            return None
+        return ",".join(intersection)

--- a/tests/unit/test_linter_unreachable_tools.py
+++ b/tests/unit/test_linter_unreachable_tools.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pkgs.dsl.linter import LinterIssue, lint_unreachable_tools
+
+
+def _base_flow() -> dict:
+    return {
+        "version": 0.1,
+        "globals": {
+            "tools": {
+                "gpt": {
+                    "type": "llm",
+                    "tags": ["llm", "analysis"],
+                },
+                "web_search": {
+                    "type": "mcp",
+                    "tags": ["search", "external"],
+                },
+            },
+            "tool_sets": {
+                "analysis_only": ["gpt"],
+                "search_only": ["web_search"],
+            },
+        },
+        "graph": {
+            "policy": {"allow_tools": ["analysis_only"], "deny_tags": ["external"]},
+            "nodes": [
+                {
+                    "id": "plan",
+                    "kind": "unit",
+                    "spec": {"type": "llm", "tool_ref": "gpt"},
+                },
+                {
+                    "id": "search",
+                    "kind": "unit",
+                    "spec": {"type": "tool", "tool_ref": "web_search"},
+                },
+                {
+                    "id": "router",
+                    "kind": "decision",
+                    "spec": {
+                        "options": [
+                            {
+                                "key": "answer",
+                                "goto": "plan",
+                            }
+                        ],
+                        "default": "answer",
+                    },
+                },
+            ],
+        },
+    }
+
+
+def test_linter_flags_unreachable_tool_due_to_policy() -> None:
+    flow = _base_flow()
+    issues = lint_unreachable_tools(flow)
+
+    assert issues
+    issue = issues[0]
+    assert isinstance(issue, LinterIssue)
+    assert issue.code == "policy.unreachable_tool"
+    assert issue.level == "error"
+    assert issue.path == "graph.nodes[1]"
+    assert "search" in issue.msg
+    assert "web_search" in issue.msg
+
+
+def test_linter_accepts_branch_policy_allowing_tool() -> None:
+    flow = _base_flow()
+    # Attach a branch policy that allows the search tool explicitly.
+    for node in flow["graph"]["nodes"]:
+        if node["id"] == "router":
+            node["spec"]["options"].append(
+                {
+                    "key": "search",
+                    "goto": "search",
+                    "policy": {"allow_tools": ["search_only"]},
+                }
+            )
+
+    issues = lint_unreachable_tools(flow)
+    assert not issues

--- a/tests/unit/test_policy_stack_resolution.py
+++ b/tests/unit/test_policy_stack_resolution.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from pkgs.dsl.models import ToolDescriptor
+from pkgs.dsl.policy import PolicyStack
+
+
+@pytest.fixture()
+def tool_registry() -> dict[str, ToolDescriptor]:
+    return {
+        "gpt": ToolDescriptor(name="gpt", tags=("llm", "analysis")),
+        "web_search": ToolDescriptor(
+            name="web_search", tags=("search", "external")
+        ),
+        "vector_query": ToolDescriptor(
+            name="vector_query", tags=("retrieve", "internal")
+        ),
+    }
+
+
+@pytest.fixture()
+def tool_sets() -> dict[str, tuple[str, ...]]:
+    return {
+        "analysis_only": ("gpt",),
+        "search_only": ("web_search",),
+        "safe_internal": ("vector_query", "gpt"),
+    }
+
+
+def test_policy_resolution_respects_hierarchy(tool_registry, tool_sets) -> None:
+    stack = PolicyStack(tool_sets=tool_sets)
+    stack.push(
+        {
+            "allow_tools": ["analysis_only"],
+            "deny_tags": ["external"],
+        },
+        scope="global",
+    )
+
+    resolution = stack.effective_allowlist(tool_registry)
+    assert resolution.allowed == {"gpt"}
+    assert resolution.denied == {"web_search", "vector_query"}
+
+    search_decision = resolution.decisions["web_search"]
+    assert not search_decision.allowed
+    assert search_decision.source == "deny_tags"
+    assert search_decision.scope == "global"
+    assert "external" in (search_decision.detail or "")
+
+    loop_policy = {"allow_tools": ["safe_internal"]}
+    stack.push(loop_policy, scope="loop:react")
+    loop_resolution = stack.effective_allowlist(tool_registry)
+
+    assert loop_resolution.decisions["vector_query"].allowed
+    assert loop_resolution.decisions["vector_query"].scope == "loop:react"
+    assert stack.trace[-1].event == "policy_push"
+
+    stack.push({"allow_tools": ["search_only"]}, scope="decision:search")
+    branch_resolution = stack.effective_allowlist(tool_registry)
+
+    # Branch policy should override earlier deny_tags and allow the search tool.
+    assert branch_resolution.decisions["web_search"].allowed
+    assert branch_resolution.decisions["web_search"].scope == "decision:search"
+
+    stack.push({"deny_tools": ["analysis_only"]}, scope="node:block-gpt")
+    deny_resolution = stack.effective_allowlist(tool_registry)
+
+    gpt_decision = deny_resolution.decisions["gpt"]
+    assert not gpt_decision.allowed
+    assert gpt_decision.scope == "node:block-gpt"
+    assert gpt_decision.source == "deny_tools"
+
+
+def test_policy_resolution_implicit_deny_when_allowlist_present(
+    tool_registry, tool_sets
+) -> None:
+    stack = PolicyStack(tool_sets=tool_sets)
+    stack.push({"allow_tags": ["analysis"]}, scope="global")
+    resolution = stack.effective_allowlist(tool_registry)
+
+    assert resolution.decisions["gpt"].allowed
+    assert not resolution.decisions["web_search"].allowed
+    assert resolution.decisions["web_search"].source == "implicit_deny"
+
+    stack.push({"allow_tags": ["search"]}, scope="decision:search")
+    branch_resolution = stack.effective_allowlist(tool_registry)
+    assert branch_resolution.decisions["web_search"].allowed


### PR DESCRIPTION
## Summary
- add a policy engine with hierarchical stack evaluation primitives for tools and tags
- implement a DSL linter helper that flags nodes whose tools are blocked by policy contexts
- cover behaviour with policy resolution and linter unit tests

## Testing
- `pytest tests/unit/test_policy_stack_resolution.py tests/unit/test_linter_unreachable_tools.py`
- `./scripts/ensure_green.sh` *(fails: transport parity test in integration suite reports mismatched transport metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68e7bcd0bde0832ca09acc8a33b82b08