### PR TITLE
Implement DSL policy stack and enforcement

### DIFF
--- a/pkgs/__init__.py
+++ b/pkgs/__init__.py
@@ -1,0 +1,2 @@
+"""Top-level package for RAGX Python components."""
+

--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,0 +1,32 @@
+"""DSL policy engine public API."""
+
+from pkgs.dsl.models import (
+    PolicyDecision,
+    PolicyDenial,
+    PolicyResolution,
+    PolicySnapshot,
+    PolicyTraceEvent,
+    PolicyViolationError,
+    ToolDescriptor,
+)
+from pkgs.dsl.policy import (
+    PolicyError,
+    PolicyStack,
+    PolicyTraceRecorder,
+    emit_policy_event,
+)
+
+__all__ = [
+    "PolicyDecision",
+    "PolicyDenial",
+    "PolicyResolution",
+    "PolicySnapshot",
+    "PolicyTraceEvent",
+    "PolicyViolationError",
+    "ToolDescriptor",
+    "PolicyError",
+    "PolicyStack",
+    "PolicyTraceRecorder",
+    "emit_policy_event",
+]
+

--- a/pkgs/dsl/models.py
+++ b/pkgs/dsl/models.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+
+@dataclass(frozen=True)
+class ToolDescriptor:
+    """Normalized metadata describing a tool in the registry."""
+
+    tool_id: str
+    tags: frozenset[str]
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Outcome of evaluating a tool against the active policy stack."""
+
+    tool: str
+    allowed: bool
+    reason: str
+    allow_scope: str | None
+    deny_scope: str | None
+    matched_tags: frozenset[str]
+
+
+@dataclass(frozen=True)
+class PolicyResolution:
+    """Aggregate view of an allowlist evaluation."""
+
+    allowed: frozenset[str]
+    denied: frozenset[str]
+    candidates: frozenset[str]
+    decisions: Mapping[str, PolicyDecision]
+
+    def __post_init__(self) -> None:  # pragma: no cover - defensive copy guard.
+        object.__setattr__(self, "decisions", MappingProxyType(dict(self.decisions)))
+
+
+@dataclass(frozen=True)
+class PolicyDenial:
+    """Structured payload describing why a tool was rejected."""
+
+    tool: str
+    reason: str
+    scope: str | None
+
+
+@dataclass(frozen=True)
+class PolicySnapshot(PolicyResolution):
+    """Immutable snapshot reused for enforcement and diagnostics."""
+
+    denials: tuple[PolicyDenial, ...]
+
+
+class PolicyViolationError(RuntimeError):
+    """Raised when enforcement encounters a disallowed tool."""
+
+    def __init__(self, denial: PolicyDenial) -> None:
+        super().__init__(f"Policy violation for tool '{denial.tool}': {denial.reason}")
+        self.denial = denial
+
+
+@dataclass(frozen=True)
+class PolicyTraceEvent:
+    """Structured trace emitted by policy stack operations."""
+
+    event: str
+    scope: str
+    data: Mapping[str, object]
+

--- a/pkgs/dsl/policy.py
+++ b/pkgs/dsl/policy.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from pkgs.dsl.models import (
+    PolicyDecision,
+    PolicyDenial,
+    PolicySnapshot,
+    PolicyTraceEvent,
+    PolicyViolationError,
+    ToolDescriptor,
+)
+
+
+class PolicyError(ValueError):
+    """Raised when policies reference unknown tools or violate stack rules."""
+
+
+@dataclass(frozen=True)
+class _PolicyFrame:
+    scope: str
+    source: str | None
+    allow_tools: frozenset[str] | None
+    allow_tags: frozenset[str] | None
+    deny_tools: frozenset[str] | None
+    deny_tags: frozenset[str] | None
+    raw: Mapping[str, Sequence[str]]
+
+
+class PolicyTraceRecorder:
+    """In-memory collector for policy trace events."""
+
+    def __init__(self) -> None:
+        self._events: list[PolicyTraceEvent] = []
+
+    def record(self, event: PolicyTraceEvent) -> None:
+        self._events.append(event)
+
+    @property
+    def events(self) -> tuple[PolicyTraceEvent, ...]:
+        return tuple(self._events)
+
+
+def emit_policy_event(
+    recorder: PolicyTraceRecorder,
+    sink: Callable[[PolicyTraceEvent], None] | None,
+    *,
+    event: str,
+    scope: str,
+    payload: Mapping[str, object],
+) -> None:
+    record = PolicyTraceEvent(event=event, scope=scope, data=MappingProxyType(dict(payload)))
+    recorder.record(record)
+    if sink is not None:
+        sink(record)
+
+
+class PolicyStack:
+    """Hierarchical allow/deny resolver for DSL tool policies."""
+
+    def __init__(
+        self,
+        *,
+        tool_registry: Mapping[str, Mapping[str, Any]],
+        tool_sets: Mapping[str, Sequence[str]] | None = None,
+        recorder: PolicyTraceRecorder | None = None,
+        event_sink: Callable[[PolicyTraceEvent], None] | None = None,
+    ) -> None:
+        if not tool_registry:
+            raise PolicyError("tool_registry must not be empty")
+
+        self._tool_descriptors = {
+            tool_id: ToolDescriptor(tool_id=tool_id, tags=_normalize_tags(meta))
+            for tool_id, meta in tool_registry.items()
+        }
+        self._tool_sets = {name: tuple(entries) for name, entries in (tool_sets or {}).items()}
+        self._validate_tool_sets()
+        self._recorder = recorder or PolicyTraceRecorder()
+        self._event_sink = event_sink
+        self._stack: list[_PolicyFrame] = []
+
+    @property
+    def recorder(self) -> PolicyTraceRecorder:
+        return self._recorder
+
+    @property
+    def stack_depth(self) -> int:
+        return len(self._stack)
+
+    def push(
+        self,
+        policy: Mapping[str, Sequence[str]] | None,
+        *,
+        scope: str,
+        source: str | None = None,
+    ) -> None:
+        normalized = self._normalize_policy(policy or {})
+        frame = _PolicyFrame(
+            scope=scope,
+            source=source,
+            allow_tools=normalized.get("allow_tools"),
+            allow_tags=normalized.get("allow_tags"),
+            deny_tools=normalized.get("deny_tools"),
+            deny_tags=normalized.get("deny_tags"),
+            raw=_serialize_policy(normalized),
+        )
+        self._stack.append(frame)
+        emit_policy_event(
+            self._recorder,
+            self._event_sink,
+            event="policy_push",
+            scope=scope,
+            payload={
+                "source": source,
+                "policy": frame.raw,
+                "stack_depth": self.stack_depth,
+            },
+        )
+
+    def pop(self, *, scope: str) -> None:
+        if not self._stack:
+            raise PolicyError("PolicyStack.pop() called on empty stack")
+
+        frame = self._stack.pop()
+        if frame.scope != scope:
+            self._stack.append(frame)
+            raise PolicyError(f"policy scope mismatch: expected '{frame.scope}', got '{scope}'")
+
+        emit_policy_event(
+            self._recorder,
+            self._event_sink,
+            event="policy_pop",
+            scope=scope,
+            payload={
+                "source": frame.source,
+                "policy": frame.raw,
+                "stack_depth": self.stack_depth,
+            },
+        )
+
+    def effective_allowlist(self, *, candidates: Iterable[str] | None = None) -> PolicySnapshot:
+        candidate_set = _resolve_candidates(candidates, self._tool_descriptors)
+        directives = self._resolve_directives()
+
+        allowed: set[str] = set()
+        denied: set[str] = set()
+        decisions: dict[str, PolicyDecision] = {}
+        denials: list[PolicyDenial] = []
+
+        for tool_id in candidate_set:
+            descriptor = self._tool_descriptors[tool_id]
+            tags = descriptor.tags
+
+            allowed_by_tools = False
+            allow_scope = None
+            if directives.allow_tools is None:
+                allowed_by_tools = True
+            else:
+                allowed_by_tools = tool_id in directives.allow_tools.values
+                allow_scope = directives.allow_tools.scope if allowed_by_tools else None
+
+            allowed_by_tags = False
+            if directives.allow_tags is None:
+                allowed_by_tags = directives.allow_tools is None
+            else:
+                tag_match = tags & directives.allow_tags.values
+                allowed_by_tags = bool(tag_match)
+                if allowed_by_tags:
+                    allow_scope = directives.allow_tags.scope
+
+            allow_result = allowed_by_tools or allowed_by_tags
+            reason = "allowed" if allow_result else "not_in_allowlist"
+            deny_scope = None
+            matched_tags = (
+                tags & directives.allow_tags.values if directives.allow_tags else frozenset()
+            )
+
+            if directives.deny_tools is not None and tool_id in directives.deny_tools.values:
+                allow_result = False
+                reason = "denied:tool"
+                deny_scope = directives.deny_tools.scope
+            elif directives.deny_tags is not None:
+                denied_tags = tags & directives.deny_tags.values
+                if denied_tags:
+                    allow_result = False
+                    reason = "denied:tag"
+                    deny_scope = directives.deny_tags.scope
+                    matched_tags = denied_tags
+
+            decision = PolicyDecision(
+                tool=tool_id,
+                allowed=allow_result,
+                reason=reason,
+                allow_scope=allow_scope,
+                deny_scope=deny_scope,
+                matched_tags=frozenset(matched_tags),
+            )
+            decisions[tool_id] = decision
+
+            if allow_result:
+                allowed.add(tool_id)
+            else:
+                denied.add(tool_id)
+                if reason.startswith("denied") or reason == "not_in_allowlist":
+                    denials.append(
+                        PolicyDenial(tool=tool_id, reason=reason, scope=deny_scope or allow_scope)
+                    )
+
+        snapshot = PolicySnapshot(
+            allowed=frozenset(allowed),
+            denied=frozenset(denied),
+            candidates=candidate_set,
+            decisions=decisions,
+            denials=tuple(denials),
+        )
+
+        emit_policy_event(
+            self._recorder,
+            self._event_sink,
+            event="policy_resolved",
+            scope=self._stack[-1].scope if self._stack else "<root>",
+            payload={
+                "allowed": sorted(snapshot.allowed),
+                "denied": sorted(snapshot.denied),
+                "candidates": sorted(snapshot.candidates),
+                "stack_depth": self.stack_depth,
+            },
+        )
+        return snapshot
+
+    def enforce(
+        self,
+        tool: str,
+        *,
+        raise_on_violation: bool = True,
+    ) -> PolicySnapshot:
+        if tool not in self._tool_descriptors:
+            raise PolicyError(f"unknown tool '{tool}'")
+
+        snapshot = self.effective_allowlist(candidates=[tool])
+        if tool in snapshot.allowed:
+            return snapshot
+
+        denial = next((denial for denial in snapshot.denials if denial.tool == tool), None)
+        if denial is None:
+            denial = PolicyDenial(tool=tool, reason="not_in_allowlist", scope=None)
+
+        emit_policy_event(
+            self._recorder,
+            self._event_sink,
+            event="policy_violation",
+            scope=denial.scope or (self._stack[-1].scope if self._stack else "<root>"),
+            payload={
+                "tool": tool,
+                "reason": denial.reason,
+                "stack_depth": self.stack_depth,
+            },
+        )
+
+        if raise_on_violation:
+            raise PolicyViolationError(denial)
+
+        return snapshot
+
+    # ----------------------------
+    # Internal helpers
+    # ----------------------------
+
+    def _validate_tool_sets(self) -> None:
+        for set_name in self._tool_sets:
+            self._expand_tool_set(set_name, deque(), set())
+
+    def _expand_tool_set(
+        self,
+        set_name: str,
+        stack: deque[str],
+        seen: set[str],
+    ) -> frozenset[str]:
+        if set_name in seen or set_name in stack:
+            cycle = " -> ".join(list(stack) + [set_name])
+            raise PolicyError(f"cyclic tool_set reference detected: {cycle}")
+
+        if set_name not in self._tool_sets:
+            raise PolicyError(f"unknown tool_set '{set_name}'")
+
+        stack.append(set_name)
+        seen.add(set_name)
+        expanded: set[str] = set()
+        for entry in self._tool_sets[set_name]:
+            if entry in self._tool_descriptors:
+                expanded.add(entry)
+            elif entry in self._tool_sets:
+                expanded.update(self._expand_tool_set(entry, stack, seen))
+            else:
+                raise PolicyError(f"unknown tool reference '{entry}' in tool_set '{set_name}'")
+        stack.pop()
+        return frozenset(expanded)
+
+    def _normalize_policy(
+        self, policy: Mapping[str, Sequence[str]]
+    ) -> dict[str, frozenset[str] | None]:
+        normalized: dict[str, frozenset[str] | None] = {
+            "allow_tools": None,
+            "allow_tags": None,
+            "deny_tools": None,
+            "deny_tags": None,
+        }
+
+        if "allow_tools" in policy:
+            normalized["allow_tools"] = self._expand_entries(policy["allow_tools"])
+        if "deny_tools" in policy:
+            normalized["deny_tools"] = self._expand_entries(policy["deny_tools"])
+        if "allow_tags" in policy:
+            normalized["allow_tags"] = frozenset(policy["allow_tags"])
+        if "deny_tags" in policy:
+            normalized["deny_tags"] = frozenset(policy["deny_tags"])
+
+        return normalized
+
+    def _expand_entries(self, entries: Sequence[str]) -> frozenset[str]:
+        expanded: set[str] = set()
+        for entry in entries:
+            if entry in self._tool_descriptors:
+                expanded.add(entry)
+            elif entry in self._tool_sets:
+                expanded.update(self._expand_tool_set(entry, deque(), set()))
+            else:
+                raise PolicyError(f"unknown tool reference '{entry}'")
+        return frozenset(expanded)
+
+    def _resolve_directives(self) -> _DirectiveResolution:
+        allow_tools = _DirectiveValue.empty()
+        allow_tags = _DirectiveValue.empty()
+        deny_tools = _DirectiveValue.empty()
+        deny_tags = _DirectiveValue.empty()
+
+        for frame in reversed(self._stack):
+            if allow_tools.is_empty and frame.allow_tools is not None:
+                allow_tools = _DirectiveValue(frame.allow_tools, frame.scope)
+            if allow_tags.is_empty and frame.allow_tags is not None:
+                allow_tags = _DirectiveValue(frame.allow_tags, frame.scope)
+            if deny_tools.is_empty and frame.deny_tools is not None:
+                deny_tools = _DirectiveValue(frame.deny_tools, frame.scope)
+            if deny_tags.is_empty and frame.deny_tags is not None:
+                deny_tags = _DirectiveValue(frame.deny_tags, frame.scope)
+
+            if not any(
+                value.is_empty for value in (allow_tools, allow_tags, deny_tools, deny_tags)
+            ):
+                break
+
+        return _DirectiveResolution(
+            allow_tools=None if allow_tools.is_empty else allow_tools,
+            allow_tags=None if allow_tags.is_empty else allow_tags,
+            deny_tools=None if deny_tools.is_empty else deny_tools,
+            deny_tags=None if deny_tags.is_empty else deny_tags,
+        )
+
+
+@dataclass(frozen=True)
+class _DirectiveValue:
+    values: frozenset[str]
+    scope: str | None
+
+    @property
+    def is_empty(self) -> bool:
+        return self.scope is None
+
+    @staticmethod
+    def empty() -> _DirectiveValue:
+        return _DirectiveValue(values=frozenset(), scope=None)
+
+
+@dataclass(frozen=True)
+class _DirectiveResolution:
+    allow_tools: _DirectiveValue | None
+    allow_tags: _DirectiveValue | None
+    deny_tools: _DirectiveValue | None
+    deny_tags: _DirectiveValue | None
+
+
+def _normalize_tags(meta: Mapping[str, Any]) -> frozenset[str]:
+    tags = meta.get("tags", [])
+    if isinstance(tags, str):
+        return frozenset([tags])
+    if not isinstance(tags, Iterable):
+        return frozenset()
+    return frozenset(str(tag) for tag in tags)
+
+
+def _serialize_policy(policy: Mapping[str, frozenset[str] | None]) -> Mapping[str, Sequence[str]]:
+    serialized: dict[str, Sequence[str]] = {}
+    for key, value in policy.items():
+        if value is not None:
+            serialized[key] = tuple(sorted(value))
+    return MappingProxyType(serialized)
+
+
+def _resolve_candidates(
+    candidates: Iterable[str] | None,
+    registry: Mapping[str, ToolDescriptor],
+) -> frozenset[str]:
+    if candidates is None:
+        return frozenset(registry.keys())
+
+    resolved: set[str] = set()
+    for candidate in candidates:
+        if candidate not in registry:
+            raise PolicyError(f"unknown tool '{candidate}' in candidates")
+        resolved.add(candidate)
+    return frozenset(resolved)
+

--- a/tests/unit/test_policy_stack_enforce.py
+++ b/tests/unit/test_policy_stack_enforce.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from pkgs.dsl.models import PolicyViolationError
+from pkgs.dsl.policy import PolicyStack
+
+TOOL_REGISTRY = {
+    "gpt": {"tags": ["llm", "analysis"]},
+    "web_search": {"tags": ["search", "external"]},
+}
+
+
+@pytest.fixture()
+def stack() -> PolicyStack:
+    policy_stack = PolicyStack(tool_registry=TOOL_REGISTRY, tool_sets={})
+    policy_stack.push({"deny_tags": ["external"]}, scope="globals")
+    return policy_stack
+
+
+def test_enforce_blocks_disallowed_tool(stack: PolicyStack) -> None:
+    with pytest.raises(PolicyViolationError) as excinfo:
+        stack.enforce("web_search")
+
+    assert excinfo.value.denial.tool == "web_search"
+    assert excinfo.value.denial.reason == "denied:tag"
+
+
+def test_enforce_emits_violation_event(stack: PolicyStack) -> None:
+    recorder = stack.recorder
+    with pytest.raises(PolicyViolationError):
+        stack.enforce("web_search")
+
+    events = recorder.events
+    assert events[-1].event == "policy_violation"
+    assert events[-1].data["tool"] == "web_search"
+    assert events[-1].data["reason"] == "denied:tag"
+
+
+def test_enforce_can_return_snapshot_without_raise() -> None:
+    stack = PolicyStack(tool_registry=TOOL_REGISTRY, tool_sets={})
+    stack.push({"deny_tags": ["external"]}, scope="globals")
+
+    snapshot = stack.enforce("web_search", raise_on_violation=False)
+    assert snapshot.denied == {"web_search"}
+    assert snapshot.denials[0].reason == "denied:tag"
+

--- a/tests/unit/test_policy_stack_resolution.py
+++ b/tests/unit/test_policy_stack_resolution.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pkgs.dsl.policy import PolicyError, PolicyStack, PolicyTraceRecorder
+
+TOOL_REGISTRY = {
+    "gpt": {"tags": ["llm", "analysis"]},
+    "web_search": {"tags": ["search", "external"]},
+    "vector_query": {"tags": ["retrieve", "internal"]},
+}
+
+TOOL_SETS = {
+    "analysis_only": ["gpt"],
+    "search_pair": ["web_search", "vector_query"],
+}
+
+
+def _stack() -> PolicyStack:
+    return PolicyStack(tool_registry=TOOL_REGISTRY, tool_sets=TOOL_SETS)
+
+
+def test_policy_stack_resolves_allow_and_deny() -> None:
+    stack = _stack()
+    stack.push(
+        {
+            "allow_tools": ["analysis_only"],
+            "allow_tags": ["internal"],
+            "deny_tags": ["external"],
+        },
+        scope="globals",
+        source="flow.yaml",
+    )
+
+    snapshot = stack.effective_allowlist()
+
+    assert snapshot.allowed == {"gpt", "vector_query"}
+    assert snapshot.denied == {"web_search"}
+
+    gpt_decision = snapshot.decisions["gpt"]
+    assert gpt_decision.allowed is True
+    assert gpt_decision.reason == "allowed"
+    assert gpt_decision.allow_scope == "globals"
+
+    web_decision = snapshot.decisions["web_search"]
+    assert web_decision.allowed is False
+    assert web_decision.reason == "denied:tag"
+    assert web_decision.deny_scope == "globals"
+    assert web_decision.matched_tags == frozenset({"external"})
+
+
+def test_nearest_scope_overrides_global_directives() -> None:
+    stack = _stack()
+    stack.push({"deny_tools": ["gpt"]}, scope="globals", source="flow.yaml")
+    stack.push({"deny_tools": []}, scope="node:answer", source="node")
+    stack.push({"allow_tools": ["gpt"]}, scope="branch:answer", source="branch")
+
+    snapshot = stack.effective_allowlist(candidates=["gpt"])
+    decision = snapshot.decisions["gpt"]
+
+    assert decision.allowed is True
+    assert decision.allow_scope == "branch:answer"
+    assert decision.deny_scope is None
+
+
+def test_policy_stack_rejects_unknown_tool_ref() -> None:
+    stack = _stack()
+
+    try:
+        stack.push({"allow_tools": ["missing_tool"]}, scope="globals")
+    except PolicyError as exc:  # pragma: no cover - exercised below
+        assert "unknown tool" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("PolicyError expected for unknown tool reference")
+
+
+def test_trace_records_candidates_and_depth() -> None:
+    recorder = PolicyTraceRecorder()
+    stack = PolicyStack(tool_registry=TOOL_REGISTRY, tool_sets=TOOL_SETS, recorder=recorder)
+    stack.push({"allow_tags": ["internal"]}, scope="globals")
+
+    stack.effective_allowlist(candidates=["vector_query"])
+    stack.pop(scope="globals")
+
+    events = recorder.events
+    assert [event.event for event in events] == ["policy_push", "policy_resolved", "policy_pop"]
+    resolved_event = events[1]
+    assert resolved_event.data["allowed"] == ["vector_query"]
+    assert resolved_event.data["stack_depth"] == 1
+


### PR DESCRIPTION
## Summary
- add a typed policy model layer (ToolDescriptor, PolicyDecision, PolicySnapshot, etc.) and expose it via pkgs.dsl
- implement a PolicyStack with validated push/pop, nearest-scope resolution, tracing, and an enforce() API with violation reporting
- cover resolution and enforcement behaviour with focused unit tests exercising traces, overrides, and violation flows

## Testing
- ./scripts/ensure_green.sh *(fails: tests/integration/mcp/test_transport_parity.py::test_transport_parity_for_tool_invocation parity assertion)*
- pytest tests/unit/test_policy_stack_resolution.py tests/unit/test_policy_stack_enforce.py


------
https://chatgpt.com/codex/tasks/task_e_68e84e4ae5dc832c9dad77392bd7eeb7