### PR TITLE
Add P2 synthesis review and plan for policy engine

### DIFF
--- a/codex/agents/POSTEXECUTION/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e
+++ b/codex/agents/POSTEXECUTION/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e
@@ -1,0 +1,18 @@
+post_execution_feedback:
+  was_successful: null
+  failed_tasks: []
+  recommended_revisions: []
+  synthesis_notes:
+    - reason: opportunity to consolidate trace emission logic across branches
+      recommendation: extract shared `trace_event_emitter` to shared module
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+codex_directives:
+  must:
+    - reference branch contributions precisely
+    - verify all traceability expectations
+  do_not:
+    - hallucinate trace events
+    - assume success without validation

--- a/codex/agents/PREVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e
+++ b/codex/agents/PREVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e
@@ -1,0 +1,27 @@
+plan_preview:
+  reuse_logic:
+    - branch: codex/implement-dsl-policy-engine-in-yaml
+      notes:
+        - Keep `PolicyDefinition` parsing, tool-set expansion safeguards, and scope-validated push/pop with `PolicyTraceRecorder` wiring as the backbone.
+    - branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+      notes:
+        - Adopt `_PolicyFrame` / `ToolDescriptor` modeling for richer metadata and branch/loop context cloning for the linter.
+    - branch: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+      notes:
+        - Reuse the `enforce()` surface, `PolicySnapshot`/`PolicyDenial` schema, and optional event sink plumbing for violations.
+    - branch: codex/implement-dsl-policy-engine-in-yaml-81p0id
+      notes:
+        - Salvage candidate-tracking diagnostics so snapshots can report evaluated tool IDs without reintroducing mutable state.
+  conflicts:
+    - 81p0id/yp01n0 iterate policies FIFO while baseline/reclz1 expect LIFO; need a single resolver that enforces nearest-scope-wins with tests.
+    - reclz1 drops push/pop scope validation whereas baseline/yp01n0 rely on it; we must restore guard rails while supporting optional policies.
+    - All branches diverge on trace schemas (`policy_resolved` vs. `policy_allowlist` vs. violation events); unify on baseline schema plus violation events and ensure deterministic payload keys.
+    - Tool validation paths differ: baseline validates eagerly, variants skip; consolidate onto baseline behavior while keeping reclz1 descriptors.
+  redesign_targets:
+    - Rebuild `PolicyResolution`/`PolicySnapshot` into a single immutable snapshot containing per-tool provenance, candidate list, and denial metadata to satisfy both observability and enforcement.
+    - Extract a shared trace emitter that can fan out to recorder + optional sink, preventing drift across branches.
+    - Simplify linter integration by wrapping stack evaluations in helper methods that inject branch/loop context without exposing raw frames.
+  open_questions:
+    - How aggressively should we cache snapshots (per evaluation vs. per node) before invalidating after stack mutations?
+    - Should optional/None policies be allowed at the API surface (reclz1 style) or must callers guard them to preserve trace completeness?
+    - Do we expose candidate diagnostics externally or keep them internal to observability tooling?

--- a/codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e
+++ b/codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e
@@ -1,0 +1,46 @@
+metadata:
+  generated_at: 2024-07-19T00:00:00Z
+  repo: pfahlr/ragx
+  task_id: 07a_dsl_policy_engine_completion
+  tags: [dsl, policy_engine, review, traceability]
+  execution_mode: comparative_review
+analysis:
+  branch_reviews:
+    - branch: codex/implement-dsl-policy-engine-in-yaml
+      bullets:
+        - Establishes the canonical `PolicyStack` contract with `PolicyDefinition` parsing, cycle-safe tool/tool-set expansion, and nearest-scope-wins resolution cached through `PolicyResolution` plus reason strings for denials.
+        - Maintains scope safety by requiring matching `pop(scope)` calls and records `policy_push`, `policy_pop`, and `policy_resolved` events through a `PolicyTraceRecorder`, preserving DSL trace schema fidelity.
+        - Validates tool references eagerly (raising `PolicyError` on unknown names) and guards set expansion against recursion, aligning with DSL override semantics and preventing hallucinated tools.
+        - Gaps: lacks an `enforce()` API for runtime policy checks, does not expose richer per-tool diagnostics beyond reason strings, and the linter scaffolding does not yet model decision/loop contexts; tests only cover simple resolution cases with no loop/decision coverage.
+    - branch: codex/implement-dsl-policy-engine-in-yaml-81p0id
+      bullets:
+        - Replaces immutable resolution snapshots with mutable tables (`state`, `denial_reasons`) and introduces candidate tracking meant for richer observability of evaluated tool IDs.
+        - Iterates frames oldest-to-newest, so outer `allow_tools` permanently mask inner overrides—breaking the spec’s nearest-scope precedence and blocking branch-local tool grants; `pop` no longer validates scope ordering.
+        - Drops `PolicyTraceRecorder` in favor of ad-hoc `policy_allowlist` events, removing the spec-required `policy_resolved` payload and skipping validation of policy payloads, so trace fidelity and error surfacing both regress.
+        - Eliminates tool/tool-set expansion checks and the dedicated `PolicyError`, letting unknown names silently pass; no additional tests were added, so the regression in override semantics and trace sequencing goes uncaught.
+    - branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
+      bullets:
+        - Introduces `_PolicyFrame` + `ToolDescriptor` normalization and stack cloning so the linter can analyze loop/decision scopes with enriched metadata for each tool/tag combination.
+        - Restores reverse-order frame evaluation to recover nearest-scope precedence and captures branch context when resolving options, improving scope correctness compared to 81p0id.
+        - However, `push()` now ignores falsy policies, drops the `source`/scope validation metadata, and allows unknown tool names because tool-set expansion no longer runs; `pop()` lacks guard rails, so stack safety regresses.
+        - Trace events are appended directly to a list without policy snapshots, and `effective_allowlist()` requires callers to pass tool registries on every call; no new unit tests cover decision/loop policy analysis despite the new data structures.
+    - branch: codex/implement-dsl-policy-engine-in-yaml-yp01n0
+      bullets:
+        - Adds the long-needed `enforce()` API, `PolicyViolationError`, and `PolicySnapshot`/`PolicyDenial` structures plus an injectable event sink, giving the runner a way to emit `policy_violation` telemetry.
+        - Persists the tool registry on the stack, simplifying callers relative to reclz1, and structures violation payloads with scope + reason metadata suitable for observability pipelines.
+        - Still iterates frames in insertion order (inheriting the nearest-scope regression from 81p0id) and removes `pop` scope validation, so overrides in decision branches fail silently and stack misuse goes undetected.
+        - `policy_resolved` is never emitted, unknown tool references are accepted, and no loop/decision/trace sequencing tests accompany the new enforcement surface, leaving runner integration high risk.
+  redundancy_or_hallucination_check:
+    - None of the branches invent new DSL concepts, but 81p0id and yp01n0 hallucinate a `policy_allowlist` trace event that is unsupported by the spec while simultaneously omitting required `policy_resolved` telemetry.
+    - reclz1 and yp01n0 duplicate partial fixes for nearest-scope precedence; only reclz1 actually restores reverse iteration, so merging both without care would reintroduce the FIFO bug.
+    - All variants drop cycle detection or scope guards at some point, so we must intentionally retain baseline protections to avoid compounded regressions.
+  synthesis_rationale:
+    - Start from `codex/implement-dsl-policy-engine-in-yaml` for validated tool expansion, scope-safe push/pop, and canonical trace emission.
+    - Lift `_PolicyFrame`/`ToolDescriptor` modeling and branch-aware linter hooks from `...-reclz1`, but reinstate source bookkeeping and strict push/pop validation.
+    - Adopt the `enforce()` surface, structured `PolicySnapshot`, and violation sink patterns from `...-yp01n0` while rewriting resolution to reuse LIFO semantics and to emit the missing `policy_resolved` trace before violation checks.
+    - Reuse 81p0id’s candidate-tracking idea only as supplemental diagnostics attached to snapshots, avoiding its mutable state machine and reintroducing cycle-safe expansion + deterministic tracing.
+  optional_enhancements:
+    - Add targeted unit tests for decision-node overrides, loop-embedded scopes, and trace ordering (push/policy_resolved/enforce/pop) to lock regression-prone behaviors.
+    - Extract a shared `trace_event_emitter` utility so both the recorder and optional sinks share a single serialization path.
+    - Provide property-based tests or table-driven fixtures covering tag intersections to validate allow/deny precedence beyond the current name-only cases.
+    - Extend the linter tests to exercise fallback chains and unreachable branch detection using the richer diagnostics from reclz1.

--- a/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e
+++ b/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e
@@ -1,0 +1,100 @@
+version: 1
+id: 07a_dsl_policy_engine_completion
+title: Merge policy stack resolution, enforcement, and trace fidelity
+summary: Consolidate the DSL policy engine by unifying validated stack semantics with enforcement and trace diagnostics from the four Codex variants.
+description: |
+  Implement a production-ready policy engine that preserves the baseline branch's validation and trace schema, integrates
+  reclz1's metadata-rich frames for linter analysis, and adopts yp01n0's enforcement contract plus violation sink while
+  salvaging 81p0id's candidate diagnostics without its FIFO regression. The work must reinstate nearest-scope precedence,
+  emit the full trace contract (`policy_push`, `policy_resolved`, `policy_violation`, `policy_pop`), and extend the linter
+  and unit tests to cover decision/loop scopes and fallback reachability.
+metadata:
+  owners: [pfahlr@gmail.com]
+  labels: [dsl, policy-engine, tracing]
+  priority: P1
+  risk: high
+  last_updated: 2024-07-19
+strategy:
+  tests_first: true
+  deterministic: true
+  golden_management: manual
+scope:
+  goals:
+    - Restore nearest-scope policy resolution with validated tool/tool-set expansion and scope-safe stack operations.
+    - Provide an `enforce()` API emitting structured `policy_violation` events and raising `PolicyViolationError` on disallowed tools.
+    - Emit deterministic policy trace events covering push, resolved snapshots, violations, and pop with shared serialization logic.
+    - Update the DSL linter and unit tests to exercise decision branches, loops, fallback paths, and trace sequencing.
+  non_goals:
+    - Modifying runner execution semantics beyond the policy stack contract.
+    - Implementing budget enforcement or non-policy observability features.
+assumptions:
+  - Tool registries follow the spec-defined schema and expose tags required for allow/deny evaluation.
+  - Existing DSL node definitions remain unchanged; only policy enforcement layers require updates.
+constraints:
+  - Preserve backward-compatible trace payload keys for existing downstream consumers while adding new diagnostics under gated keys.
+  - Keep the policy engine free of network or filesystem dependencies to maintain deterministic tests.
+component_ids:
+  - pkgs.dsl.policy
+  - pkgs.dsl.linter
+  - tests.unit.policy_stack
+structured_logging_contract:
+  format: jsonl
+  storage_path_prefix: logs/policy_engine
+  latest_symlink: logs/policy_engine/latest
+  retention: 14d
+  event_fields:
+    - event
+    - scope
+    - payload.allowed_tools
+    - payload.denied_tools
+    - payload.candidates
+    - payload.scope_stack
+    - payload.reason
+  metadata_fields:
+    - run_id
+    - graph_id
+    - node_id
+  volatile_fields:
+    - payload.latency_ms
+    - payload.timestamp
+observability_requirements:
+  - Maintain per-event correlation IDs so traces can be joined to runner node executions.
+  - Surface denial provenance (scope and directive) within violation events for debugging unreachable nodes.
+ci:
+  xfail_marker: policy_engine_known_issue
+  workflows:
+    - name: ensure_green
+      gates:
+        - scripts/ensure_green.sh
+      artifacts:
+        - tests/unit/test_policy_stack_resolution.py
+        - tests/unit/test_linter_unreachable_tools.py
+actions:
+  - stage: stabilize_harness
+    summary: Backfill regression coverage before refactors.
+    tasks:
+      - Author unit tests for decision-branch overrides, loop scope unwinding, fallback exhaustion, and trace ordering (push -> resolved -> violation -> pop).
+      - Add fixture coverage for tool-set cycle detection and unknown tool rejection.
+  - stage: unify_policy_stack
+    summary: Merge validated stack semantics with metadata-rich frames.
+    tasks:
+      - Refactor `PolicyStack` to use `_PolicyFrame` descriptors while preserving validated push/pop, tool expansion, and LIFO evaluation.
+      - Collapse `PolicyResolution` and `PolicySnapshot` into an immutable snapshot carrying allowed/denied sets, candidate list, and provenance metadata.
+      - Implement a shared trace emitter that records to the baseline recorder and optional sinks with deterministic payload keys.
+  - stage: enforcement_and_linter
+    summary: Deliver enforcement API and align linter diagnostics.
+    tasks:
+      - Implement `enforce()` using cached snapshots, raising `PolicyViolationError`, and emitting `policy_violation` events with denial provenance.
+      - Update the DSL linter to consume enriched diagnostics, ensuring unreachable tool detection across decision and loop scopes.
+      - Document and validate the trace schema via a JSON schema artifact (`codex/specs/schemas/policy_trace_event.schema.json`).
+  - stage: integration_ci
+    summary: Ensure repository health and documentation.
+    tasks:
+      - Update developer docs outlining the policy trace contract and enforcement usage.
+      - Run `scripts/ensure_green.sh` and address lint/type/test failures.
+      - Capture changelog notes referencing branch contributions (baseline, reclz1, yp01n0, 81p0id).
+acceptance:
+  - tests/unit/test_policy_stack_resolution.py passes with new decision/loop cases.
+  - tests/unit/test_linter_unreachable_tools.py covers unreachable fallback and branch contexts.
+  - Policy trace fixtures assert push/resolved/violation/pop sequencing with deterministic payload keys.
+  - `scripts/ensure_green.sh` succeeds locally prior to submission.


### PR DESCRIPTION
## Summary
- document a comparative review of the four policy engine branches and identify synthesis priorities
- capture a plan preview outlining reuse, conflicts, redesign targets, and open questions for P2 execution
- publish the schema-valid implementation plan and post-execution directives for downstream agents

## Testing
- not run (documentation and planning updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e8490f3a40832c9acba46e3af6e297