### PR TITLE
Add comparative review and plan for DSL policy engine variants

### DIFF
--- a/codex/agents/POSTEXECUTION/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
+++ b/codex/agents/POSTEXECUTION/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
@@ -1,0 +1,18 @@
+post_execution_feedback:
+  was_successful: null
+  failed_tasks: []
+  recommended_revisions: []
+  synthesis_notes:
+    - reason: opportunity to consolidate trace emission logic across branches
+      recommendation: extract shared `trace_event_emitter` to shared module
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+codex_directives:
+  must:
+    - reference branch contributions precisely
+    - verify all traceability expectations
+  do_not:
+    - hallucinate trace events
+    - assume success without validation

--- a/codex/agents/PREVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
+++ b/codex/agents/PREVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
@@ -1,0 +1,22 @@
+plan_preview: |
+  Reused logic/structures per branch:
+  - Base (`codex/implement-dsl-policy-engine-in-yaml`): keep tool/ tool-set normalization, cycle-safe `_expand_tool_refs`, and the trace recorder scaffold as the foundation for stack correctness.
+  - `-reclz1`: adopt `ToolDescriptor` modeling, per-tool `PolicyDecision` metadata, and stack cloning strategy for linter contexts.
+  - `-81p0id`: salvage candidate-scoped evaluation (passing explicit candidate lists, denial reason capture) and richer trace payload structure.
+  - `-yp01n0`: port the `PolicySnapshot`/`enforce()` contract and structured `PolicyDenial` wiring so runtime enforcement emits violations consistently.
+
+  Conflicts & planned resolutions:
+  - Frame iteration order: both `-81p0id` and `-yp01n0` walk oldest→newest; I will rebase their candidate/denial logic onto the base branch’s newest→oldest traversal so nearest scope wins.
+  - Trace schemas differ (`PolicyTraceEvent` vs. `PolicyEvent`); I will standardize on the base recorder but expand payload fields to include candidate lists and denial metadata without renaming events.
+  - Registry ownership: `-reclz1` delegates tool validation to callers, conflicting with base guarantees. I will keep registry ownership inside `PolicyStack` while still allowing descriptor views for consumers.
+  - Linter entry points differ (function vs. class). I’ll consolidate around a single `lint_unreachable_tools` facade backed by a reusable analyzer that supports loops/decisions/fallbacks.
+
+  Redesign/simplification targets:
+  - Rework `_tools_with_tags_mapping` to record nearest-scope tag overrides rather than first-match wins.
+  - Unify policy push/pop APIs so scope names and optional sources are always captured; empty policies should still emit traces but short-circuit evaluation work.
+  - Extract a shared trace emitter used by both policy evaluation and linter/enforcement to avoid duplicated event formatting.
+
+  Open questions / trade-offs:
+  - Do we need to persist full `PolicySnapshot` objects for every enforcement call, or can we stream violations via iterators to reduce recomputation cost?
+  - How far should the linter simulate decision paths (e.g., cross-product of nested loops) without exploding runtime—should we cap at a configurable breadth?
+  - Should fallback validation treat non-existent tools as policy violations or defer to schema validation elsewhere?

--- a/codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
+++ b/codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
@@ -1,0 +1,49 @@
+metadata:
+  reviewer: gpt-5-codex
+  created_at: 2025-03-20T00:00:00Z
+  task: 07a_dsl_policy_engine_completion
+  scope: comparative_branch_review
+section_a: |
+  Branch: codex/implement-dsl-policy-engine-in-yaml
+  - ✅ Maintains canonical tool registry normalization with cycle detection for tool sets; `_expand_tool_refs` defends against unknown references and emits consistent `policy_push/pop/resolved` traces via `PolicyTraceRecorder` (`PolicyTraceEvent` payload mirrors spec contract).
+  - ✅ `effective_allowlist()` computes `(allow_tools ∪ allow_tags_matches) − (deny_tools ∪ deny_tags_matches)` while defaulting to "allow all" when no allow directives exist; nearest-scope precedence is respected per dimension by searching the stack in reverse.
+  - ⚠️ Lacks stack cloning or scope exploration for loops/branch policies, so `FlowLinter.find_unreachable_tools()` only evaluates a single stack path (global → node) and misses unreachable decision branches/fallback exhaustions.
+  - ⚠️ `PolicyResolution` exposes only coarse `allowed/blocked/reasons`, so downstream tooling cannot surface per-scope metadata or candidate-specific denials without recomputing.
+  - ⚠️ Test suite (`tests/unit/test_policy_stack_resolution.py`, `test_linter_unreachable_tools.py`) covers simple push/pop and global vs. node overrides but omits decision/loop stacks, fallback exhaustion, and trace-order assertions beyond happy paths.
+
+  Branch: codex/implement-dsl-policy-engine-in-yaml-81p0id
+  - ✅ Introduces candidate-aware `PolicyDecision` objects and richer trace payloads (stack depth, candidate list) plus linter coverage for decision branches and fallback lists.
+  - ❌ Processes stack frames oldest-to-newest and never re-allows tools once `state[tool]` becomes `False`; downstream scopes cannot relax upstream deny/allow filters, violating the spec’s "nearest scope wins" rule and making branch overrides ineffective.
+  - ❌ Drops tool-set recursion and cycle detection; `_resolve_tool_refs` silently treats nested sets as flat lists and raises `KeyError` only for unknown symbols encountered in policies, reducing diagnostic parity with the base branch.
+  - ❌ Trace contract diverges (`PolicyEvent`/`policy_allowlist`) and `push()` no longer accepts a `source`, so event payloads cannot be correlated with DSL paths.
+  - ⚠️ Linter path reports use `path="nodes.<id>"`, drifting from array-index addressing (`graph.nodes[i]`), and tests still miss loop policy scenarios.
+
+  Branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+  - ✅ Refactors policy evaluation around immutable `ToolDescriptor`s and per-tool `PolicyDecision` metadata, and adds `PolicyStack.clone()` so the linter can explore loop and decision contexts independently.
+  - ✅ Linter builds cartesian stacks by combining graph, loop, branch, and node policies, dramatically improving unreachable-tool detection fidelity (`lint_unreachable_tools`).
+  - ❌ `PolicyStack` no longer owns the canonical tool registry; `_expand_tool_entries` treats unknown references as literal tool names, so typos skip validation and silently cause implicit-deny behavior instead of raising `PolicyError`.
+  - ❌ Trace coverage regresses: no `policy_resolved` emission, push/pop payloads lack normalized policy dicts, and policies equal to `{}` are discarded (skipping traces) even though the spec expects explicit scope entry/exit traces.
+  - ⚠️ Tests validate branch override semantics and implicit deny, but still omit fallback/tool-set cycle cases and rely on manual fixture wiring for loops.
+
+  Branch: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+  - ✅ Adds `PolicySnapshot` + `enforce()` API with structured `PolicyDenial` metadata and `policy_violation` events, enabling runtime enforcement hooks.
+  - ✅ Linter surfaces fallback exhaustion alongside unreachable tools and reuses the policy stack to emit `PolicyDenial` context in issues.
+  - ❌ Stack iteration order is oldest→newest; once a tool is removed from `allowed`, later scopes cannot re-allow it, so branch/loop overrides fail (identical regression to 81p0id).
+  - ❌ `_tools_with_tags_mapping()` records the first matching tag and never overwrites it, so nearer deny-tags cannot supersede distant ones; combined with the iteration bug this breaks tag precedence guarantees.
+  - ❌ `pop()` lacks scope validation, `push()` always appends even-empty policies (inflating `stack`), and no `policy_resolved` trace is emitted, so traceability/stack-safety regress relative to base.
+  - ⚠️ Tests bootstrap from the master spec (heavy I/O) but still do not cover loops, decision-option policies, or enforcement of `tool_sets` recursion/validation.
+
+redundancy_or_hallucination_check: |
+  - Both `-81p0id` and `-yp01n0` independently reinvent candidate-level allowlist evaluation yet share the same nearest-scope regression (processing frames oldest→newest) and omit trace parity—these are redundant mistakes rather than complementary ideas.
+  - No branch hallucinates nonexistent DSL fields, but event naming in `-81p0id` (`policy_allowlist`) and enforcement messaging in `-yp01n0` drift from the spec’s documented trace contract and should be realigned.
+
+synthesis_rationale: |
+  - Start from the base branch’s validated registry normalization, trace recorder, and error semantics to keep tool-set validation and scope-aware tracing intact.
+  - Fold in `reclz1`’s `ToolDescriptor` abstraction, per-tool `PolicyDecision` metadata, and stack cloning strategy so the linter can explore loop/decision contexts without mutating the live stack.
+  - Incorporate candidate-level evaluation and enriched denial reasons from `-81p0id`, but execute frames newest→oldest and reuse the trace recorder so nearest scopes truly dominate.
+  - Adapt `-yp01n0`’s `PolicySnapshot`/`enforce()` concepts by layering them atop the corrected allowlist engine, ensuring violation events reuse the shared trace emitter rather than bespoke sinks.
+
+optional_enhancements: |
+  - Extract a shared `TraceEventEmitter` to keep `policy_push/pop/resolved/violation` payloads consistent across stack, linter, and runtime enforcement.
+  - Augment tests with table-driven cases covering decision-option overrides, nested loop scopes, tool-set recursion/cycle detection, and fallback exhaustion to guard against regressions uncovered across the branches.
+  - Add property-based fuzzing for tag precedence to confirm nearest-scope deny-tags always dominate and that allowlists can expand as policies are pushed/popped.

--- a/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
+++ b/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
@@ -1,0 +1,140 @@
+version: 1
+id: 07a_dsl_policy_engine_completion.plan
+title: Consolidated DSL policy engine completion
+summary: Merge the strongest ideas from four experimental branches into a spec-compliant policy stack, linter, and enforcement suite.
+description: |
+  This plan synthesizes the validated registry normalization and tracing from the base branch with the richer metadata,
+  candidate-aware reasoning, stack cloning, and enforcement pathways explored across the three experimental variants.
+  The outcome is a deterministic PolicyStack that honors nearest-scope precedence, emits structured traces, supports
+  runtime enforcement, and powers a linter that can reason about loops, decisions, and fallbacks.
+metadata:
+  owners: [pfahlr@gmail.com]
+  labels: [dsl, policy-engine, codex]
+  priority: P1
+  risk: medium
+  last_updated: 2025-03-20
+strategy:
+  tests_first: true
+  deterministic: true
+  golden_management: manual
+scope:
+  goals:
+    - Deliver a unified PolicyStack implementation that merges registry validation, per-scope resolution, candidate evaluation, and enforcement hooks.
+    - Extend the DSL linter to explore loop and decision contexts using stack cloning while preserving trace fidelity.
+    - Backfill regression tests for nested scopes, fallback exhaustion, and trace event contracts.
+  non_goals:
+    - Designing new DSL syntax beyond the master specification.
+    - Implementing runtime executors or planners beyond policy enforcement needs.
+assumptions:
+  - Tool and policy schemas continue to align with codex/specs/ragx_master_spec.yaml.
+  - Existing test harness (pytest, ruff, mypy, yamllint) remains green once new tests are added.
+constraints:
+  - Preserve deterministic trace ordering for reproducible policy debugging.
+  - Avoid network calls inside unit tests; rely on in-repo fixtures.
+structured_logging_contract:
+  format: jsonl
+  storage_path_prefix: s3://ragx/policy_engine/traces
+  latest_symlink: latest
+  retention: 30d
+  event_fields: [event, scope, payload.allowed, payload.denied, stack_depth]
+  metadata_fields: [flow_id, run_id, task_id]
+  volatile_fields: [timestamp]
+ci:
+  xfail_marker: policy_engine_known_issue
+  workflows:
+    - name: ensure_green
+      gates: [ruff, mypy, yamllint, pytest]
+      artifacts: [coverage.xml]
+      cache_dependency_paths: [codex/specs, pkgs/dsl]
+artifacts:
+  python_modules:
+    paths:
+      - pkgs/dsl/policy.py
+      - pkgs/dsl/linter.py
+  schemas:
+    paths:
+      - codex/specs/ragx_master_spec.yaml
+  documentation:
+    path: docs/policies.md
+test_matrix:
+  python: ["3.11"]
+  os: [ubuntu-22.04]
+test_plan:
+  unit:
+    - tests/unit/test_policy_stack_resolution.py
+    - tests/unit/test_linter_unreachable_tools.py
+  integration:
+    - tests/unit/test_runner_loops.py
+  property_based:
+    - tests/property/test_policy_tag_precedence.py
+  fixtures:
+    - tests/fixtures/policies/
+actions:
+  - stage: policy_stack_core
+    summary: Reconcile stack invariants, metadata modeling, and trace emission.
+    tasks:
+      - |
+          execution_mode: always
+          reusable: false
+          summary: Merge ToolDescriptor modeling with registry-backed validation and nearest-scope traversal.
+          adapted_from_branch:
+            - codex/implement-dsl-policy-engine-in-yaml
+            - codex/implement-dsl-policy-engine-in-yaml-reclz1
+          steps:
+            - Embed ToolDescriptor normalization inside PolicyStack so allow/deny references validate against the registry while exposing descriptor views.
+            - Rework effective_allowlist traversal to iterate newest→oldest, combining candidate filtering from -81p0id with implicit deny semantics from -reclz1.
+            - Restore policy_push/pop/resolved trace events with enriched payloads (candidates, denial reasons, stack depth).
+          tests:
+            - tests/unit/test_policy_stack_resolution.py::test_branch_policy_overrides
+            - tests/unit/test_policy_stack_resolution.py::test_allow_tags_and_tool_sets_union
+          artifacts:
+            - pkgs/dsl/policy.py
+  - stage: policy_enforcement
+    summary: Introduce runtime enforcement and violation tracing.
+    tasks:
+      - |
+          execution_mode: always
+          reusable: false
+          summary: Layer PolicySnapshot/enforce API onto the corrected PolicyStack.
+          adapted_from_branch:
+            - codex/implement-dsl-policy-engine-in-yaml-yp01n0
+          depends_on:
+            - policy_stack_core
+          steps:
+            - Produce immutable PolicySnapshot objects that capture allowed tools, denial metadata, and stack scopes without recomputing traces.
+            - Implement enforce() to emit policy_violation events through the shared trace emitter and optionally raise PolicyViolationError.
+            - Document enforcement semantics in docs/policies.md with examples for fallback escalation.
+          tests:
+            - tests/unit/test_policy_stack_resolution.py::test_enforce_violation_emits_trace
+            - tests/unit/test_policy_stack_resolution.py::test_snapshot_determinism
+          artifacts:
+            - pkgs/dsl/policy.py
+            - docs/policies.md
+  - stage: linter_and_observability
+    summary: Enhance linter to explore full policy contexts and validate traces.
+    tasks:
+      - |
+          execution_mode: always
+          reusable: true
+          summary: Refactor lint_unreachable_tools to use stack cloning with fallback and decision coverage.
+          adapted_from_branch:
+            - codex/implement-dsl-policy-engine-in-yaml-reclz1
+            - codex/implement-dsl-policy-engine-in-yaml-81p0id
+          depends_on:
+            - policy_stack_core
+          steps:
+            - Build a reusable analyzer that clones the PolicyStack per loop/decision branch and records trace context for unreachable findings.
+            - Validate fallback.try lists and decision branches emit precise issue paths (`graph.nodes[i]...`).
+            - Capture structured logging samples showing policy_push/pop/resolved/violation sequences for representative flows.
+          tests:
+            - tests/unit/test_linter_unreachable_tools.py::test_branch_override_clears_error
+            - tests/unit/test_linter_unreachable_tools.py::test_fallback_exhaustion_error
+            - tests/unit/test_runner_loops.py::test_loop_policy_context_propagates
+          artifacts:
+            - pkgs/dsl/linter.py
+            - docs/policies.md
+            - codex/fixtures/policy_traces.jsonl
+acceptance:
+  - tests/unit/test_policy_stack_resolution.py
+  - tests/unit/test_linter_unreachable_tools.py
+  - Updated docs/policies.md with enforcement guidance


### PR DESCRIPTION
## Summary
- add a detailed comparative review of the four policy-engine branches and document strengths, regressions, and redundancies
- provide a synthesis preview outlining how to merge the best ideas while resolving conflicts
- publish the final implementation plan plus post-execution directives for follow-up work

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e8490f3a40832c9acba46e3af6e297