### PR TITLE
Adjust MCP transport parity test for transport-specific metadata

### DIFF
--- a/tests/integration/mcp/test_transport_parity.py
+++ b/tests/integration/mcp/test_transport_parity.py
@@ -26,7 +26,7 @@ def _seed(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("RAGX_SEED", "42")
 
 
-VOLATILE_META_FIELDS = {"requestId", "traceId", "spanId"}
+VOLATILE_META_FIELDS = {"requestId", "traceId", "spanId", "transport"}
 
 
 def _stable_meta(meta: Mapping[str, Any]) -> dict[str, Any]:
@@ -76,4 +76,6 @@ def test_transport_parity_for_tool_invocation(tmp_path: Path) -> None:
     assert http_payload == stdio_payload
     assert http_envelope["meta"]["deterministic"] is True
     assert stdio_envelope["meta"]["deterministic"] is True
+    assert http_envelope["meta"]["transport"] == "http"
+    assert stdio_envelope["meta"]["transport"] == "stdio"
     assert _stable_meta(http_envelope["meta"]) == _stable_meta(stdio_envelope["meta"])


### PR DESCRIPTION
## Summary
- treat the transport identifier as volatile metadata when comparing HTTP and STDIO envelopes
- assert each transport reports its expected identifier before comparing the remaining fields

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68e865cd4c4c832c908c9195c1ebecb7