### PR TITLE
Add P2 review and synthesis plan for policy engine variants

### DIFF
--- a/codex/agents/POSTEXECUTION/P2/07a_dsl_policy_engine_completion.yaml-20240608-01
+++ b/codex/agents/POSTEXECUTION/P2/07a_dsl_policy_engine_completion.yaml-20240608-01
@@ -1,0 +1,19 @@
+run_id: 20240608-01
+post_execution_feedback:
+  was_successful: null
+  failed_tasks: []
+  recommended_revisions: []
+  synthesis_notes:
+    - reason: opportunity to consolidate trace emission logic across branches
+      recommendation: extract shared `trace_event_emitter` to shared module
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+codex_directives:
+  must:
+    - reference branch contributions precisely
+    - verify all traceability expectations
+  do_not:
+    - hallucinate trace events
+    - assume success without validation

--- a/codex/agents/PREVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240608-01
+++ b/codex/agents/PREVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240608-01
@@ -1,0 +1,19 @@
+run_id: 20240608-01
+plan_preview:
+  reuse:
+    - Leverage the base branch’s PolicyDefinition normalization, tool-set expansion safeguards, and `policy_resolved` trace schema to anchor stack behaviour.
+    - Adopt reclz1’s `ToolDescriptor` model and stack cloning helpers so branch/loop linting can evaluate multiple contexts without mutating the primary stack.
+    - Incorporate 81p0id’s candidate-aware denial diagnostics and decision-branch linting patterns to enrich observability and coverage.
+    - Carry over yp01n0’s enforcement surface (`PolicyViolationError`, event sink, fallback reporting) for runtime guardrails.
+  conflicts:
+    - 81p0id and yp01n0 iterate frames oldest-first and mutate global state; we must replace that with LIFO evaluation while still emitting their richer diagnostics.
+    - reclz1 drops registry ownership, so we need to merge its descriptors without losing base-branch validation and cycle detection.
+    - Event naming diverges (`policy_allowlist` vs `policy_resolved`) and trace payload shapes differ; consolidate into one contract without breaking observability requirements.
+  redesign:
+    - Rework allowlist evaluation into a pure, non-mutating pass that processes frames in reverse order, producing both aggregate snapshots and per-candidate decisions.
+    - Refactor linting into a modular analyzer that can enumerate contexts (graph, loop, decision, fallback) and reuse a shared policy evaluation helper.
+    - Simplify enforcement so `effective_allowlist` can power both snapshotting and `enforce()` without recomputing expensive registry scans each call.
+  open_questions:
+    - How should violation events encode combined deny reasons when multiple scopes contribute (e.g., deny_tags plus implicit allowlist exclusions)?
+    - Do we need to support partial tool registries per subgraph (as reclz1 assumes) or enforce a single canonical registry throughout execution?
+    - Should linter diagnostics report first failure only or aggregate all failing branches/fallback candidates for the same node?

--- a/codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240608-01
+++ b/codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240608-01
@@ -1,0 +1,30 @@
+run_id: 20240608-01
+review:
+  Branch: codex/implement-dsl-policy-engine-in-yaml
+    - Policy stack keeps its own normalized registry, expands tool sets with cycle detection, and emits structured push/pop/resolved events via the recorder; this gives us deterministic traces and validates references up front.
+    - Effective allowlist merges allow-tools and allow-tags and subtracts denies, but it only surfaces flat string reasons and lacks per-scope diagnostics or candidate filtering, so observability is limited compared to other variants.
+    - Flow linter walks graph nodes but never explores decision options or loop contexts, so it will miss scope-specific overrides that the DSL spec demands; tests cover only the straight-line happy path with a single unreachable unit.
+    - Test suite asserts nearest-scope wins with a single push/pop scenario and validates unknown reference errors, yet it omits branch, loop, and fallback combinations, leaving large parts of the spec untested.
+  Branch: codex/implement-dsl-policy-engine-in-yaml-81p0id
+    - Introduces `PolicyDecision` snapshots that include candidate filtering and denial messaging, and the linter inspects decision branches for unreachable targets—useful coverage we do not have elsewhere.
+    - Stack evaluation walks frames in insertion order and permanently flips entries in a mutable state map, so once a tool is excluded by an outer scope no nearer scope can re-allow it; this violates nearest-scope-wins semantics and contradicts the spec’s allowlist formula.
+    - Trace emitter renames the required `policy_resolved` event to `policy_allowlist`, and scope safety regresses because `pop()` no longer validates which frame is removed.
+    - Tests exercise candidate filtering and trace contents but do not cover override repairs or tool-set recursion, so the precedence bug slips through unnoticed.
+  Branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+    - Splits tool metadata into `ToolDescriptor`, tracks per-tool `PolicyDecision` objects, and clones stacks to evaluate branch/loop contexts—strong building blocks for linting complex flows.
+    - The stack no longer owns the tool registry: callers pass tool maps into `effective_allowlist`, so allow/deny entries referencing unknown tools silently become pseudo-tools; `_expand_tool_entries` also lacks cycle detection, letting recursive tool sets leak into the decision map.
+    - Trace coverage still omits a resolved snapshot event, and there is no violation pathway or enforcement API, so downstream observability remains incomplete.
+    - Tests validate implicit deny behaviour and node contexts but never assert rejection of bad tool references or fallback reachability, leaving critical error handling unguarded.
+  Branch: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+    - Adds `PolicyViolationError`, an event sink, and `PolicySnapshot` with denial metadata, plus a linter that reports blocked fallbacks—valuable enforcement primitives.
+    - Allowlist computation intersects allowed sets while iterating frames oldest-to-newest, so later scopes cannot reintroduce tools filtered earlier; denial reasons accumulate even when an override should succeed, breaking nearest-scope wins just like 81p0id.
+    - Stack accepts empty or `None` policies and still emits events, but there is no path for branch/loop previews and the linter does not explore decision contexts, leaving major DSL features uncovered.
+    - Tests couple to the master spec YAML at runtime and do not assert branch overrides, so precedence bugs persist and the suite becomes fragile to unrelated spec edits.
+Redundancy or hallucination check:
+  - All branches agree on core primitives (push/pop/effective_allowlist) but only the base branch emits the spec-mandated `policy_resolved` trace; 81p0id and yp01n0 rename behaviour without updating the contract. No branch hallucinates unsupported DSL features, yet reclz1/yp01n0 assume optional branch coverage without actually implementing decision-aware linting.
+Synthesis rationale:
+  - Use the base branch as the structural backbone for stack ownership, tool-set validation, and canonical trace schema. Layer in reclz1’s `ToolDescriptor` model, per-tool decisions, and branch/loop context cloning, then port the richer diagnostics from 81p0id (candidate denial messaging) and yp01n0 (violation events and enforcement API) while fixing the precedence bug by evaluating frames in LIFO order. Ensure tests combine branch, loop, and fallback scenarios that previously slipped through.
+Optional enhancements:
+  - Extract a shared trace emitter so events from allowlist resolution and violations use one schema, enabling replayable observability hooks.
+  - Expand the linter test matrix to cover loops, branch overrides, and fallback success/denial paths, ideally with Hypothesis-based tool-set permutations.
+  - Add dedicated cycle-detection tests for tool-set expansion and negative cases for unknown tool references to prevent silent acceptance in future variants.

--- a/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20240608-01
+++ b/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20240608-01
@@ -1,0 +1,90 @@
+plan_preview:
+  branch_inclusions:
+    - codex/implement-dsl-policy-engine-in-yaml: stack-owned registry, cycle-safe tool-set expansion, and canonical policy_resolved traces.
+    - codex/implement-dsl-policy-engine-in-yaml-81p0id: candidate-level denial diagnostics and decision-branch lint scaffolding.
+    - codex/implement-dsl-policy-engine-in-yaml-reclz1: ToolDescriptor normalization plus stack cloning for loop/decision contexts.
+    - codex/implement-dsl-policy-engine-in-yaml-yp01n0: enforce()/PolicyViolationError surface and event-sink plumbing.
+  conflict_resolution:
+    - Re-evaluate policy frames in LIFO order using immutable snapshots to restore nearest-scope-wins while still emitting detailed diagnostics.
+    - Retain baseline scope-checked pop semantics and registry validation when blending reclz1 descriptor handling.
+    - Normalize trace event kinds to push/pop/policy_resolved/policy_violation and back them with a shared emitter API.
+  redesign_decisions:
+    - Introduce a PolicySnapshot builder that produces both aggregate allowlists and per-tool decisions without mutating shared state.
+    - Promote ToolDescriptor into the policy core so the stack owns canonical metadata yet exposes read-only views for the linter.
+    - Split linter evaluation into reusable helpers (context expansion, candidate analysis) to support loops, decisions, and fallback checks uniformly.
+  exclusions:
+    - Drop reclz1’s silent skip for falsy policies; always push explicit frames so traces stay complete.
+    - Avoid 81p0id/yp01n0’s FIFO iteration and mutable state tables.
+  open_questions:
+    - Should violation events aggregate multiple contributing scopes or report only the nearest blocker?
+    - Do we need asynchronous trace dispatch for future observability tooling, or is synchronous emission sufficient for now?
+shared_blocks:
+  - name: trace_event_emitter
+    implementation: |
+      def emit_policy_event(callback: Callable[[PolicyEvent], None] | None, event: PolicyEvent, recorder: list[PolicyEvent] | None) -> None:
+          if callback:
+              callback(event)
+          elif recorder is not None:
+              recorder.append(event)
+  - name: scope_pop_guard
+    implementation: |
+      def pop_with_scope(stack: list[_PolicyFrame], expected_scope: str) -> _PolicyFrame:
+          frame = stack.pop()
+          if frame.scope != expected_scope:
+              raise PolicyError(f"Policy stack scope mismatch: expected '{expected_scope}', got '{frame.scope}'")
+          return frame
+tasks:
+  - id: establish_policy_runtime
+    execution_mode: always
+    reusable: true
+    description: |
+      Refactor PolicyStack to own ToolDescriptor-driven registry data, expand tool sets with cycle detection, and compute PolicySnapshot outputs by scanning frames newest-to-oldest. Emit push/pop/policy_resolved events through trace_event_emitter and enforce scope validation with scope_pop_guard.
+    source_files:
+      - pkgs/dsl/policy.py
+      - pkgs/dsl/models.py
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml
+    implementation_ref: scope_pop_guard
+  - id: integrate_enforcement_and_diagnostics
+    execution_mode: always
+    reusable: true
+    description: |
+      Layer enforce() and PolicyViolationError atop the runtime, reusing yp01n0’s violation payload structure while preserving baseline PolicyError taxonomy. Persist candidate-level denial diagnostics inspired by 81p0id inside PolicySnapshot so callers and linter share the same view. Route all events (push/pop/resolved/violation) through trace_event_emitter.
+    dependencies: [establish_policy_runtime]
+    source_files:
+      - pkgs/dsl/policy.py
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+  - id: expand_linter_contexts
+    execution_mode: always
+    reusable: true
+    description: |
+      Merge reclz1’s branch/loop context expansion with 81p0id’s candidate diagnostics to detect unreachable tools, fallbacks, and decision options. Reuse the unified PolicySnapshot API instead of duplicating resolution logic, and ensure tool-set cycles or unknown references surface as errors.
+    dependencies: [establish_policy_runtime]
+    source_files:
+      - pkgs/dsl/linter.py
+      - pkgs/dsl/models.py
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+  - id: author_regression_tests
+    execution_mode: always
+    reusable: false
+    description: |
+      Add pytest coverage for nearest-scope overrides (decision, loop, fallback), policy_resolved emission ordering, enforce() violation hooks, tool-set cycle detection, and linter diagnostics spanning nodes, branches, and fallback exhaustion.
+    dependencies: [integrate_enforcement_and_diagnostics, expand_linter_contexts]
+    source_files:
+      - tests/unit/test_policy_stack_resolution.py
+      - tests/unit/test_linter_unreachable_tools.py
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-81p0id
+    tests:
+      - pytest -k "policy_stack_resolution or linter_unreachable_tools"
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+codex_directives:
+  must:
+    - reuse branch-specific diagnostics in code comments where derived behaviour is ported.
+    - emit policy_resolved and policy_violation events with consistent schemas for observability.
+    - validate tool and tool_set references during push and report actionable errors.
+  do_not:
+    - revert to FIFO evaluation or mutable allowlist state tables.
+    - drop scope validation when popping frames.
+    - invent new trace event kinds beyond the agreed contract.


### PR DESCRIPTION
## Summary
- add Section A comparative review for four policy engine branches
- document plan preview and final implementation plan for P2 synthesis
- record post-execution directives for follow-up work

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e8490f3a40832c9acba46e3af6e297