### PR TITLE
Implement DSL policy stack and enforcement tracing

### DIFF
--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,0 +1,25 @@
+"""DSL package exports for policy engine components."""
+
+from .models import (
+    PolicyDecision,
+    PolicyDenial,
+    PolicyResolution,
+    PolicySnapshot,
+    PolicyTraceEvent,
+    PolicyTraceRecorder,
+    ToolDescriptor,
+)
+from .policy import PolicyStack, PolicyViolationError
+
+__all__ = [
+    "PolicyDecision",
+    "PolicyDenial",
+    "PolicyResolution",
+    "PolicySnapshot",
+    "PolicyTraceEvent",
+    "PolicyTraceRecorder",
+    "PolicyStack",
+    "PolicyViolationError",
+    "ToolDescriptor",
+]
+

--- a/pkgs/dsl/models.py
+++ b/pkgs/dsl/models.py
@@ -1,0 +1,101 @@
+"""Core data models for the DSL policy engine.
+
+These models are intentionally lightweight so that the policy stack can share
+immutable diagnostics across trace events, enforcement checks, and linter
+analysis.  All containers exposed here favour ``frozenset`` or
+``MappingProxyType`` to avoid accidental mutation after construction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+
+@dataclass(frozen=True, slots=True)
+class ToolDescriptor:
+    """Normalized description of a tool registered with the policy engine."""
+
+    name: str
+    tags: frozenset[str]
+
+    @classmethod
+    def from_spec(cls, name: str, *, tags: Sequence[str] | None = None) -> ToolDescriptor:
+        return cls(name=name, tags=frozenset(tags or ()))
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDecision:
+    """Decision diagnostic for a single tool resolution."""
+
+    tool: str
+    allowed: bool
+    scope: str | None
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyResolution:
+    """Aggregate view of policy decisions for all tools under evaluation."""
+
+    decisions: Mapping[str, PolicyDecision]
+
+    def __post_init__(self) -> None:  # pragma: no cover - defensive
+        object.__setattr__(self, "decisions", MappingProxyType(dict(self.decisions)))
+
+    @property
+    def allowed_tools(self) -> frozenset[str]:
+        return frozenset(tool for tool, decision in self.decisions.items() if decision.allowed)
+
+    @property
+    def denied_tools(self) -> Mapping[str, PolicyDecision]:
+        denied: MutableMapping[str, PolicyDecision] = {}
+        for tool, decision in self.decisions.items():
+            if not decision.allowed:
+                denied[tool] = decision
+        return MappingProxyType(denied)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDenial:
+    """Structured metadata attached to a policy violation."""
+
+    tool: str
+    decision: PolicyDecision
+    resolution: PolicyResolution
+
+
+@dataclass(frozen=True, slots=True)
+class PolicySnapshot:
+    """Immutable snapshot captured during enforcement."""
+
+    stack_depth: int
+    resolution: PolicyResolution
+
+    def __post_init__(self) -> None:  # pragma: no cover - defensive
+        object.__setattr__(self, "resolution", self.resolution)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyTraceEvent:
+    """Trace event emitted by the policy engine."""
+
+    event: str
+    scope: str
+    data: Mapping[str, object]
+
+
+class PolicyTraceRecorder:
+    """Simple recorder that stores emitted trace events for later inspection."""
+
+    def __init__(self) -> None:
+        self._events: list[PolicyTraceEvent] = []
+
+    def record(self, event: PolicyTraceEvent) -> None:
+        self._events.append(event)
+
+    @property
+    def events(self) -> Sequence[PolicyTraceEvent]:
+        return tuple(self._events)
+

--- a/pkgs/dsl/policy.py
+++ b/pkgs/dsl/policy.py
@@ -1,0 +1,266 @@
+"""Policy stack implementation for the RAGX DSL."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from .models import (
+    PolicyDecision,
+    PolicyDenial,
+    PolicyResolution,
+    PolicySnapshot,
+    PolicyTraceEvent,
+    PolicyTraceRecorder,
+    ToolDescriptor,
+)
+
+
+class PolicyViolationError(RuntimeError):
+    """Raised when policy enforcement blocks a tool invocation."""
+
+    def __init__(self, denial: PolicyDenial) -> None:
+        super().__init__(f"Tool '{denial.tool}' blocked by policy: {denial.decision.reason}")
+        self.denial = denial
+
+
+def emit_policy_event(
+    recorder: PolicyTraceRecorder,
+    sink: Callable[[PolicyTraceEvent], None] | None,
+    *,
+    event: str,
+    scope: str,
+    payload: Mapping[str, object],
+) -> None:
+    record = PolicyTraceEvent(event=event, scope=scope, data=MappingProxyType(dict(payload)))
+    recorder.record(record)
+    if sink is not None:
+        sink(record)
+
+
+@dataclass(slots=True)
+class _PolicyDirectives:
+    scope: str
+    allow_tools: frozenset[str]
+    deny_tools: frozenset[str]
+    allow_tags: frozenset[str]
+    deny_tags: frozenset[str]
+    raw_policy: Mapping[str, Any]
+
+    @property
+    def payload(self) -> Mapping[str, object]:
+        return MappingProxyType(
+            {
+                "allow_tools": tuple(sorted(self.allow_tools)),
+                "deny_tools": tuple(sorted(self.deny_tools)),
+                "allow_tags": tuple(sorted(self.allow_tags)),
+                "deny_tags": tuple(sorted(self.deny_tags)),
+            }
+        )
+
+
+class PolicyStack:
+    """LIFO policy stack supporting scoped allow/deny directives."""
+
+    def __init__(
+        self,
+        *,
+        tool_registry: Mapping[str, ToolDescriptor],
+        tool_sets: Mapping[str, Sequence[str]] | None = None,
+        event_sink: Callable[[PolicyTraceEvent], None] | None = None,
+    ) -> None:
+        if not tool_registry:
+            raise ValueError("tool_registry must not be empty")
+
+        self._registry = {name: descriptor for name, descriptor in tool_registry.items()}
+        self._tool_sets = {name: tuple(values) for name, values in (tool_sets or {}).items()}
+        self._stack: list[_PolicyDirectives] = []
+        self._recorder = PolicyTraceRecorder()
+        self._event_sink = event_sink
+
+        # Validate tool set contents upfront.
+        for set_name in self._tool_sets:
+            self._expand_tool_set(set_name, set())
+
+    @property
+    def stack_depth(self) -> int:
+        return len(self._stack)
+
+    @property
+    def recorder(self) -> PolicyTraceRecorder:
+        return self._recorder
+
+    def push(self, scope: str, policy: Mapping[str, Any] | None = None) -> None:
+        normalized = self._normalize_policy(scope, policy or {})
+        self._stack.append(normalized)
+        emit_policy_event(
+            self._recorder,
+            self._event_sink,
+            event="push",
+            scope=scope,
+            payload={"directives": normalized.payload, "stack_depth": self.stack_depth},
+        )
+
+    def pop(self, scope: str | None = None) -> None:
+        if not self._stack:
+            raise RuntimeError("policy stack underflow")
+        top = self._stack[-1]
+        if scope is not None and top.scope != scope:
+            raise RuntimeError(f"attempted to pop scope '{scope}' but top is '{top.scope}'")
+        self._stack.pop()
+        emit_policy_event(
+            self._recorder,
+            self._event_sink,
+            event="pop",
+            scope=top.scope,
+            payload={"stack_depth": self.stack_depth},
+        )
+
+    def effective_allowlist(self, *, tools: Iterable[str] | None = None) -> PolicyResolution:
+        candidates = self._candidate_tools(tools)
+        decisions: dict[str, PolicyDecision] = {}
+        for tool_name in sorted(candidates):
+            descriptor = self._registry[tool_name]
+            decisions[tool_name] = self._resolve_tool(descriptor)
+
+        resolution = PolicyResolution(decisions)
+        emit_policy_event(
+            self._recorder,
+            self._event_sink,
+            event="policy_resolved",
+            scope=self._stack[-1].scope if self._stack else "<root>",
+            payload={
+                "allowed": tuple(sorted(resolution.allowed_tools)),
+                "denied": tuple(sorted(resolution.denied_tools)),
+                "stack_depth": self.stack_depth,
+            },
+        )
+        return resolution
+
+    def enforce(self, tool: str, *, raise_error: bool = True) -> PolicySnapshot:
+        if tool not in self._registry:
+            raise ValueError(f"unknown tool '{tool}'")
+
+        resolution = self.effective_allowlist(tools=[tool])
+        decision = resolution.decisions[tool]
+        snapshot = PolicySnapshot(stack_depth=self.stack_depth, resolution=resolution)
+
+        if decision.allowed:
+            return snapshot
+
+        denial = PolicyDenial(tool=tool, decision=decision, resolution=resolution)
+        emit_policy_event(
+            self._recorder,
+            self._event_sink,
+            event="violation",
+            scope=decision.scope or "<unspecified>",
+            payload={
+                "tool": tool,
+                "reason": decision.reason,
+                "stack_depth": self.stack_depth,
+            },
+        )
+        if raise_error:
+            raise PolicyViolationError(denial)
+        return snapshot
+
+    # ---------------------------------------------------------------------
+    # Internal helpers
+    # ---------------------------------------------------------------------
+    def _candidate_tools(self, tools: Iterable[str] | None) -> Sequence[str]:
+        if tools is None:
+            return tuple(sorted(self._registry))
+        normalized = []
+        for tool in tools:
+            if tool not in self._registry:
+                raise ValueError(f"unknown tool '{tool}'")
+            normalized.append(tool)
+        return tuple(normalized)
+
+    def _resolve_tool(self, descriptor: ToolDescriptor) -> PolicyDecision:
+        for directives in reversed(self._stack):
+            if descriptor.name in directives.deny_tools:
+                return PolicyDecision(
+                    tool=descriptor.name,
+                    allowed=False,
+                    scope=directives.scope,
+                    reason="deny_tools",
+                )
+            if directives.deny_tags & descriptor.tags:
+                return PolicyDecision(
+                    tool=descriptor.name,
+                    allowed=False,
+                    scope=directives.scope,
+                    reason="deny_tags",
+                )
+            if descriptor.name in directives.allow_tools:
+                return PolicyDecision(
+                    tool=descriptor.name,
+                    allowed=True,
+                    scope=directives.scope,
+                    reason="allow_tools",
+                )
+            if directives.allow_tags & descriptor.tags:
+                return PolicyDecision(
+                    tool=descriptor.name,
+                    allowed=True,
+                    scope=directives.scope,
+                    reason="allow_tags",
+                )
+
+        return PolicyDecision(
+            tool=descriptor.name,
+            allowed=False,
+            scope=None,
+            reason="implicit_deny",
+        )
+
+    def _normalize_policy(self, scope: str, policy: Mapping[str, Any]) -> _PolicyDirectives:
+        allow_tools = self._expand_directive(policy.get("allow_tools", ()))
+        deny_tools = self._expand_directive(policy.get("deny_tools", ()))
+        allow_tags = frozenset(policy.get("allow_tags", ()))
+        deny_tags = frozenset(policy.get("deny_tags", ()))
+
+        unknown_tags = [tag for tag in allow_tags | deny_tags if not isinstance(tag, str)]
+        if unknown_tags:
+            raise TypeError("tags must be strings")
+
+        return _PolicyDirectives(
+            scope=scope,
+            allow_tools=allow_tools,
+            deny_tools=deny_tools,
+            allow_tags=allow_tags,
+            deny_tags=deny_tags,
+            raw_policy=MappingProxyType(dict(policy)),
+        )
+
+    def _expand_directive(self, values: Iterable[str]) -> frozenset[str]:
+        expanded: set[str] = set()
+        for value in values:
+            expanded.update(self._expand_value(value, set()))
+        return frozenset(expanded)
+
+    def _expand_value(self, value: str, seen: set[str]) -> set[str]:
+        if value in self._registry:
+            return {value}
+        if value in self._tool_sets:
+            return set(self._expand_tool_set(value, seen))
+        raise ValueError(f"unknown tool or tool_set '{value}'")
+
+    def _expand_tool_set(self, set_name: str, seen: set[str]) -> frozenset[str]:
+        if set_name in seen:
+            raise ValueError(f"cycle detected in tool_sets expansion: {set_name}")
+        seen.add(set_name)
+        tools: set[str] = set()
+        for entry in self._tool_sets.get(set_name, ()):  # type: ignore[arg-type]
+            if entry in self._registry:
+                tools.add(entry)
+            elif entry in self._tool_sets:
+                tools.update(self._expand_tool_set(entry, seen))
+            else:
+                raise ValueError(f"unknown tool or tool_set '{entry}' in set '{set_name}'")
+        seen.remove(set_name)
+        return frozenset(tools)
+

--- a/tests/unit/test_policy_stack_enforce.py
+++ b/tests/unit/test_policy_stack_enforce.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from pkgs.dsl import (
+    PolicyStack,
+    PolicyTraceEvent,
+    PolicyViolationError,
+    ToolDescriptor,
+)
+
+
+def _build_registry() -> dict[str, ToolDescriptor]:
+    return {
+        "gpt": ToolDescriptor.from_spec("gpt", tags=["analysis", "internal"]),
+        "vector_query": ToolDescriptor.from_spec("vector_query", tags=["retrieval", "internal"]),
+        "web_search": ToolDescriptor.from_spec("web_search", tags=["external", "search"]),
+    }
+
+
+def test_effective_allowlist_prefers_nearest_scope() -> None:
+    events: list[PolicyTraceEvent] = []
+    stack = PolicyStack(
+        tool_registry=_build_registry(),
+        tool_sets={"analysis_only": ["gpt"], "safe_internal": ["analysis_only", "vector_query"]},
+        event_sink=events.append,
+    )
+
+    stack.push(
+        "global",
+        {
+            "allow_tools": ["safe_internal"],
+            "deny_tags": ["external"],
+        },
+    )
+    stack.push(
+        "node:search",
+        {
+            "allow_tools": ["web_search"],
+            "deny_tools": ["gpt"],
+        },
+    )
+
+    resolution = stack.effective_allowlist()
+
+    assert resolution.decisions["vector_query"].allowed is True
+    assert resolution.decisions["vector_query"].scope == "global"
+    assert resolution.decisions["gpt"].allowed is False
+    assert resolution.decisions["gpt"].scope == "node:search"
+    assert resolution.decisions["web_search"].allowed is True
+    assert resolution.decisions["web_search"].scope == "node:search"
+
+    assert events[-1].event == "policy_resolved"
+    assert set(events[-1].data["allowed"]) == {"vector_query", "web_search"}
+    assert "gpt" in resolution.denied_tools
+
+
+def test_push_unknown_tool_set_raises() -> None:
+    stack = PolicyStack(tool_registry=_build_registry(), tool_sets={})
+    with pytest.raises(ValueError, match="unknown tool or tool_set 'analysis_only'"):
+        stack.push("global", {"allow_tools": ["analysis_only"]})
+
+
+def test_tool_set_cycle_detection() -> None:
+    tool_sets = {"cycle_a": ["cycle_b"], "cycle_b": ["cycle_a"]}
+    with pytest.raises(ValueError, match="cycle detected"):
+        PolicyStack(tool_registry=_build_registry(), tool_sets=tool_sets)
+
+
+def test_enforce_emits_violation_event_and_error() -> None:
+    events: list[PolicyTraceEvent] = []
+    stack = PolicyStack(tool_registry=_build_registry(), tool_sets={}, event_sink=events.append)
+    stack.push("global", {"allow_tools": ["vector_query"]})
+
+    with pytest.raises(PolicyViolationError) as excinfo:
+        stack.enforce("gpt")
+
+    assert excinfo.value.denial.decision.tool == "gpt"
+    assert events[-1].event == "violation"
+    assert events[-1].data["tool"] == "gpt"
+
+
+def test_enforce_returns_snapshot_when_allowed() -> None:
+    stack = PolicyStack(tool_registry=_build_registry(), tool_sets={})
+    stack.push("global", {"allow_tools": ["gpt"]})
+
+    snapshot = stack.enforce("gpt")
+
+    assert snapshot.stack_depth == stack.stack_depth
+    assert snapshot.resolution.decisions["gpt"].allowed is True
+


### PR DESCRIPTION
## Summary
- add core policy engine models for decisions, trace events, and immutable snapshots
- implement the PolicyStack with scoped allow/deny resolution, tool-set expansion, and violation tracing
- cover enforcement behaviour with unit tests for stack precedence, validation, and trace emission

## Testing
- pytest tests/unit/test_policy_stack_enforce.py
- ./scripts/ensure_green.sh *(fails: transport parity test expects identical `transport` metadata across HTTP/STDIO)*

------
https://chatgpt.com/codex/tasks/task_e_68e84e4ae5dc832c9dad77392bd7eeb7