### PR TITLE
Add comparative review and unified plan for DSL policy engine

### DIFF
--- a/codex/agents/POSTEXECUTION/P1/07a_dsl_policy_engine_completion.yaml-20240225T112233Z
+++ b/codex/agents/POSTEXECUTION/P1/07a_dsl_policy_engine_completion.yaml-20240225T112233Z
@@ -1,0 +1,17 @@
+post_execution_feedback:
+  was_successful: null
+  failed_tasks: []
+  recommended_revisions: []
+
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+
+codex_directives:
+  must:
+    - attribute reused logic to specific branches
+    - emit `policy_resolved` trace
+  do_not:
+    - invent tools or APIs not seen in diffs
+    - reuse test logic without attribution

--- a/codex/agents/REVIEWS/P1/07a_dsl_policy_engine_completion.yaml-20240225T112233Z
+++ b/codex/agents/REVIEWS/P1/07a_dsl_policy_engine_completion.yaml-20240225T112233Z
@@ -1,0 +1,103 @@
+metadata:
+  last_updated: 2024-02-25T11:22:33Z
+  repo: pfahlr/
+  tags: [dsl, codex_task, policy_engine, traceability, refactor]
+  execution_mode: plan_synthesis
+analysis:
+  branch_diffs:
+    - from: codex/implement-dsl-policy-engine-in-yaml
+      to: codex/implement-dsl-policy-engine-in-yaml-81p0id
+      git_diff: |
+        diff --git a/pkgs/dsl/policy.py b/pkgs/dsl/policy.py
+        @@
+        -class PolicyTraceEvent:
+        -    event: str
+        -    scope: str
+        -    data: Mapping[str, object]
+        +class PolicyEvent:
+        +    event: str
+        +    scope: str
+        +    payload: dict[str, Any] = field(default_factory=dict)
+        @@
+        -class PolicyResolution:
+        -    allowed: frozenset[str]
+        -    blocked: frozenset[str]
+        -    reasons: Mapping[str, str]
+        +class PolicyDecision:
+        +    allowed: set[str]
+        +    denied: dict[str, str]
+        +    candidates: list[str]
+        +    stack_depth: int
+        @@
+        -        self.trace.record(PolicyTraceEvent(event="policy_resolved", scope="stack", data=...))
+        +        self._emit("policy_allowlist", scope, {"allowed": sorted(allowed_candidates), ...})
+      commentary: |
+        81p0id pivots to a mutating allowlist state machine that emits per-scope payloads but iterates frames oldest-to-newest, so later scopes cannot relax upstream denials. It also drops cycle detection and the explicit `policy_resolved` trace, replacing it with a bespoke `policy_allowlist` event, which diverges from the spec contract.
+    - from: codex/implement-dsl-policy-engine-in-yaml
+      to: codex/implement-dsl-policy-engine-in-yaml-reclz1
+      git_diff: |
+        diff --git a/pkgs/dsl/policy.py b/pkgs/dsl/policy.py
+        @@
+        -class PolicyResolution:
+        -    allowed: frozenset[str]
+        -    blocked: frozenset[str]
+        -    reasons: Mapping[str, str]
+        +class PolicyResolution:
+        +    allowed: frozenset[str]
+        +    denied: frozenset[str]
+        +    decisions: Mapping[str, PolicyDecision]
+        @@
+        -class PolicyStack:
+        -    def __init__(self, *, tools: Mapping[str, Mapping[str, object]], ...):
+        +class PolicyStack:
+        +    def __init__(self, *, tool_sets: Mapping[str, Sequence[str]] | None = None, ...):
+        @@
+        +    def effective_allowlist(self, tools: Mapping[str, ToolDescriptor | Mapping[str, object]]) -> PolicyResolution:
+        +        descriptors = {name: ToolDescriptor.from_mapping(...)}
+        +        ...
+      commentary: |
+        reclz1 introduces `ToolDescriptor` modeling and contextual stack cloning so the linter can explore loop and decision branches. However, the stack no longer owns the canonical tool registry, so unknown tool references slip through unchecked and pushes skip `None` policies entirely, reducing trace coverage.
+    - from: codex/implement-dsl-policy-engine-in-yaml
+      to: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+      git_diff: |
+        diff --git a/pkgs/dsl/policy.py b/pkgs/dsl/policy.py
+        @@
+        -class PolicyError(RuntimeError):
+        -    ...
+        +class PolicyDefinitionError(ValueError):
+        +class PolicyViolationError(RuntimeError):
+        @@
+        +@dataclass(frozen=True)
+        +class PolicySnapshot:
+        +    allowed_tools: frozenset[str]
+        +    denied_tools: Mapping[str, PolicyDenial]
+        +    stack: Sequence[str]
+        @@
+        +    def enforce(self, tool_ref: str, *, scope: str | None = None, raise_on_violation: bool = True) -> bool:
+        +        ...
+      commentary: |
+        yp01n0 layers an `enforce()` API and violation emission pathway around precomputed snapshots, adding structured denial metadata. Yet allowlist resolution still walks scopes from oldest to newest, so “nearest scope wins” is lost, and `_tools_with_tags_mapping()` records the first matching tag instead of the most local directive.
+  summary_of_findings:
+    common_flaws:
+      - Later scopes cannot override upstream allow/deny choices because 81p0id and yp01n0 iterate frames in insertion order instead of reverse order.
+      - None of the variants emit the exact `policy_resolved` trace envelope defined in the base branch.
+    unique_strengths:
+      - reclz1 supplies branch-aware linting with loop/decision context cloning.
+      - yp01n0 adds `PolicyViolationError` plus an `enforce()` façade ready for runner integration.
+      - 81p0id captures verbose denial diagnostics per candidate tool, useful for observability.
+    critical_gaps:
+      - reclz1 drops validation for unknown tools and tool-set cycles, so malformed policies are silently accepted.
+      - yp01n0 always pushes even empty policies and lacks cycle detection, polluting traces and hiding configuration bugs.
+      - 81p0id omits an exception path for unknown tools, relying on `KeyError` instead of a typed error.
+confidence_notes:
+  - area: enforce() semantics
+    confidence: medium
+    reason: Branches disagree on stack traversal order and denial precedence, so expected behavior requires clarification from the spec owner.
+coverage_gaps:
+  - missing: unit test for `policy_resolved` trace when computing allowlists.
+  - missing: recursion validation in allowlist expansion (tool-set cycles) in all but the base branch.
+traceability_checklist:
+  - must-emit: push
+  - must-emit: pop
+  - must-emit: policy_resolved
+  - must-raise: PolicyViolationError

--- a/codex/agents/TASKS_FINAL/P1/07a_dsl_policy_engine_completion.yaml-20240225T112233Z
+++ b/codex/agents/TASKS_FINAL/P1/07a_dsl_policy_engine_completion.yaml-20240225T112233Z
@@ -1,0 +1,105 @@
+plan_preview:
+  branch_inclusions:
+    - codex/implement-dsl-policy-engine-in-yaml: cycle-safe tool expansion and canonical traces
+    - codex/implement-dsl-policy-engine-in-yaml-reclz1: ToolDescriptor model + branch/loop linter contexts
+    - codex/implement-dsl-policy-engine-in-yaml-yp01n0: enforce() API and PolicyViolationError surface
+    - codex/implement-dsl-policy-engine-in-yaml-81p0id: rich denial diagnostics for observability
+  conflict_resolution:
+    - Reapply nearest-scope-wins by iterating frames in reverse order before computing allow/deny results.
+    - Normalize trace emission to the base branch contract (push/pop/policy_resolved/violation) while keeping richer payloads optional.
+    - Validate tool-set expansion for unknown references and cycles before accepting policies.
+  exclusions:
+    - Drop 81p0id's global state mutation that prevents local overrides.
+    - Avoid yp01n0's push-of-empty-policies side effect to keep trace noise minimal.
+  open_questions:
+    - Clarify from spec owners whether policy traces should attach stack depth metadata or remain minimal JSON per base branch.
+    - Confirm whether allow_tags should expand via registry snapshot at push time or defer evaluation per resolution.
+  redesign_decisions:
+    - Model tool metadata via ToolDescriptor but keep registry ownership in PolicyStack for validation consistency.
+    - Provide a deterministic TraceRecorder abstraction that can be replaced by runner sinks without altering APIs.
+refinement_opportunities:
+  - Refactor PolicyStack into explicit PolicyScope objects enabling memoized allowlist caching per stack signature.
+  - Replace ad-hoc tag filtering in linter with shared helper from PolicyStack to reduce divergence.
+shared_blocks:
+  - name: scope_enforcer
+    implementation: |
+      def enforce_scope_resolution(stack: PolicyStack, tool: str, *, scope: str | None = None) -> PolicyResolution:
+          snapshot = stack.effective_allowlist()
+          if tool in snapshot.allowed:
+              return snapshot
+          raise PolicyViolationError(f"Tool '{tool}' blocked in scope {scope or '<unspecified>'}")
+  - name: trace_event_emitter
+    implementation: |
+      def emit_trace_event(trace: PolicyTraceRecorder, event_type: str, scope: str, payload: Mapping[str, object]) -> None:
+          trace.record(PolicyTraceEvent(event=event_type, scope=scope, data=dict(payload)))
+
+tasks:
+  - id: setup_policy_core
+    execution_mode: always
+    reusable: true
+    description: >
+      Restore PolicyStack ownership of the tool registry, enforce cycle-safe tool-set expansion, and compute nearest-scope-wins allowlists with deterministic `policy_resolved` traces.
+    source_files:
+      - pkgs/dsl/policy.py
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml
+    implementation_ref: trace_event_emitter
+  - id: integrate_diagnostics_layer
+    execution_mode: always
+    reusable: true
+    description: Extend PolicyStack data structures to use ToolDescriptor metadata and expose decision details for diagnostics.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+    dependencies: [setup_policy_core]
+    source_files:
+      - pkgs/dsl/models.py
+      - pkgs/dsl/policy.py
+    implementation:
+      python: |
+        @dataclass(frozen=True, slots=True)
+        class ToolDescriptor:
+            name: str
+            tags: tuple[str, ...]
+  - id: add_policy_enforce_api
+    execution_mode: always
+    reusable: false
+    description: Publish the enforce() API with PolicyViolationError and structured violation traces without regressing stack semantics.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+    dependencies: [integrate_diagnostics_layer]
+    source_files:
+      - pkgs/dsl/policy.py
+    tests:
+      - name: test_blocked_tool_raises
+        file: tests/unit/test_policy_enforce.py
+  - id: finalize_tracing_contract
+    execution_mode: optional
+    reusable: true
+    description: Emit push, pop, policy_resolved, and violation events with consistent payload schemas, keeping denial diagnostics from 81p0id.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-81p0id
+    dependencies: [add_policy_enforce_api]
+    source_files:
+      - pkgs/dsl/policy.py
+    implementation_ref: trace_event_emitter
+    artifacts:
+      - name: policy_event_schema
+        file: codex/specs/schemas/policy_trace_event.schema.json
+  - id: expand_linter_reachability
+    execution_mode: always
+    reusable: true
+    description: Merge branch- and loop-aware policy contexts into the linter while sourcing validation helpers from the unified stack.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+    dependencies: [finalize_tracing_contract]
+    source_files:
+      - pkgs/dsl/linter.py
+      - pkgs/dsl/policy.py
+
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+
+codex_directives:
+  must:
+    - attribute reused logic to specific branches
+    - emit `policy_resolved` trace
+  do_not:
+    - invent tools or APIs not seen in diffs
+    - reuse test logic without attribution


### PR DESCRIPTION
## Summary
- document branch-by-branch diffs for the DSL policy engine task and highlight major regressions
- capture a plan preview synthesizing the strongest concepts from each branch with conflict resolutions
- record post-execution feedback and downstream directives for future Codex agents

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e82fd60f08832cbd72951c18af1ab4