### PR TITLE
Add policy engine branch comparison review and plan

### DIFF
--- a/codex/agents/POSTEXECUTION/P1/07a_dsl_policy_engine_completion.yaml-20250317-81c1
+++ b/codex/agents/POSTEXECUTION/P1/07a_dsl_policy_engine_completion.yaml-20250317-81c1
@@ -1,0 +1,15 @@
+post_execution_feedback:
+  was_successful: null
+  failed_tasks: []
+  recommended_revisions: []
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+codex_directives:
+  must:
+    - attribute reused logic to specific branches
+    - emit policy_resolved trace
+  do_not:
+    - invent tools or APIs not seen in diffs
+    - reuse test logic without attribution

--- a/codex/agents/REVIEWS/P1/07a_dsl_policy_engine_completion.yaml-20250317-81c1
+++ b/codex/agents/REVIEWS/P1/07a_dsl_policy_engine_completion.yaml-20250317-81c1
@@ -1,0 +1,127 @@
+metadata:
+  last_updated: 2025-03-17
+  repo: pfahlr/
+  tags: [dsl, codex_task, policy_engine, traceability, refactor]
+  execution_mode: plan_synthesis
+analysis:
+  branch_diffs:
+    - from: codex/implement-dsl-policy-engine-in-yaml
+      to: codex/implement-dsl-policy-engine-in-yaml-81p0id
+      git_diff: |
+        --- a/pkgs/dsl/policy.py
+        +++ b/pkgs/dsl/policy.py
+        @@
+        -class PolicyTraceRecorder:
+        -    """Collects policy trace events for later inspection."""
+        -    def __init__(self) -> None:
+        -        self.events: list[PolicyTraceEvent] = []
+        +class PolicyEvent:
+        +    """Structured trace emitted by ``PolicyStack`` operations."""
+        +    payload: dict[str, Any] = field(default_factory=dict)
+        @@
+        -        self.trace.record(
+        -            PolicyTraceEvent(event="policy_resolved", scope="stack", data={...})
+        -        )
+        +        self._emit(
+        +            "policy_allowlist",
+        +            self.stack[-1].scope if self.stack else "global",
+        +            {"allowed": sorted(allowed_candidates), "denied": denied_candidates},
+        +        )
+      commentary: |
+        Branch 81p0id swaps the recorder abstraction for a bare list of ``PolicyEvent``
+        records, but the contract regresses: ``effective_allowlist`` emits a non-spec
+        ``policy_allowlist`` event and only tracks denial reasons for the provided
+        candidates. Because the evaluation loop walks frames in push order, newer
+        scopes cannot re-allow a tool denied earlier, breaking the nearest-scope-wins
+        rule. Unknown tool references only raise ``KeyError`` on access and set
+        expansion does not detect cycles.
+    - from: codex/implement-dsl-policy-engine-in-yaml
+      to: codex/implement-dsl-policy-engine-in-yaml-reclz1
+      git_diff: |
+        --- a/pkgs/dsl/policy.py
+        +++ b/pkgs/dsl/policy.py
+        @@
+        -class PolicyDefinition:
+        -    allow_tools: frozenset[str] | None = None
+        -    deny_tools: frozenset[str] | None = None
+        +class PolicyDecision:
+        +    allowed: bool
+        +    source: str
+        +    scope: str
+        @@
+        -class PolicyStack:
+        -    def __init__(..., tools: Mapping[str, Mapping[str, object]], ...):
+        -        self._tools = {...}
+        +class PolicyStack:
+        +    def __init__(..., tool_sets: Mapping[str, Sequence[str]] | None = None, trace=None):
+        +        self._tool_sets = {...}
+        +        self.stack: list[_PolicyFrame] = []
+        +        self.trace: MutableSequence[PolicyTraceEvent] = trace or []
+      commentary: |
+        Branch reclz1 promotes richer diagnostics by introducing ``ToolDescriptor``
+        objects, per-tool ``PolicyDecision`` records, and stack cloning for branch
+        previews. It no longer retains a registry of known tools in the stack
+        itself—callers must pass descriptors to ``effective_allowlist``—so unknown
+        tool references in directives silently pass through. Trace coverage still
+        lacks ``policy_resolved`` and no violation event is emitted.
+    - from: codex/implement-dsl-policy-engine-in-yaml
+      to: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+      git_diff: |
+        --- a/pkgs/dsl/policy.py
+        +++ b/pkgs/dsl/policy.py
+        @@
+        -class PolicyTraceEvent:
+        -    event: str
+        -    scope: str
+        -    data: Mapping[str, object]
+        +class PolicyEvent:
+        +    kind: str
+        +    scope: str
+        +    policy: Mapping[str, Any] | None
+        +    detail: Mapping[str, Any] = field(default_factory=dict)
+        @@
+        -class PolicyStack:
+        -    def effective_allowlist(self) -> PolicyResolution:
+        -        ...
+        +class PolicyStack:
+        +    def enforce(self, tool_ref: str, *, scope: str | None = None,
+        +                 raise_on_violation: bool = True) -> bool:
+        +        ...
+      commentary: |
+        Branch yp01n0 layers in enforcement primitives (``PolicyViolationError``,
+        ``PolicyEvent`` sink, ``PolicySnapshot``) and validates tool/set references on
+        ingestion. However, stack evaluation iterates frames in insertion order, so a
+        later scope cannot override an earlier denial, and ``policy_resolved`` traces
+        disappear. Tool-set expansion still lacks cycle detection.
+  summary_of_findings:
+    common_flaws:
+      - Missing ``policy_resolved`` trace emission across non-base branches.
+      - No branch wires policy evaluation into unit tests; coverage remains absent.
+      - Tool-set expansion lacks cycle detection in every variant.
+    unique_strengths:
+      - codex/implement-dsl-policy-engine-in-yaml provides robust normalization,
+        cycle protection, and complete trace coverage for push/pop/resolved events.
+      - codex/implement-dsl-policy-engine-in-yaml-reclz1 adds reusable
+        ``ToolDescriptor`` models and per-tool decision diagnostics.
+      - codex/implement-dsl-policy-engine-in-yaml-yp01n0 introduces
+        ``PolicyViolationError`` plus an ``enforce()`` API with event sink hooks.
+    critical_gaps:
+      - codex/implement-dsl-policy-engine-in-yaml-81p0id breaks nearest-scope-wins by
+        evaluating in FIFO order and never clearing prior denials.
+      - codex/implement-dsl-policy-engine-in-yaml-reclz1 silently accepts unknown
+        tools/sets, deferring discovery until runtime consumers pass registries.
+      - codex/implement-dsl-policy-engine-in-yaml-yp01n0 emits no ``policy_resolved``
+        trace and leaves allowlist decisions irreversible once filtered.
+confidence_notes:
+  - area: enforce() semantics
+    confidence: medium
+    reason: Divergent stack traversal strategies lead to inconsistent allow/deny
+      overrides across branches.
+coverage_gaps:
+  - missing: Unit tests validating ``policy_resolved`` traces across push/pop cycles.
+  - missing: Regression tests for recursive tool-set cycle validation.
+traceability_checklist:
+  - must-emit: push
+  - must-emit: pop
+  - must-emit: policy_resolved
+  - must-raise: PolicyViolationError

--- a/codex/agents/TASKS_FINAL/P1/07a_dsl_policy_engine_completion.yaml-20250317-81c1
+++ b/codex/agents/TASKS_FINAL/P1/07a_dsl_policy_engine_completion.yaml-20250317-81c1
@@ -1,0 +1,103 @@
+plan_preview:
+  branch_inclusions:
+    - codex/implement-dsl-policy-engine-in-yaml: stack normalization, cycle-safe tool-set expansion, and trace recorder contract.
+    - codex/implement-dsl-policy-engine-in-yaml-reclz1: ToolDescriptor model plus per-tool decision diagnostics.
+    - codex/implement-dsl-policy-engine-in-yaml-yp01n0: enforce() API, PolicyViolationError, and event-sink hook for violations.
+  conflict_resolution:
+    - Reconcile trace contracts by standardizing on PolicyTraceEvent(event/scope/payload) while retaining base branch recorder semantics and adding optional sinks.
+    - Preserve nearest-scope-wins by iterating frames in LIFO order; override FIFO logic from 81p0id/yp01n0 with explicit tests.
+    - Merge policy normalization paths so allow/deny directives accept iterables yet validate tool existence using registry + descriptors.
+  exclusions:
+    - Drop 81p0id's candidate-filtered PolicyDecision dataclass in favor of richer decisions map covering all tools.
+    - Avoid reclz1's silent acceptance of unknown tool references; always validate during push/expansion.
+  open_questions:
+    - Should enforce() reuse cached PolicyResolution snapshots across repeated calls within a scope to avoid recomputation?
+    - What is the canonical sink interface for downstream tracing (callable vs. recorder vs. structured logger)?
+    - How should allowlist resolution handle empty stack scenarios for runner bootstrap traces?
+refinement_opportunities:
+  - Introduce immutable PolicyStackView objects for snapshotting without copying entire stack lists.
+  - Parameterize tag matching to allow future plug-in validators (e.g., regex tags or capability classes).
+  - Extend linter diagnostics to surface branch-context lineage alongside denial reasons.
+shared_blocks:
+  - name: scope_resolution_core
+    implementation: |
+      def resolve_effective_directives(stack: Sequence[_PolicyLayer]) -> tuple[
+          frozenset[str] | None,
+          frozenset[str] | None,
+          frozenset[str] | None,
+          frozenset[str] | None,
+      ]:
+          allow_tools = next((layer.policy.allow_tools for layer in reversed(stack) if layer.policy.allow_tools is not None), None)
+          deny_tools = next((layer.policy.deny_tools for layer in reversed(stack) if layer.policy.deny_tools is not None), None)
+          allow_tags = next((layer.policy.allow_tags for layer in reversed(stack) if layer.policy.allow_tags is not None), None)
+          deny_tags = next((layer.policy.deny_tags for layer in reversed(stack) if layer.policy.deny_tags is not None), None)
+          return allow_tools, deny_tools, allow_tags, deny_tags
+  - name: trace_emitter
+    implementation: |
+      def emit_trace(event: str, scope: str, payload: Mapping[str, object], recorder: PolicyTraceRecorder, sink: Callable[[PolicyTraceEvent], None] | None) -> None:
+          record = PolicyTraceEvent(event=event, scope=scope, data=MappingProxyType(dict(payload)))
+          recorder.record(record)
+          if sink is not None:
+              sink(record)
+tasks:
+  - id: policy_stack_core
+    execution_mode: always
+    reusable: true
+    description: Integrate tool registry normalization, cycle-safe tool-set expansion, and nearest-scope-wins evaluation into PolicyStack.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml
+    source_files:
+      - pkgs/dsl/policy.py
+    implementation_ref: scope_resolution_core
+  - id: policy_diagnostics_layer
+    execution_mode: always
+    reusable: true
+    description: Introduce ToolDescriptor, PolicyDecision map, and trace payload enrichments for per-tool diagnostics.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+    dependencies: [policy_stack_core]
+    source_files:
+      - pkgs/dsl/models.py
+      - pkgs/dsl/policy.py
+      - pkgs/dsl/__init__.py
+  - id: enforcement_api
+    execution_mode: always
+    reusable: false
+    description: Add enforce() surface, PolicyViolationError, and policy_violation traces with optional sink wiring.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+    dependencies: [policy_diagnostics_layer]
+    source_files:
+      - pkgs/dsl/policy.py
+      - pkgs/dsl/__init__.py
+    tests:
+      - name: test_enforce_blocks_disallowed_tool
+        file: tests/unit/test_policy_stack.py
+      - name: test_enforce_emits_violation_trace
+        file: tests/unit/test_policy_stack.py
+  - id: linter_alignment
+    execution_mode: always
+    reusable: true
+    description: Update DSL linter to consume new PolicyStack diagnostics and ensure fallback/branch analysis honors enhanced decisions.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+    dependencies: [enforcement_api]
+    source_files:
+      - pkgs/dsl/linter.py
+      - tests/unit/test_policy_linter.py
+  - id: trace_contract_tests
+    execution_mode: always
+    reusable: true
+    description: Author unit tests covering push/pop/policy_resolved/violation traces, tool-set cycle guards, and nearest-scope overrides.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml
+    dependencies: [linter_alignment]
+    source_files:
+      - tests/unit/test_policy_traces.py
+      - tests/unit/test_policy_stack.py
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+codex_directives:
+  must:
+    - attribute reused logic to specific branches
+    - emit policy_resolved trace
+  do_not:
+    - invent tools or APIs not seen in diffs
+    - reuse test logic without attribution


### PR DESCRIPTION
## Summary
- capture comparative analysis of the DSL policy engine branches with diff excerpts and findings
- author a consolidated development plan with preview, shared blocks, and execution tasks for downstream agents
- register post-execution feedback contract for task 07a handoff

## Testing
- `./scripts/ensure_green.sh` *(fails: missing numpy dependency in e2e suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e82fd60f08832cbd72951c18af1ab4