### PR TITLE
Add policy engine branch synthesis review and plan

### DIFF
--- a/codex/agents/POSTEXECUTION/P2/07a_dsl_policy_engine_completion.yaml-20240516-opsz
+++ b/codex/agents/POSTEXECUTION/P2/07a_dsl_policy_engine_completion.yaml-20240516-opsz
@@ -1,0 +1,18 @@
+post_execution_feedback:
+  was_successful: null
+  failed_tasks: []
+  recommended_revisions: []
+  synthesis_notes:
+    - reason: opportunity to consolidate trace emission logic across branches
+      recommendation: extract shared trace_event_emitter to shared module
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+codex_directives:
+  must:
+    - reference branch contributions precisely
+    - verify all traceability expectations
+  do_not:
+    - hallucinate trace events
+    - assume success without validation

--- a/codex/agents/PREVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240516-opsz
+++ b/codex/agents/PREVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240516-opsz
@@ -1,0 +1,21 @@
+plan_preview: |
+  Reuse plan
+  - Baseline normalization, scope-checked push/pop, and trace recorder wiring from codex/implement-dsl-policy-engine-in-yaml will anchor the policy stack API and validation flow.
+  - Adopt ToolDescriptor modeling, per-tool PolicyDecision provenance, and loop/decision-aware linter traversal from codex/implement-dsl-policy-engine-in-yaml-reclz1 (after adding missing imports and integrating registry ownership).
+  - Bring in the PolicyDenial/PolicySnapshot/enforce() surfaces plus optional event sink contract from codex/implement-dsl-policy-engine-in-yaml-yp01n0 while replacing its intersection semantics with LIFO nearest-wins resolution.
+  - Lift candidate-oriented trace payload enrichment and decision-branch lint assertions from codex/implement-dsl-policy-engine-in-yaml-81p0id, keeping only the observability pieces.
+
+  Conflict resolution
+  - Align policy evaluation order by iterating stack layers in reverse (LIFO) and allowing deeper scopes to replace allow_* directives entirely; drop FIFO loops from 81p0id/yp01n0.
+  - Normalize all policies into canonical frozensets/tuples at push() time so linter + stack share one representation; reject unknown tools/tool_sets immediately (fixing reclz1 gaps).
+  - Unify trace emission via a helper that forwards PolicyTraceEvent objects to both the recorder (baseline branch) and optional sinks (yp01n0) while adding candidate lists (81p0id).
+
+  Redesign / simplification targets
+  - Refactor allowlist computation to reuse a single `_resolve_effective_directives()` routine that returns nearest allow/deny sets and tag filters without repeated expansion.
+  - Collapse disparate linter entry points into a FlowLinter class that can evaluate unit nodes, decision branches, and loop targets using cloned stacks seeded with global + graph policies.
+  - Replace spec-file dependent fixtures with inlined registries to keep tests hermetic and deterministic.
+
+  Open questions / tradeoffs
+  - Do we expose PolicyResolution.decisions publicly (as in reclz1) or keep it internal to avoid leaking implementation details? We may compromise by returning read-only MappingProxyType.
+  - How aggressively should we cache per-tag tool lookups versus recomputing each evaluation to avoid stale data when registries mutate between pushes?
+  - Should enforce() return denial metadata alongside the boolean to reduce duplicate snapshot calculations for callers that want both outcomes and reasons?

--- a/codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240516-opsz
+++ b/codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240516-opsz
@@ -1,0 +1,43 @@
+metadata:
+  reviewer: gpt-5-codex
+  date: 2024-05-16
+  repo: pfahlr/ragx
+  task: 07a_dsl_policy_engine_completion
+analysis: |
+  Branch: codex/implement-dsl-policy-engine-in-yaml
+  - Policy stack stores a normalized tool registry (tags validated, cycle-safe tool-set expansion) and enforces scope discipline on pop(), giving us the cleanest baseline for registry hygiene and stack safety. PolicyTraceRecorder + PolicyTraceEvent provide deterministic traces, though there is no optional sink for downstream logging.
+  - effective_allowlist() respects nearest-wins per dimension by walking the stack in reverse, unions allow_tools with allow_tags at evaluation time, and records denial reasons (`denied:tool:*`, `denied:tag:*`, `not_in_allowlist`). However, it recomputes tool-set expansion each call and never emits which layer granted access, leaving diagnostics minimal versus the richer detail in other branches.
+  - FlowLinter() checks unit nodes and fallbacks against the current stack, but it only considers globals.policy + node.policy; graph-level, decision-option, and loop scopes are ignored so unreachable branches slip through. Tests cover allow/tag merges and fallback validation yet omit decisions/loops and pop() mismatch cases.
+  - Unique contributions: robust normalization, cycle detection during push, scope-checked pop(), compact PolicyResolution with read-only mapping, and an inline trace recorder compatible with spec semantics.
+
+  Branch: codex/implement-dsl-policy-engine-in-yaml-81p0id
+  - PolicyStack here flattens traces to PolicyEvent entries and introduces PolicyDecision (per-candidate) plus optional candidate filtering. Unfortunately, evaluation iterates frames in FIFO order and the allow/deny helpers only turn tools OFF—once a global frame filters a tool out, later (more local) scopes cannot re-allow it. That violates the spec's "nearest wins" rule and prevents branch overrides; tests never catch it.
+  - Normalization is shallow (no iterable/type validation, no cycle detection), pop() drops frames without scope verification, and `_resolve_tool_refs` allows recursive tool sets without guardrails. ValueError on empty tool registries makes linting partial flows brittle.
+  - lint_unreachable_tools adds decision-branch analysis and fallback reasoning but still ignores loop control scopes and never inspects globals.policy. Tests cover candidate filtering and branch diagnostics yet miss denial precedence and error handling for unknown refs.
+  - Unique contributions worth salvaging: candidate-focused PolicyDecision diagnostics, trace payload contents (`candidates`, `stack_depth`), and decision-branch lint coverage. Major regressions: scoping precedence, irreversible allowlist filters, missing validation.
+
+  Branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+  - Introduces ToolDescriptor model, PolicyDecision detail (`allowed`, `source`, `scope`, `detail`), and PolicyResolution.decisions map. Clone() enables branch exploration and the linter indexes loop + decision policies to build per-path stacks, giving the most complete reachability analysis.
+  - However, PolicyStack lacks a tool registry altogether; callers must pass tool maps into effective_allowlist() every time. Without registry ownership, push() can't validate allow/deny references, `_expand_tool_entries` silently accepts unknown names, and tool-set cycles remain unchecked. Multiple imports (Iterable, Sequence, MutableSequence) are missing, so the module will not run as-is. Empty/falsey policies are dropped on push() which prevents explicit clears.
+  - Tests emphasise hierarchical overrides and implicit deny, but never exercise tool-set validation, cycle errors, or stack pop mismatch. Linter tests ensure branch policies unblock paths, yet no loop iteration budget or scope enforcement checks exist.
+  - Unique contributions: ToolDescriptor normalization, per-tool decision provenance, branch/loop-aware linter scaffolding, and clone() reuse. Must fix missing imports and registry validation to make it viable.
+
+  Branch: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+  - Adds PolicyDenial, PolicySnapshot, an enforce() API with PolicyViolationError, and optional event sink wiring for policy_push/pop/violation—all valuable for runner integration and observability. Allow/deny normalization validates entries and records provenance strings.
+  - Core logic is flawed: allowed tools start as the entire registry and every policy frame intersects (`allowed &= subset`). Thus a narrower upstream allowlist permanently removes tools; downstream scopes cannot widen access, again breaking nearest-wins semantics. Deny reasons default to the latest scope even when earlier frames blocked the tool, muddying diagnostics.
+  - Tool/tag expansion runs against stored registry so unknown names raise immediately, but tool_sets are required (no default {}). `effective_allowlist` never caches results and recomputes tags each time. Linter reuses the stack but only looks at globals/flow policy + node policies; loops, decisions, and branch overrides are absent. Tests rely on reading codex/specs/ragx_master_spec.yaml and miss imports (Path, yaml fixtures), so they fail before reaching assertions.
+  - Unique contributions: enforcement API with violation trace emission, PolicySnapshot for bulk inspection, and richer denial metadata. Major regressions: allowlist intersection semantics, overreliance on external spec file in tests, and sparse linter coverage.
+
+  Redundancy / hallucination check
+  - No branch invents unsupported DSL directives, but 81p0id and yp01n0 both hallucinate FIFO scope precedence that contradicts the spec. reclz1 omits registry ownership entirely, assuming callers supply descriptors each time. Tests in yp01n0 hallucinate spec fields (`tool_registry`, `tool_sets`) at top level instead of using globals.tools/tool_sets.
+
+  Synthesis rationale
+  - Use codex/implement-dsl-policy-engine-in-yaml as the structural baseline for registry normalization, cycle-safe tool-set expansion, scope-checked stack ops, and trace recorder contract.
+  - Merge reclz1's ToolDescriptor + per-tool PolicyDecision diagnostics and its branch/loop-aware linter traversal (after fixing imports and registry validation) to provide richer decision provenance.
+  - Incorporate yp01n0's PolicyDenial/PolicySnapshot/enforce() + optional event sink, but rewrite allowlist evaluation to honour LIFO precedence and union semantics instead of intersection.
+  - Borrow 81p0id's trace payload structure (candidate lists, stack depth) for trace enrichment while retaining LIFO semantics and validation from the baseline.
+
+  Optional enhancements
+  - Extract a shared trace_event_emitter that can broadcast to both the in-memory recorder and optional external sinks (per codex directives).
+  - Add targeted tests for decision-option overrides, loop scope propagation, tool-set cycle detection, and pop() scope mismatch to lock in behaviour.
+  - Cache normalized ToolDescriptor registry and tag indexes to avoid recomputation inside effective_allowlist and linter paths.

--- a/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20240516-opsz
+++ b/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20240516-opsz
@@ -1,0 +1,100 @@
+summary:
+  - codex/implement-dsl-policy-engine-in-yaml supplies the registry normalization, scope-safe push/pop, and baseline trace recorder we will retain.
+  - codex/implement-dsl-policy-engine-in-yaml-reclz1 contributes ToolDescriptor modelling, per-tool decision provenance, and branch/loop-aware linter scaffolding.
+  - codex/implement-dsl-policy-engine-in-yaml-81p0id informs trace payload enrichment (candidates, stack depth) for observability.
+  - codex/implement-dsl-policy-engine-in-yaml-yp01n0 contributes PolicyDenial/PolicySnapshot types, enforce() surface, and optional event sink wiring (after fixing LIFO semantics).
+conflict_resolution:
+  - Rebuild allowlist evaluation around LIFO stack traversal so nearest scopes override upstream directives; discard FIFO/intersection logic.
+  - Validate tool and tool_set references during push() using the owned registry, rejecting unknown names and cycles before evaluation.
+  - Standardize trace emission via a helper that records PolicyTraceEvent objects and forwards to optional sinks without duplicating payload assembly.
+exclusions:
+  - Drop yp01n0's intersection-based allowlist contraction and spec-file fixtures.
+  - Skip reclz1's assumption that callers pass tool registries into effective_allowlist(); stack retains ownership instead.
+open_questions:
+  - Determine whether PolicyResolution should expose MappingProxyType decisions publicly or keep them internal to avoid accidental mutation.
+  - Decide on caching strategy for tag-to-tool indexes versus recomputation trade-offs under frequent push/pop churn.
+refinement_opportunities:
+  - Add metrics hooks around enforce() outcomes to support future observability tasks.
+  - Consider memoizing tool-set expansions per scope to avoid repeated recursion in hot paths.
+shared_blocks:
+  - name: trace_event_emitter
+    implementation: |
+      def emit_policy_event(
+          recorder: PolicyTraceRecorder,
+          sink: Callable[[PolicyTraceEvent], None] | None,
+          *,
+          event: str,
+          scope: str,
+          payload: Mapping[str, object],
+      ) -> None:
+          record = PolicyTraceEvent(event=event, scope=scope, data=MappingProxyType(dict(payload)))
+          recorder.record(record)
+          if sink is not None:
+              sink(record)
+tasks:
+  - id: policy_stack_foundation
+    execution_mode: always
+    reusable: true
+    description: Implement PolicyStack with normalized registry + tool-set expansion, cycle detection, scope-checked push/pop, and LIFO directive resolution.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml
+    source_files:
+      - pkgs/dsl/policy.py
+      - pkgs/dsl/__init__.py
+    artifacts:
+      - trace_event_emitter
+    tests:
+      - name: test_policy_stack_resolves_allow_and_deny
+        file: tests/unit/test_policy_stack_resolution.py
+      - name: test_policy_stack_rejects_unknown_tool_ref
+        file: tests/unit/test_policy_stack_resolution.py
+  - id: policy_decision_diagnostics
+    execution_mode: always
+    reusable: true
+    description: Add ToolDescriptor registry, PolicyDecision/PolicyResolution diagnostics map, and enriched trace payloads (candidates, stack depth).
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+    depends_on: [policy_stack_foundation]
+    source_files:
+      - pkgs/dsl/models.py
+      - pkgs/dsl/policy.py
+    tests:
+      - name: test_policy_resolution_reports_sources
+        file: tests/unit/test_policy_stack_resolution.py
+      - name: test_trace_records_candidates_and_depth
+        file: tests/unit/test_policy_stack_resolution.py
+  - id: policy_enforcement_api
+    execution_mode: always
+    reusable: false
+    description: Introduce PolicyDenial/PolicySnapshot, enforce() API with PolicyViolationError, and optional event sink integration for push/pop/violation events.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+    depends_on: [policy_decision_diagnostics]
+    source_files:
+      - pkgs/dsl/policy.py
+      - pkgs/dsl/__init__.py
+    tests:
+      - name: test_enforce_blocks_disallowed_tool
+        file: tests/unit/test_policy_stack_enforce.py
+      - name: test_enforce_emits_violation_event
+        file: tests/unit/test_policy_stack_enforce.py
+  - id: linter_reachability_analysis
+    execution_mode: always
+    reusable: true
+    description: Update FlowLinter to evaluate unit nodes, decision branches, and loop contexts using cloned stacks seeded with global/graph policies.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+    depends_on: [policy_decision_diagnostics]
+    source_files:
+      - pkgs/dsl/linter.py
+    tests:
+      - name: test_linter_flags_unreachable_nodes
+        file: tests/unit/test_linter_unreachable_tools.py
+      - name: test_linter_allows_branch_override
+        file: tests/unit/test_linter_unreachable_tools.py
+  - id: regression_test_hardening
+    execution_mode: always
+    reusable: false
+    description: Expand unit coverage for decision overrides, loop propagation, fallback reachability, and pop() scope mismatches; ensure fixtures are self-contained.
+    adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-81p0id
+    depends_on: [linter_reachability_analysis]
+    source_files:
+      - tests/unit/test_policy_stack_resolution.py
+      - tests/unit/test_linter_unreachable_tools.py
+      - tests/unit/test_policy_stack_enforce.py


### PR DESCRIPTION
## Summary
- document comparative review across four policy engine branches for task 07a
- capture plan preview outlining reuse, conflicts, and redesign targets
- author schema-aligned final implementation plan and post-execution directives for follow-on work

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e8490f3a40832c9acba46e3af6e297