### PR TITLE
Support async toolpack execution within running event loops

### DIFF
--- a/apps/mcp_server/stdio/server.py
+++ b/apps/mcp_server/stdio/server.py
@@ -125,7 +125,7 @@ class JsonRpcStdioServer:
                 method="mcp.tool.invoke",
                 deterministic_ids=self._deterministic_ids,
             )
-            envelope = self._service.invoke_tool(
+            envelope = await self._service.invoke_tool_async(
                 tool_id=tool_id,
                 arguments=arguments,
                 context=context,

--- a/docs/toolpacks_executor.md
+++ b/docs/toolpacks_executor.md
@@ -20,6 +20,14 @@ result = executor.run_toolpack(pack, {"text": "hello"})
 print(result["text"])
 ```
 
+Async transports can await toolpacks directly using the asynchronous helpers:
+
+```python
+async def invoke():
+    result = await executor.run_toolpack_async(pack, {"text": "hello"})
+    print(result["text"])
+```
+
 To capture execution metrics alongside the payload, use
 `run_toolpack_with_stats`:
 
@@ -53,7 +61,9 @@ be retrieved via `executor.last_run_stats()`.
 - Handlers are resolved via the `execution.module` field using the
   `module:callable` convention. Invalid formats, missing modules, missing
   callables, or non-callable attributes raise `ToolpackExecutionError`.
-- Async handlers (`async def`) are awaited automatically via `asyncio.run`.
+- Async handlers (`async def`) are awaited automatically. Use the `run_toolpack_async`
+  or `run_toolpack_with_stats_async` helpers when invoking toolpacks from within an
+  active event loop.
 - Schema-level problems raised by the loader (invalid `$ref` targets or schema
   definitions) surface as `ToolpackValidationError`, while runtime or validation
   problems surface as `ToolpackExecutionError`.


### PR DESCRIPTION
## Summary
- add async execution helpers in the toolpack executor and guard synchronous entrypoints when an event loop is active
- expose an async McpService.invoke_tool path and use it from the STDIO transport so async toolpacks run under the server loop
- document the async helpers and add regression coverage for invoking async toolpacks from a running loop

## Testing
- pytest tests/unit/test_toolpacks_exec_python.py tests/unit/mcp/test_stdio_transport.py tests/unit/mcp/test_mcp_service.py tests/unit/mcp/test_mcp_service_guardrails.py

------
https://chatgpt.com/codex/tasks/task_e_68e7bce1e7b0832c8934091714d48aeb