### PR TITLE
Add budget metering primitives and loop stop integration

### DIFF
--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,5 +1,14 @@
-"""DSL package exports for policy engine components."""
+"""DSL package exports for policy and runner components."""
 
+from .budget import (  # noqa: F401
+    BudgetBreachHard,
+    BudgetChargeOutcome,
+    BudgetError,
+    BudgetMeter,
+    BudgetRemaining,
+    BudgetSpec,
+    CostSnapshot,
+)
 from .models import (  # noqa: F401
     PolicyDecision,
     PolicyDenial,
@@ -14,16 +23,30 @@ from .policy import (  # noqa: F401
     PolicyTraceRecorder,
     PolicyViolationError,
 )
+from .runner import FlowRunner, RunResult  # noqa: F401
+from .trace import InMemoryTraceWriter, TraceEvent, TraceWriter  # noqa: F401
 
 __all__ = [
+    "BudgetBreachHard",
+    "BudgetChargeOutcome",
+    "BudgetError",
+    "BudgetMeter",
+    "BudgetRemaining",
+    "BudgetSpec",
+    "CostSnapshot",
+    "FlowRunner",
+    "InMemoryTraceWriter",
     "PolicyDecision",
     "PolicyDenial",
+    "PolicyError",
     "PolicyResolution",
     "PolicySnapshot",
-    "PolicyError",
     "PolicyStack",
     "PolicyTraceEvent",
     "PolicyTraceRecorder",
     "PolicyViolationError",
+    "RunResult",
     "ToolDescriptor",
+    "TraceEvent",
+    "TraceWriter",
 ]

--- a/pkgs/dsl/budget.py
+++ b/pkgs/dsl/budget.py
@@ -1,0 +1,287 @@
+"""Budget metering primitives for the DSL runner."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+__all__ = [
+    "BudgetError",
+    "BudgetBreachHard",
+    "BudgetSpec",
+    "BudgetRemaining",
+    "BudgetChargeOutcome",
+    "CostSnapshot",
+    "BudgetMeter",
+]
+
+
+class BudgetError(RuntimeError):
+    """Base error for budget evaluation failures."""
+
+
+class BudgetBreachHard(BudgetError):
+    """Raised when a hard budget cap is exceeded."""
+
+    def __init__(self, scope: str, *, limit: str, amount: float | int) -> None:
+        super().__init__(f"Budget hard cap exceeded for {scope}: {limit}={amount}")
+        self.scope = scope
+        self.limit = limit
+        self.amount = amount
+
+
+@dataclass(slots=True, frozen=True)
+class BudgetSpec:
+    """Canonical representation of a budget configuration."""
+
+    mode: str | None = None
+    scope: str | None = None
+    max_usd: float | None = None
+    max_tokens: int | None = None
+    max_calls: int | None = None
+    time_limit_sec: float | None = None
+    token_rate: Mapping[str, object] | None = None
+    breach_action: str | None = None
+
+    @classmethod
+    def from_mapping(
+        cls,
+        data: Mapping[str, object] | None,
+        *,
+        scope: str | None = None,
+    ) -> BudgetSpec:
+        if not data:
+            return cls(scope=scope)
+        raw_mode = data.get("mode")
+        mode = raw_mode if isinstance(raw_mode, str) else None
+        raw_breach = data.get("breach_action")
+        breach_action = raw_breach if isinstance(raw_breach, str) else None
+        raw_token_rate = data.get("token_rate")
+        def _coerce_number(value: object) -> float | None:
+            if value is None:
+                return None
+            if isinstance(value, int | float):
+                return float(value)
+            return None
+
+        def _coerce_int(value: object) -> int | None:
+            if value is None:
+                return None
+            if isinstance(value, int):
+                return value
+            if isinstance(value, float) and value.is_integer():
+                return int(value)
+            return None
+
+        return cls(
+            mode=mode,
+            scope=scope,
+            max_usd=_coerce_number(data.get("max_usd")),
+            max_tokens=_coerce_int(data.get("max_tokens")),
+            max_calls=_coerce_int(data.get("max_calls")),
+            time_limit_sec=_coerce_number(data.get("time_limit_sec")),
+            token_rate=raw_token_rate if isinstance(raw_token_rate, Mapping) else None,
+            breach_action=breach_action,
+        )
+
+
+@dataclass(slots=True, frozen=True)
+class CostSnapshot:
+    """Concrete spend payload for budget accounting."""
+
+    usd: float = 0.0
+    calls: int = 0
+    tokens_in: int = 0
+    tokens_out: int = 0
+    seconds: float = 0.0
+
+    @property
+    def tokens_total(self) -> int:
+        return self.tokens_in + self.tokens_out
+
+
+@dataclass(slots=True, frozen=True)
+class BudgetRemaining:
+    """Remaining headroom for each tracked metric."""
+
+    usd: float | None
+    calls: int | None
+    tokens: int | None
+    seconds: float | None
+
+
+@dataclass(slots=True, frozen=True)
+class BudgetChargeOutcome:
+    """Result metadata returned from :meth:`BudgetMeter.charge`."""
+
+    soft_breach: bool
+    breach_kind: str | None
+    remaining: BudgetRemaining
+
+
+class BudgetMeter:
+    """Accumulates spend against configured budget caps."""
+
+    def __init__(
+        self,
+        spec: BudgetSpec,
+        *,
+        scope: str,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._spec = spec
+        self._scope = scope
+        self._clock = clock or (lambda: 0.0)
+        self._usd_spent = 0.0
+        self._tokens_spent = 0
+        self._calls_spent = 0
+        self._seconds_spent = 0.0
+        self._soft_exceeded = False
+        self._hard_exceeded = False
+        self._defer_hard_stop = (
+            (spec.scope == "loop" or scope == "loop")
+            and spec.breach_action == "stop"
+        )
+
+    @classmethod
+    def from_spec(
+        cls,
+        config: BudgetSpec | Mapping[str, object] | None,
+        *,
+        scope: str,
+        clock: Callable[[], float] | None = None,
+    ) -> BudgetMeter:
+        if isinstance(config, BudgetSpec):
+            spec = config
+        else:
+            spec = BudgetSpec.from_mapping(config, scope=scope)
+        return cls(spec, scope=scope, clock=clock)
+
+    @classmethod
+    def unlimited(cls, *, scope: str) -> BudgetMeter:
+        return cls(BudgetSpec(scope=scope), scope=scope)
+
+    @property
+    def mode(self) -> str:
+        if self._spec.mode:
+            return self._spec.mode
+        if self._spec.breach_action:
+            return "hard"
+        return "hard"
+
+    @property
+    def stop_behavior(self) -> str:
+        return self._spec.breach_action or "error"
+
+    @property
+    def exceeded(self) -> bool:
+        return self._soft_exceeded or self._hard_exceeded
+
+    def can_spend(self, cost: CostSnapshot) -> bool:
+        totals = self._project_totals(cost)
+        for _name, limit, total in totals:
+            if limit is None or limit <= 0:
+                continue
+            if total > limit + 1e-9:
+                if self.mode == "hard" and not self._defer_hard_stop:
+                    return False
+        return True
+
+    def charge(self, cost: CostSnapshot) -> BudgetChargeOutcome:
+        breach_kind: str | None = None
+        breach_limit: str | None = None
+        totals = self._project_totals(cost)
+        for name, limit, total in totals:
+            if limit is None or limit <= 0:
+                continue
+            if total > limit + 1e-9:
+                breach_kind = "hard" if self.mode == "hard" else "soft"
+                breach_limit = name
+                break
+        self._usd_spent += cost.usd
+        self._calls_spent += cost.calls
+        self._tokens_spent += cost.tokens_total
+        self._seconds_spent += cost.seconds
+        for _name, limit, total in totals:
+            if limit is None or limit <= 0:
+                continue
+            if total >= limit - 1e-9:
+                if self.mode == "hard":
+                    self._hard_exceeded = True
+                else:
+                    self._soft_exceeded = True
+        if breach_kind == "hard":
+            if not self._defer_hard_stop:
+                raise BudgetBreachHard(
+                    self._scope,
+                    limit=breach_limit or "budget",
+                    amount=self._current_amount(breach_limit or "budget", cost),
+                )
+        elif breach_kind == "soft":
+            self._soft_exceeded = True
+        return BudgetChargeOutcome(
+            soft_breach=breach_kind == "soft",
+            breach_kind=breach_kind,
+            remaining=self.remaining(),
+        )
+
+    def remaining(self) -> BudgetRemaining:
+        return BudgetRemaining(
+            usd=self._remaining_float(self._spec.max_usd, self._usd_spent),
+            calls=self._remaining_int(self._spec.max_calls, self._calls_spent),
+            tokens=self._remaining_int(self._spec.max_tokens, self._tokens_spent),
+            seconds=self._remaining_float(self._spec.time_limit_sec, self._seconds_spent),
+        )
+
+    def _project_totals(
+        self, cost: CostSnapshot
+    ) -> tuple[tuple[str, float | int | None, float | int], ...]:
+        return (
+            ("usd", self._spec.max_usd, self._usd_spent + cost.usd),
+            ("calls", self._spec.max_calls, self._calls_spent + cost.calls),
+            ("tokens", self._spec.max_tokens, self._tokens_spent + cost.tokens_total),
+            ("seconds", self._spec.time_limit_sec, self._seconds_spent + cost.seconds),
+        )
+
+    def _current_amount(self, limit: str, cost: CostSnapshot) -> float | int:
+        if limit == "usd":
+            return self._usd_spent + cost.usd
+        if limit == "calls":
+            return self._calls_spent + cost.calls
+        if limit == "tokens":
+            return self._tokens_spent + cost.tokens_total
+        if limit == "seconds":
+            return self._seconds_spent + cost.seconds
+        return 0
+
+    @staticmethod
+    def _remaining_float(limit: float | None, spent: float) -> float | None:
+        if limit is None or limit <= 0:
+            return None
+        return max(limit - spent, 0.0)
+
+    @staticmethod
+    def _remaining_int(limit: int | None, spent: int) -> int | None:
+        if limit is None or limit <= 0:
+            return None
+        remaining = limit - spent
+        return remaining if remaining >= 0 else 0
+
+    def snapshot(self) -> Mapping[str, float | int | None]:
+        return MappingProxyType(
+            {
+                "usd_spent": self._usd_spent,
+                "calls_spent": self._calls_spent,
+                "tokens_spent": self._tokens_spent,
+                "seconds_spent": self._seconds_spent,
+                "remaining_usd": self._remaining_float(self._spec.max_usd, self._usd_spent),
+                "remaining_calls": self._remaining_int(self._spec.max_calls, self._calls_spent),
+                "remaining_tokens": self._remaining_int(
+                    self._spec.max_tokens, self._tokens_spent
+                ),
+                "remaining_seconds": self._remaining_float(
+                    self._spec.time_limit_sec, self._seconds_spent
+                ),
+            }
+        )

--- a/pkgs/dsl/runner.py
+++ b/pkgs/dsl/runner.py
@@ -1,0 +1,285 @@
+"""Minimal FlowRunner implementation with budget integration."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from dataclasses import asdict, dataclass
+from types import MappingProxyType
+from typing import Any
+
+from .budget import (
+    BudgetBreachHard,
+    BudgetChargeOutcome,
+    BudgetMeter,
+    BudgetRemaining,
+    BudgetSpec,
+    CostSnapshot,
+)
+from .trace import InMemoryTraceWriter, TraceWriter
+
+__all__ = ["FlowRunner", "RunResult"]
+
+
+@dataclass(slots=True, frozen=True)
+class RunResult:
+    """Structured result returned by :meth:`FlowRunner.run`."""
+
+    run_id: str
+    status: str
+    outputs: Mapping[str, Any]
+    trace: Sequence[Mapping[str, object]]
+    loop_iterations: Mapping[str, int]
+    loop_stop_reasons: Mapping[str, str]
+
+
+class FlowRunner:
+    """Execute DSL flows with budget enforcement for loops and nodes."""
+
+    def __init__(
+        self,
+        *,
+        trace_writer: TraceWriter | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._trace = trace_writer or InMemoryTraceWriter()
+        self._clock = clock or time.perf_counter
+        self._reported_breaches: set[str] = set()
+
+    def run(self, spec: Mapping[str, Any], vars: Mapping[str, Any] | None = None) -> RunResult:
+        run_id = str(uuid.uuid4())
+        self._reported_breaches.clear()
+        self._trace.emit("run_start", {"run_id": run_id})
+        run_meter = self._build_run_meter(spec)
+        node_map = {node["id"]: node for node in spec.get("graph", {}).get("nodes", [])}
+        loop_iterations: MutableMapping[str, int] = {}
+        loop_stop_reasons: MutableMapping[str, str] = {}
+        outputs: MutableMapping[str, Any] = {}
+        status = "ok"
+        try:
+            for loop in spec.get("graph", {}).get("control", []):
+                loop_id = loop.get("id", "loop")
+                loop_meter = self._build_loop_meter(loop)
+                loop_stop_reasons[loop_id] = "completed"
+                iterations = 0
+                max_iterations = self._coerce_int(loop.get("stop", {}).get("max_iterations"))
+                while True:
+                    if max_iterations is not None and iterations >= max_iterations:
+                        loop_stop_reasons[loop_id] = "max_iterations"
+                        break
+                    loop_break = False
+                    for node_id in loop.get("target_subgraph", []):
+                        node = node_map[node_id]
+                        self._trace.emit("node_start", {"run_id": run_id, "node_id": node_id})
+                        node_meter = self._build_node_meter(node)
+                        cost = self._execute_node(node)
+                        try:
+                            self._apply_cost(
+                                run_id,
+                                node_id,
+                                cost,
+                                run_meter=run_meter,
+                                node_meter=node_meter,
+                                loop_meter=loop_meter,
+                                loop_id=loop_id,
+                            )
+                        except BudgetBreachHard:
+                            status = "error"
+                            loop_stop_reasons[loop_id] = "budget_breach"
+                            self._trace.emit(
+                                "node_end",
+                                {
+                                    "run_id": run_id,
+                                    "node_id": node_id,
+                                    "status": "error",
+                                    "cost": self._cost_dict(cost),
+                                },
+                            )
+                            loop_break = True
+                            break
+                        else:
+                            self._trace.emit(
+                                "node_end",
+                                {
+                                    "run_id": run_id,
+                                    "node_id": node_id,
+                                    "status": "ok",
+                                    "cost": self._cost_dict(cost),
+                                },
+                            )
+                    iterations += 1
+                    loop_iterations[loop_id] = iterations
+                    self._trace.emit(
+                        "loop_iter",
+                        {"run_id": run_id, "loop_id": loop_id, "iter": iterations},
+                    )
+                    if loop_break:
+                        break
+                    if loop_meter and loop_meter.exceeded:
+                        self._emit_budget_breach(run_id, "loop", loop_id, loop_meter, "hard")
+                        loop_stop_reasons[loop_id] = "budget_breach"
+                        if loop_meter.stop_behavior == "stop":
+                            break
+                        raise BudgetBreachHard(loop_id, limit="loop", amount=iterations)
+                loop_iterations.setdefault(loop_id, iterations)
+        finally:
+            self._trace.emit("run_end", {"run_id": run_id, "status": status})
+        return RunResult(
+            run_id=run_id,
+            status=status,
+            outputs=MappingProxyType(dict(outputs)),
+            trace=self._trace.snapshot(),
+            loop_iterations=MappingProxyType(dict(loop_iterations)),
+            loop_stop_reasons=MappingProxyType(dict(loop_stop_reasons)),
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _build_run_meter(self, spec: Mapping[str, Any]) -> BudgetMeter | None:
+        run_budget = spec.get("globals", {}).get("run_budget")
+        if not run_budget:
+            return None
+        return BudgetMeter.from_spec(
+            BudgetSpec.from_mapping(run_budget, scope="run"),
+            scope="run",
+            clock=self._clock,
+        )
+
+    def _build_node_meter(self, node: Mapping[str, Any]) -> BudgetMeter | None:
+        budget = node.get("budget")
+        if not budget:
+            return None
+        return BudgetMeter.from_spec(
+            BudgetSpec.from_mapping(budget, scope="node"),
+            scope="node",
+            clock=self._clock,
+        )
+
+    def _build_loop_meter(self, loop: Mapping[str, Any]) -> BudgetMeter | None:
+        stop = loop.get("stop", {})
+        budget = stop.get("budget")
+        if not budget:
+            return None
+        spec = BudgetSpec.from_mapping(budget, scope="loop")
+        return BudgetMeter.from_spec(spec, scope="loop", clock=self._clock)
+
+    def _apply_cost(
+        self,
+        run_id: str,
+        node_id: str,
+        cost: CostSnapshot,
+        *,
+        run_meter: BudgetMeter | None,
+        node_meter: BudgetMeter | None,
+        loop_meter: BudgetMeter | None,
+        loop_id: str | None,
+    ) -> None:
+        if run_meter is not None:
+            self._charge_meter(run_id, "run", "run", cost, run_meter)
+        if node_meter is not None:
+            self._charge_meter(run_id, "node", node_id, cost, node_meter)
+        if loop_meter is not None and loop_id is not None:
+            self._charge_meter(run_id, "loop", loop_id, cost, loop_meter)
+
+    def _charge_meter(
+        self,
+        run_id: str,
+        scope: str,
+        identifier: str,
+        cost: CostSnapshot,
+        meter: BudgetMeter,
+    ) -> BudgetChargeOutcome:
+        outcome = meter.charge(cost)
+        self._trace.emit(
+            "budget_charge",
+            {
+                "run_id": run_id,
+                "scope": scope,
+                "meter_id": identifier,
+                "cost": self._cost_dict(cost),
+                "remaining": self._remaining_dict(outcome.remaining),
+            },
+        )
+        key = self._meter_key(scope, identifier)
+        if outcome.breach_kind and key not in self._reported_breaches:
+            self._emit_budget_breach(run_id, scope, identifier, meter, outcome.breach_kind)
+        elif meter.exceeded and key not in self._reported_breaches:
+            kind = "hard" if meter.mode == "hard" else "soft"
+            self._emit_budget_breach(run_id, scope, identifier, meter, kind)
+        return outcome
+
+    def _emit_budget_breach(
+        self,
+        run_id: str,
+        scope: str,
+        identifier: str,
+        meter: BudgetMeter,
+        kind: str,
+    ) -> None:
+        key = self._meter_key(scope, identifier)
+        if key in self._reported_breaches:
+            return
+        self._reported_breaches.add(key)
+        self._trace.emit(
+            "budget_breach",
+            {
+                "run_id": run_id,
+                "scope": scope,
+                "meter_id": identifier,
+                "breach_kind": kind,
+                "mode": meter.mode,
+                "stop_behavior": meter.stop_behavior,
+            },
+        )
+
+    @staticmethod
+    def _meter_key(scope: str, identifier: str) -> str:
+        return f"{scope}:{identifier}"
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int | None:
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+        return None
+
+    @staticmethod
+    def _cost_dict(cost: CostSnapshot) -> Mapping[str, object]:
+        return MappingProxyType(asdict(cost))
+
+    @staticmethod
+    def _remaining_dict(remaining: BudgetRemaining) -> Mapping[str, object]:
+        return MappingProxyType(
+            {
+                "usd": remaining.usd,
+                "calls": remaining.calls,
+                "tokens": remaining.tokens,
+                "seconds": remaining.seconds,
+            }
+        )
+
+    @staticmethod
+    def _execute_node(node: Mapping[str, Any]) -> CostSnapshot:
+        spec = node.get("spec", {})
+        mock_cost = spec.get("mock_cost", {})
+        usd = FlowRunner._coerce_float(mock_cost.get("usd")) or 0.0
+        calls = FlowRunner._coerce_int(mock_cost.get("calls")) or 0
+        tokens_in = FlowRunner._coerce_int(mock_cost.get("tokens_in")) or 0
+        tokens_out = FlowRunner._coerce_int(mock_cost.get("tokens_out")) or 0
+        seconds = FlowRunner._coerce_float(mock_cost.get("seconds")) or 0.0
+        return CostSnapshot(
+            usd=usd,
+            calls=calls,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            seconds=seconds,
+        )
+
+    @staticmethod
+    def _coerce_float(value: Any) -> float | None:
+        if isinstance(value, int | float):
+            return float(value)
+        return None

--- a/pkgs/dsl/trace.py
+++ b/pkgs/dsl/trace.py
@@ -1,0 +1,46 @@
+"""Trace writer utilities for the DSL runner."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+__all__ = ["TraceEvent", "TraceWriter", "InMemoryTraceWriter"]
+
+
+@dataclass(slots=True, frozen=True)
+class TraceEvent:
+    """Single trace event emitted during runner execution."""
+
+    event: str
+    payload: Mapping[str, object]
+
+
+class TraceWriter:
+    """Abstract trace sink used by the runner."""
+
+    def emit(self, event: str, payload: Mapping[str, object]) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    def snapshot(self) -> Sequence[Mapping[str, object]]:  # pragma: no cover
+        raise NotImplementedError
+
+
+class InMemoryTraceWriter(TraceWriter):
+    """Simple trace writer that buffers events in memory."""
+
+    def __init__(self) -> None:
+        self._events: list[MutableMapping[str, object]] = []
+
+    def emit(self, event: str, payload: Mapping[str, object]) -> None:
+        record: MutableMapping[str, object] = {"event": event}
+        record.update(payload)
+        self._events.append(record)
+
+    def snapshot(self) -> Sequence[Mapping[str, object]]:
+        return tuple(MappingProxyType(dict(event)) for event in self._events)
+
+    @property
+    def events(self) -> Sequence[Mapping[str, object]]:
+        return self.snapshot()

--- a/tests/e2e/test_runner_budget_stop.py
+++ b/tests/e2e/test_runner_budget_stop.py
@@ -1,0 +1,76 @@
+"""End-to-end budget integration tests for FlowRunner loops."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pkgs.dsl.runner import FlowRunner, RunResult
+from pkgs.dsl.trace import InMemoryTraceWriter
+
+
+@pytest.fixture()
+def runner() -> FlowRunner:
+    return FlowRunner(trace_writer=InMemoryTraceWriter())
+
+
+def _loop_budget_spec(max_iterations: int, max_calls: int) -> dict[str, Any]:
+    return {
+        "version": "0.1",
+        "globals": {
+            "tools": {
+                "mock_tool": {
+                    "type": "tool",
+                    "pricing": {"per_call_usd": 0.2},
+                }
+            },
+            "run_budget": {"mode": "hard", "max_usd": 10.0},
+        },
+        "graph": {
+            "nodes": [
+                {
+                    "id": "step",
+                    "kind": "unit",
+                    "spec": {
+                        "type": "tool",
+                        "tool_ref": "mock_tool",
+                        "mock_cost": {"usd": 0.5, "calls": 1},
+                    },
+                    "inputs": {},
+                    "outputs": ["result"],
+                    "budget": {"mode": "hard", "max_usd": 2.0},
+                }
+            ],
+            "control": [
+                {
+                    "id": "loop",
+                    "kind": "loop",
+                    "target_subgraph": ["step"],
+                    "stop": {
+                        "max_iterations": max_iterations,
+                        "budget": {"max_calls": max_calls, "breach_action": "stop"},
+                    },
+                }
+            ],
+        },
+    }
+
+
+def test_loop_stops_on_budget_breach(runner: FlowRunner) -> None:
+    spec = _loop_budget_spec(max_iterations=6, max_calls=3)
+    result = runner.run(spec, vars={})
+    assert isinstance(result, RunResult)
+    assert result.status == "ok"
+    assert result.loop_iterations.get("loop") == 3
+    assert result.loop_stop_reasons.get("loop") == "budget_breach"
+    breach_events = [e for e in result.trace if e["event"] == "budget_breach"]
+    assert breach_events and breach_events[-1]["scope"] == "loop"
+
+
+def test_loop_respects_max_iterations_when_budget_unlimited(runner: FlowRunner) -> None:
+    spec = _loop_budget_spec(max_iterations=2, max_calls=10)
+    result = runner.run(spec, vars={})
+    assert result.loop_iterations["loop"] == 2
+    assert result.loop_stop_reasons["loop"] == "max_iterations"
+    assert not [e for e in result.trace if e["event"] == "budget_breach"]

--- a/tests/unit/test_budget_meter_limits.py
+++ b/tests/unit/test_budget_meter_limits.py
@@ -1,0 +1,69 @@
+"""Unit tests for BudgetMeter limit enforcement."""
+
+from __future__ import annotations
+
+import pytest
+
+from pkgs.dsl.budget import (
+    BudgetBreachHard,
+    BudgetMeter,
+    BudgetSpec,
+    CostSnapshot,
+)
+
+
+@pytest.fixture
+def hard_meter() -> BudgetMeter:
+    return BudgetMeter.from_spec(
+        BudgetSpec(mode="hard", max_usd=1.0, scope="run"),
+        scope="run",
+    )
+
+
+@pytest.fixture
+def soft_meter() -> BudgetMeter:
+    return BudgetMeter.from_spec(
+        BudgetSpec(mode="soft", max_tokens=100, scope="node"),
+        scope="node",
+    )
+
+
+def test_can_spend_checks_remaining_budget(hard_meter: BudgetMeter) -> None:
+    assert hard_meter.can_spend(CostSnapshot(usd=0.4)) is True
+    hard_meter.charge(CostSnapshot(usd=0.6))
+    assert hard_meter.can_spend(CostSnapshot(usd=0.5)) is False
+    assert hard_meter.remaining().usd == pytest.approx(0.4)
+
+
+def test_hard_cap_blocks_charge(hard_meter: BudgetMeter) -> None:
+    hard_meter.charge(CostSnapshot(usd=0.8, calls=1))
+    with pytest.raises(BudgetBreachHard):
+        hard_meter.charge(CostSnapshot(usd=0.3))
+
+
+def test_soft_cap_emits_breach_but_allows_charge(soft_meter: BudgetMeter) -> None:
+    outcome = soft_meter.charge(CostSnapshot(tokens_in=40, tokens_out=40))
+    assert outcome.soft_breach is False
+    outcome = soft_meter.charge(CostSnapshot(tokens_in=30, tokens_out=50))
+    assert outcome.soft_breach is True
+    assert outcome.breach_kind == "soft"
+    assert soft_meter.exceeded is True
+
+
+def test_unlimited_budget_allows_large_spend() -> None:
+    meter = BudgetMeter.unlimited(scope="run")
+    assert meter.can_spend(CostSnapshot(usd=1_000_000, calls=10_000)) is True
+    outcome = meter.charge(CostSnapshot(usd=500_000, tokens_in=1_000_000))
+    assert outcome.soft_breach is False
+    assert meter.remaining().usd is None
+
+
+def test_loop_stop_budget_records_breach_action_stop() -> None:
+    meter = BudgetMeter.from_spec(
+        BudgetSpec(breach_action="stop", max_calls=2, scope="loop"),
+        scope="loop",
+    )
+    meter.charge(CostSnapshot(calls=1))
+    meter.charge(CostSnapshot(calls=1))
+    assert meter.exceeded is True
+    assert meter.stop_behavior == "stop"


### PR DESCRIPTION
## Summary
- implement BudgetMeter and supporting data classes to parse budget specs and track spend across run/node/loop scopes
- add a minimal FlowRunner with trace writer integration that enforces run/node budgets and halts loops on stop budget breaches
- cover budget behavior with dedicated unit tests and an end-to-end loop budget stop scenario

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68e87910ae88832cac6051626b61f24c