### PR TITLE
Handle transport-specific meta differences in parity test

### DIFF
--- a/tests/integration/mcp/test_transport_parity.py
+++ b/tests/integration/mcp/test_transport_parity.py
@@ -26,7 +26,14 @@ def _seed(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("RAGX_SEED", "42")
 
 
-VOLATILE_META_FIELDS = {"requestId", "traceId", "spanId"}
+VOLATILE_META_FIELDS = {
+    # These fields legitimately diverge between transports or requests and should
+    # be excluded when comparing deterministic metadata for parity.
+    "requestId",
+    "traceId",
+    "spanId",
+    "transport",
+}
 
 
 def _stable_meta(meta: Mapping[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- ignore the transport field when comparing deterministic metadata across HTTP and STDIO transports
- document why the field is excluded in the transport parity integration test helper

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68e865cd4c4c832c908c9195c1ebecb7