### PR TITLE
Implement budget meters and loop budget enforcement

### DIFF
--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,5 +1,12 @@
 """DSL package exports for policy engine components."""
 
+from .budget import (  # noqa: F401
+    BudgetBreachError,
+    BudgetChargeResult,
+    BudgetError,
+    BudgetMeter,
+    BudgetWarning,
+)
 from .models import (  # noqa: F401
     PolicyDecision,
     PolicyDenial,
@@ -14,6 +21,7 @@ from .policy import (  # noqa: F401
     PolicyTraceRecorder,
     PolicyViolationError,
 )
+from .runner import FlowRunner, RunResult  # noqa: F401
 
 __all__ = [
     "PolicyDecision",
@@ -26,4 +34,11 @@ __all__ = [
     "PolicyTraceRecorder",
     "PolicyViolationError",
     "ToolDescriptor",
+    "BudgetError",
+    "BudgetBreachError",
+    "BudgetWarning",
+    "BudgetChargeResult",
+    "BudgetMeter",
+    "FlowRunner",
+    "RunResult",
 ]

--- a/pkgs/dsl/budget.py
+++ b/pkgs/dsl/budget.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import SupportsFloat
+
+__all__ = [
+    "BudgetError",
+    "BudgetBreachError",
+    "BudgetWarning",
+    "BudgetChargeResult",
+    "BudgetMeter",
+]
+
+
+_METRIC_KEYS = ("usd", "tokens", "calls", "time_ms")
+
+
+def _coerce_float(value: object) -> float:
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, SupportsFloat):
+        return float(value)
+    if isinstance(value, str):
+        return float(value)
+    raise TypeError(f"Budget value must be numeric, got {type(value)!r}")
+
+
+class BudgetError(RuntimeError):
+    """Base error for budget enforcement issues."""
+
+
+class BudgetBreachError(BudgetError):
+    """Raised when a hard budget cap would be exceeded."""
+
+    def __init__(
+        self,
+        *,
+        scope: str,
+        metric: str,
+        limit: float,
+        attempted: float,
+    ) -> None:
+        super().__init__(
+            f"{scope} budget hard cap exceeded for {metric}: "
+            f"attempted {attempted:.4f} against limit {limit:.4f}"
+        )
+        self.scope = scope
+        self.metric = metric
+        self.limit = limit
+        self.attempted = attempted
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetWarning:
+    """Details for a soft budget overage."""
+
+    scope: str
+    over: Mapping[str, float]
+    mode: str
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetChargeResult:
+    """Outcome of a budget charge operation."""
+
+    scope: str
+    cost: Mapping[str, float]
+    spent: Mapping[str, float]
+    limits: Mapping[str, float | None]
+    warning: BudgetWarning | None = None
+
+
+class BudgetMeter:
+    """Track spend against configured hard/soft budget caps."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        scope: str,
+        config: Mapping[str, object] | None,
+    ) -> None:
+        self.name = name
+        self.scope = scope
+        normalized = dict(config or {})
+        self.mode = str(normalized.get("mode", "hard" if scope != "spec" else "soft"))
+        self.breach_action = normalized.get("breach_action")
+        self._limits = self._extract_limits(normalized)
+        self._spent = {key: 0.0 for key in _METRIC_KEYS}
+        self._warnings: list[BudgetWarning] = []
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _extract_limits(config: Mapping[str, object]) -> dict[str, float | None]:
+        limits: dict[str, float | None] = {key: None for key in _METRIC_KEYS}
+        if "max_usd" in config:
+            limits["usd"] = _coerce_float(config["max_usd"])
+        if "max_tokens" in config:
+            limits["tokens"] = _coerce_float(config["max_tokens"])
+        if "max_calls" in config:
+            limits["calls"] = _coerce_float(config["max_calls"])
+        if "max_time_ms" in config:
+            limits["time_ms"] = _coerce_float(config["max_time_ms"])
+        if "time_limit_ms" in config:
+            limits["time_ms"] = _coerce_float(config["time_limit_ms"])
+        if "time_limit_sec" in config:
+            limits["time_ms"] = _coerce_float(config["time_limit_sec"]) * 1000.0
+        return limits
+
+    @staticmethod
+    def _normalize_cost(cost: Mapping[str, object]) -> dict[str, float]:
+        normalized = {key: 0.0 for key in _METRIC_KEYS}
+        for key in _METRIC_KEYS:
+            value = cost.get(key)
+            if value is None:
+                continue
+            normalized[key] = _coerce_float(value)
+        # Accept shorthand keys for compatibility.
+        if "time_limit_ms" in cost:
+            normalized["time_ms"] = _coerce_float(cost["time_limit_ms"])
+        if "time_limit_sec" in cost:
+            normalized["time_ms"] = _coerce_float(cost["time_limit_sec"]) * 1000.0
+        if "max_calls" in cost:
+            normalized["calls"] = _coerce_float(cost["max_calls"])
+        if "max_tokens" in cost:
+            normalized["tokens"] = _coerce_float(cost["max_tokens"])
+        if "max_usd" in cost:
+            normalized["usd"] = _coerce_float(cost["max_usd"])
+        return normalized
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def can_spend(self, cost: Mapping[str, object]) -> bool:
+        """Return ``True`` when the meter can accommodate the cost."""
+
+        if self.mode == "soft":
+            return True
+        for metric, amount in self._normalize_cost(cost).items():
+            limit = self._limits[metric]
+            if limit is None:
+                continue
+            if self._spent[metric] + amount - limit > 1e-9:
+                return False
+        return True
+
+    def charge(self, cost: Mapping[str, object]) -> BudgetChargeResult:
+        """Charge the meter, raising on hard overages."""
+
+        normalized = self._normalize_cost(cost)
+        warning_over: dict[str, float] = {}
+        for metric, amount in normalized.items():
+            if amount == 0:
+                continue
+            limit = self._limits[metric]
+            if limit is None:
+                continue
+            projected = self._spent[metric] + amount
+            if projected - limit > 1e-9:
+                if self.mode == "hard":
+                    raise BudgetBreachError(
+                        scope=self.full_scope,
+                        metric=metric,
+                        limit=limit,
+                        attempted=projected,
+                    )
+                warning_over[metric] = projected - limit
+        for metric, amount in normalized.items():
+            self._spent[metric] += amount
+        warning_obj: BudgetWarning | None = None
+        if warning_over:
+            warning_obj = BudgetWarning(
+                scope=self.full_scope,
+                over=MappingProxyType(dict(warning_over)),
+                mode=self.mode,
+            )
+            self._warnings.append(warning_obj)
+        return BudgetChargeResult(
+            scope=self.full_scope,
+            cost=MappingProxyType({k: v for k, v in normalized.items() if v}),
+            spent=MappingProxyType(self._spent.copy()),
+            limits=MappingProxyType(self._limits.copy()),
+            warning=warning_obj,
+        )
+
+    @property
+    def full_scope(self) -> str:
+        return f"{self.scope}:{self.name}" if self.scope else self.name
+
+    @property
+    def is_exhausted(self) -> bool:
+        for metric, limit in self._limits.items():
+            if limit is None:
+                continue
+            if limit <= 0 and self._spent[metric] > 0:
+                return True
+            if limit > 0 and self._spent[metric] >= limit - 1e-9:
+                return True
+        return False
+
+    def remaining(self) -> Mapping[str, float]:
+        remaining: dict[str, float] = {}
+        for metric, limit in self._limits.items():
+            if limit is None:
+                continue
+            remaining[metric] = max(0.0, limit - self._spent[metric])
+        return MappingProxyType(remaining)
+
+
+    @property
+    def limits(self) -> Mapping[str, float | None]:
+        return MappingProxyType(self._limits.copy())
+
+    @property
+    def spent(self) -> Mapping[str, float]:
+        return MappingProxyType(self._spent.copy())
+    @property
+    def warnings(self) -> tuple[BudgetWarning, ...]:
+        return tuple(self._warnings)

--- a/pkgs/dsl/runner.py
+++ b/pkgs/dsl/runner.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .budget import BudgetBreachError, BudgetMeter
+
+__all__ = ["RunResult", "FlowRunner"]
+
+
+@dataclass(slots=True)
+class RunResult:
+    """Minimal run result returned by :class:`FlowRunner`."""
+
+    run_id: str
+    status: str
+    outputs: dict[str, dict[str, Any]]
+    stop_reasons: list[dict[str, Any]] = field(default_factory=list)
+
+
+class FlowRunner:
+    """Execute a simplified flow spec with budget enforcement."""
+
+    def __init__(
+        self,
+        *,
+        adapters: Mapping[str, Callable[..., Mapping[str, Any]]] | None = None,
+        trace_path: Path | None = None,
+        run_id_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self._adapters = dict(adapters or {})
+        self._run_id_factory = run_id_factory or (lambda: uuid.uuid4().hex)
+        self._trace_path = Path(trace_path) if trace_path is not None else None
+        self._trace_events: list[dict[str, Any]] = []
+        self._outputs: dict[str, dict[str, Any]] = {}
+        self._stop_reasons: list[dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def trace_events(self) -> list[dict[str, Any]]:
+        return list(self._trace_events)
+
+    def run(self, *, spec: Mapping[str, Any], vars: Mapping[str, Any]) -> RunResult:
+        self._trace_events.clear()
+        self._outputs = {}
+        self._stop_reasons = []
+        run_id = self._run_id_factory()
+        self._record_event("run_start", scope="run", run_id=run_id)
+
+        globals_cfg = spec.get("globals", {}) if isinstance(spec, Mapping) else {}
+        run_meter = self._build_meter(name="run", scope="run", config=globals_cfg.get("run_budget"))
+
+        node_specs = {node["id"]: node for node in spec.get("nodes", [])}
+        node_meters = {
+            node_id: self._build_meter(name=node_id, scope="node", config=node.get("budget"))
+            for node_id, node in node_specs.items()
+        }
+        spec_meters = {
+            node_id: self._build_meter(
+                name=node_id,
+                scope="spec",
+                config=node.get("spec", {}).get("budget"),
+            )
+            for node_id, node in node_specs.items()
+        }
+
+        status = "ok"
+        for control in spec.get("control", []):
+            if control.get("kind") != "loop":
+                continue
+            loop_status = self._execute_loop(
+                run_id=run_id,
+                loop=control,
+                node_specs=node_specs,
+                node_meters=node_meters,
+                spec_meters=spec_meters,
+                run_meter=run_meter,
+                vars=vars,
+            )
+            if loop_status == "halted":
+                status = "halted"
+                break
+
+        self._flush_trace()
+        return RunResult(
+            run_id=run_id,
+            status=status,
+            outputs=self._outputs,
+            stop_reasons=list(self._stop_reasons),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _execute_loop(
+        self,
+        *,
+        run_id: str,
+        loop: Mapping[str, Any],
+        node_specs: Mapping[str, Mapping[str, Any]],
+        node_meters: Mapping[str, BudgetMeter | None],
+        spec_meters: Mapping[str, BudgetMeter | None],
+        run_meter: BudgetMeter | None,
+        vars: Mapping[str, Any],
+    ) -> str | None:
+        loop_id = loop.get("id", "loop")
+        stop_cfg = loop.get("stop", {})
+        max_iterations = stop_cfg.get("max_iterations")
+        loop_meter = self._build_meter(name=loop_id, scope="loop", config=stop_cfg.get("budget"))
+        breach_action = (stop_cfg.get("budget", {}) or {}).get("breach_action", "stop")
+        iteration = 0
+        while max_iterations is None or iteration < max_iterations:
+            for node_id in loop.get("target_subgraph", []):
+                node = node_specs.get(node_id)
+                if node is None:
+                    raise KeyError(f"Unknown node id '{node_id}' referenced in loop '{loop_id}'")
+                self._execute_node(
+                    run_id=run_id,
+                    node=node,
+                    loop_id=loop_id,
+                    iteration=iteration,
+                    run_meter=run_meter,
+                    loop_meter=loop_meter,
+                    node_meter=node_meters.get(node_id),
+                    spec_meter=spec_meters.get(node_id),
+                    vars=vars,
+                )
+            iteration += 1
+            if loop_meter and loop_meter.is_exhausted:
+                metric, limit = self._detect_breach(loop_meter)
+                self._record_event(
+                    "budget_breach",
+                    scope=loop_meter.full_scope,
+                    action=breach_action,
+                    details={"metric": metric, "limit": limit},
+                )
+                if breach_action == "stop":
+                    self._stop_reasons.append(
+                        {
+                            "scope": loop_meter.full_scope,
+                            "reason": "budget_exhausted",
+                            "details": {"metric": metric, "limit": limit},
+                        }
+                    )
+                    return "halted"
+                raise RuntimeError("loop budget hard cap exceeded")
+            if max_iterations is not None and iteration >= max_iterations:
+                break
+        return None
+
+    def _execute_node(
+        self,
+        *,
+        run_id: str,
+        node: Mapping[str, Any],
+        loop_id: str,
+        iteration: int,
+        run_meter: BudgetMeter | None,
+        loop_meter: BudgetMeter | None,
+        node_meter: BudgetMeter | None,
+        spec_meter: BudgetMeter | None,
+        vars: Mapping[str, Any],
+    ) -> None:
+        node_id = node.get("id", "node")
+        if node.get("kind") != "unit":
+            raise NotImplementedError("Only unit nodes are supported in this simplified runner")
+        spec = node.get("spec", {})
+        tool_ref = spec.get("tool_ref")
+        if tool_ref not in self._adapters:
+            raise KeyError(f"No adapter registered for tool '{tool_ref}'")
+        adapter = self._adapters[tool_ref]
+        inputs = node.get("inputs", {})
+        context = {
+            "run_id": run_id,
+            "loop_id": loop_id,
+            "iteration": iteration,
+            "vars": vars,
+        }
+        result = adapter(inputs=inputs, context=context)
+        if not isinstance(result, Mapping):
+            raise TypeError("Adapter must return a mapping with outputs and cost")
+        outputs = dict(result.get("outputs", {}))
+        cost = dict(result.get("cost", {}))
+        self._outputs[node_id] = outputs
+
+        self._charge_all(cost, [run_meter, loop_meter, node_meter, spec_meter])
+
+        self._record_event(
+            "node_end",
+            scope=f"node:{node_id}",
+            loop_id=loop_id,
+            iteration=iteration,
+            outputs=outputs,
+        )
+
+    def _charge_all(self, cost: Mapping[str, Any], meters: list[BudgetMeter | None]) -> None:
+        for meter in meters:
+            if meter is None:
+                continue
+            try:
+                result = meter.charge(cost)
+            except BudgetBreachError as err:
+                self._record_event(
+                    "budget_breach",
+                    scope=err.scope,
+                    action="error",
+                    details={
+                        "metric": err.metric,
+                        "limit": err.limit,
+                        "attempted": err.attempted,
+                    },
+                )
+                raise
+            else:
+                self._record_event(
+                    "budget_charge",
+                    scope=result.scope,
+                    cost=dict(result.cost),
+                    spent=dict(result.spent),
+                )
+                if result.warning is not None:
+                    self._record_event(
+                        "budget_warn",
+                        scope=result.warning.scope,
+                        over=dict(result.warning.over),
+                        mode=result.warning.mode,
+                    )
+
+    def _detect_breach(self, meter: BudgetMeter) -> tuple[str, float | None]:
+        spent = meter.spent
+        for metric, limit in meter.limits.items():
+            if limit is None:
+                continue
+            if spent.get(metric, 0.0) >= limit - 1e-9:
+                return metric, limit
+        return "unknown", None
+
+    def _build_meter(
+        self, *, name: str, scope: str, config: Mapping[str, Any] | None
+    ) -> BudgetMeter | None:
+        if not config:
+            return None
+        return BudgetMeter(name=name, scope=scope, config=config)
+
+    def _record_event(self, event: str, *, scope: str, **payload: Any) -> None:
+        record = {"event": event, "scope": scope, **payload}
+        self._trace_events.append(record)
+
+    def _flush_trace(self) -> None:
+        if self._trace_path is None:
+            return
+        self._trace_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._trace_path.open("w", encoding="utf-8") as fh:
+            for event in self._trace_events:
+                fh.write(json.dumps(event) + "\n")

--- a/tests/e2e/test_runner_budget_stop.py
+++ b/tests/e2e/test_runner_budget_stop.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pkgs.dsl.runner import FlowRunner, RunResult
+
+
+@pytest.fixture()
+def budgeted_runner(tmp_path: Path) -> FlowRunner:
+    calls: dict[str, int] = {"count": 0}
+
+    def counter_adapter(*, inputs: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
+        calls["count"] += 1
+        return {
+            "outputs": {"value": calls["count"]},
+            "cost": {"calls": 1},
+            "metadata": {"iteration": calls["count"]},
+        }
+
+    runner = FlowRunner(
+        adapters={"counter": counter_adapter},
+        trace_path=tmp_path / "trace.jsonl",
+    )
+    runner._test_call_counter = calls  # type: ignore[attr-defined]
+    return runner
+
+
+def build_loop_spec(max_iterations: int = 10) -> dict[str, Any]:
+    return {
+        "globals": {
+            "run_budget": {"mode": "hard", "max_calls": 10},
+        },
+        "nodes": [
+            {
+                "id": "accumulate",
+                "kind": "unit",
+                "inputs": {},
+                "outputs": ["value"],
+                "spec": {
+                    "type": "tool",
+                    "tool_ref": "counter",
+                },
+                "budget": {"mode": "hard", "max_calls": 5},
+            }
+        ],
+        "control": [
+            {
+                "id": "loop_one",
+                "kind": "loop",
+                "target_subgraph": ["accumulate"],
+                "stop": {
+                    "max_iterations": max_iterations,
+                    "budget": {"max_calls": 3, "breach_action": "stop"},
+                },
+            }
+        ],
+    }
+
+
+def test_runner_loop_stops_when_loop_budget_hits(budgeted_runner: FlowRunner) -> None:
+    spec = build_loop_spec()
+    result = budgeted_runner.run(spec=spec, vars={})
+
+    assert isinstance(result, RunResult)
+    assert result.status == "halted"
+    assert result.outputs["accumulate"]["value"] == 3
+    assert result.stop_reasons == [
+        {
+            "scope": "loop:loop_one",
+            "reason": "budget_exhausted",
+            "details": {"metric": "calls", "limit": 3},
+        }
+    ]
+
+    call_count = budgeted_runner._test_call_counter["count"]  # type: ignore[attr-defined]
+    assert call_count == 3
+
+    trace_events = budgeted_runner.trace_events
+    breaches = [e for e in trace_events if e["event"] == "budget_breach"]
+    assert breaches
+    assert breaches[-1]["scope"] == "loop:loop_one"
+    assert breaches[-1]["action"] == "stop"
+
+    charges = [
+        e
+        for e in trace_events
+        if e["event"] == "budget_charge" and e["scope"] == "loop:loop_one"
+    ]
+    assert len(charges) == 3
+
+
+def test_runner_loop_raises_on_hard_breach_action_error(budgeted_runner: FlowRunner) -> None:
+    spec = build_loop_spec()
+    spec["control"][0]["stop"]["budget"]["breach_action"] = "error"
+
+    with pytest.raises(RuntimeError, match="loop budget hard cap exceeded"):
+        budgeted_runner.run(spec=spec, vars={})

--- a/tests/unit/test_budget_meter_limits.py
+++ b/tests/unit/test_budget_meter_limits.py
@@ -1,0 +1,69 @@
+"""Unit tests for the DSL budget meter implementation."""
+
+from __future__ import annotations
+
+import pytest
+
+from pkgs.dsl.budget import BudgetBreachError, BudgetMeter
+
+
+def test_budget_meter_enforces_hard_caps() -> None:
+    meter = BudgetMeter(
+        name="node:answer",
+        scope="node",
+        config={
+            "mode": "hard",
+            "max_usd": 2.5,
+            "max_tokens": 100,
+            "max_calls": 5,
+        },
+    )
+
+    assert meter.can_spend({"usd": 1.0, "tokens": 20, "calls": 1})
+
+    result = meter.charge({"usd": 1.0, "tokens": 20, "calls": 1})
+    assert result.cost == {"usd": 1.0, "tokens": 20, "calls": 1}
+    assert result.warning is None
+    assert meter.remaining()["usd"] == pytest.approx(1.5)
+    assert meter.remaining()["tokens"] == 80
+    assert meter.remaining()["calls"] == 4
+
+    result = meter.charge({"usd": 1.5, "tokens": 80, "calls": 4})
+    assert result.warning is None
+    assert meter.remaining()["usd"] == pytest.approx(0.0)
+    assert meter.remaining()["tokens"] == 0
+    assert meter.remaining()["calls"] == 0
+    assert meter.is_exhausted
+
+    assert not meter.can_spend({"usd": 0.01})
+
+    with pytest.raises(BudgetBreachError):
+        meter.charge({"usd": 0.1})
+
+
+def test_budget_meter_soft_budget_emits_warning() -> None:
+    meter = BudgetMeter(
+        name="answer",
+        scope="spec",
+        config={
+            "mode": "soft",
+            "max_tokens": 50,
+        },
+    )
+
+    first = meter.charge({"tokens": 30})
+    assert first.warning is None
+    assert meter.remaining()["tokens"] == 20
+
+    second = meter.charge({"tokens": 25})
+    assert second.warning is not None
+    assert second.warning.scope == "spec:answer"
+    assert second.warning.over == {"tokens": 5}
+    assert meter.remaining()["tokens"] == 0
+    assert meter.is_exhausted
+
+    # Soft budgets should never block spending.
+    assert meter.can_spend({"tokens": 10})
+    third = meter.charge({"tokens": 10})
+    assert third.warning is not None
+    assert third.warning.over == {"tokens": 15.0}


### PR DESCRIPTION
## Summary
- add a BudgetMeter implementation that tracks hard and soft caps, exposes remaining spend, and surfaces warnings
- build a minimal FlowRunner that wires budget meters into node execution and loop stop conditions while emitting budget trace events
- cover hard/soft meter behaviour and loop budget stopping with new unit and e2e tests

## Testing
- ./scripts/ensure_green.sh


------
https://chatgpt.com/codex/tasks/task_e_68e87910ae88832cac6051626b61f24c