### PR TITLE
Relax transport parity meta comparison

### DIFF
--- a/tests/integration/mcp/test_transport_parity.py
+++ b/tests/integration/mcp/test_transport_parity.py
@@ -26,7 +26,7 @@ def _seed(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("RAGX_SEED", "42")
 
 
-VOLATILE_META_FIELDS = {"requestId", "traceId", "spanId"}
+VOLATILE_META_FIELDS = {"requestId", "traceId", "spanId", "transport"}
 
 
 def _stable_meta(meta: Mapping[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- treat the transport identifier as volatile metadata when comparing HTTP and STDIO envelopes in the transport parity test

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68e865cd4c4c832c908c9195c1ebecb7