### PR TITLE
Add budget metering and loop stop enforcement

### DIFF
--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,5 +1,11 @@
 """DSL package exports for policy engine components."""
 
+from .budget import (  # noqa: F401
+    BudgetBreachHard,
+    BudgetCharge,
+    BudgetError,
+    BudgetMeter,
+)
 from .models import (  # noqa: F401
     PolicyDecision,
     PolicyDenial,
@@ -14,8 +20,13 @@ from .policy import (  # noqa: F401
     PolicyTraceRecorder,
     PolicyViolationError,
 )
+from .runner import FlowRunner, RunResult  # noqa: F401
 
 __all__ = [
+    "BudgetBreachHard",
+    "BudgetCharge",
+    "BudgetError",
+    "BudgetMeter",
     "PolicyDecision",
     "PolicyDenial",
     "PolicyResolution",
@@ -26,4 +37,6 @@ __all__ = [
     "PolicyTraceRecorder",
     "PolicyViolationError",
     "ToolDescriptor",
+    "FlowRunner",
+    "RunResult",
 ]

--- a/pkgs/dsl/budget.py
+++ b/pkgs/dsl/budget.py
@@ -1,0 +1,199 @@
+"""Budget metering utilities for the FlowRunner."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .models import mapping_proxy
+
+__all__ = [
+    "BudgetError",
+    "BudgetBreachHard",
+    "BudgetCharge",
+    "BudgetMeter",
+]
+
+
+class BudgetError(RuntimeError):
+    """Raised when budget configuration or enforcement fails."""
+
+
+class BudgetBreachHard(BudgetError):
+    """Raised when a hard budget is exceeded."""
+
+    def __init__(self, scope: str, overages: Mapping[str, float]) -> None:
+        formatted = ", ".join(
+            f"{field}:+{amount:.4g}"
+            for field, amount in overages.items()
+            if amount > 0
+        ) or "no remaining capacity"
+        super().__init__(f"Budget exceeded for {scope}: {formatted}")
+        self.scope = scope
+        self.overages = mapping_proxy(
+            {field: float(amount) for field, amount in overages.items() if amount > 0}
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetCharge:
+    """Result from charging a budget meter."""
+
+    cost: Mapping[str, float]
+    remaining: Mapping[str, float | None]
+    overages: Mapping[str, float]
+    breached: bool
+    mode: str
+
+
+class BudgetMeter:
+    """Track spend for run, loop, or node budgets."""
+
+    _FIELD_KEYS = ("usd", "tokens", "calls", "time_ms")
+    _CONFIG_MAP: dict[str, tuple[str, Callable[[Any], float]]] = {
+        "max_usd": ("usd", float),
+        "max_tokens": ("tokens", float),
+        "max_calls": ("calls", float),
+        "time_limit_sec": ("time_ms", lambda value: float(value) * 1000.0),
+        "time_limit_ms": ("time_ms", float),
+    }
+    _COST_KEYS: dict[str, str] = {
+        "usd": "usd",
+        "tokens": "tokens",
+        "calls": "calls",
+        "time_ms": "time_ms",
+    }
+
+    def __init__(
+        self,
+        *,
+        kind: str,
+        subject: str,
+        config: Mapping[str, Any] | None = None,
+        mode: str | None = None,
+        breach_action: str | None = None,
+    ) -> None:
+        self._kind = kind
+        self._subject = subject
+        raw_config = dict(config or {})
+        self._mode = (mode or raw_config.get("mode") or "hard").lower()
+        self._breach_action = (
+            breach_action or raw_config.get("breach_action") or "error"
+        ).lower()
+
+        self._caps: dict[str, float | None] = {key: None for key in self._FIELD_KEYS}
+        for key, value in raw_config.items():
+            mapped = self._CONFIG_MAP.get(key)
+            if mapped is None:
+                continue
+            name, transform = mapped
+            numeric = transform(value)
+            self._caps[name] = None if numeric <= 0 else float(numeric)
+
+        self._spent: dict[str, float] = {key: 0.0 for key in self._FIELD_KEYS}
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+    @property
+    def kind(self) -> str:
+        return self._kind
+
+    @property
+    def subject(self) -> str:
+        return self._subject
+
+    @property
+    def scope(self) -> str:
+        return f"{self._kind}:{self._subject}"
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def breach_action(self) -> str:
+        return self._breach_action
+
+    @property
+    def exceeded(self) -> bool:
+        return any(amount > 0 for amount in self.overages().values())
+
+    # ------------------------------------------------------------------
+    # Budget operations
+    # ------------------------------------------------------------------
+    def can_spend(self, cost: Mapping[str, float | int]) -> bool:
+        """Return True if the cost fits under the configured caps."""
+
+        if self._mode == "soft":
+            return True
+
+        normalized = self._normalize_cost(cost)
+        for key, amount in normalized.items():
+            cap = self._caps.get(key)
+            if cap is None:
+                continue
+            if self._spent[key] + amount > cap:
+                return False
+        return True
+
+    def charge(self, cost: Mapping[str, float | int]) -> BudgetCharge:
+        """Record cost against the meter and raise on hard breaches."""
+
+        normalized = self._normalize_cost(cost)
+        for key, amount in normalized.items():
+            self._spent[key] += amount
+
+        overages = self.overages()
+        breached = any(amount > 0 for amount in overages.values())
+        remaining = self.remaining()
+
+        if (
+            breached
+            and self._mode == "hard"
+            and self._breach_action != "stop"
+        ):
+            raise BudgetBreachHard(self.scope, overages)
+
+        return BudgetCharge(
+            cost=mapping_proxy({key: normalized[key] for key in self._FIELD_KEYS}),
+            remaining=remaining,
+            overages=overages,
+            breached=breached,
+            mode=self._mode,
+        )
+
+    def remaining(self) -> Mapping[str, float | None]:
+        """Return remaining capacity for each tracked field."""
+
+        remaining: dict[str, float | None] = {}
+        for key, cap in self._caps.items():
+            if cap is None:
+                remaining[key] = None
+            else:
+                remaining[key] = cap - self._spent[key]
+        return mapping_proxy(remaining)
+
+    def overages(self) -> Mapping[str, float]:
+        """Return positive overages for each field (0 otherwise)."""
+
+        return mapping_proxy(
+            {
+                key: max(self._spent[key] - cap, 0.0) if cap is not None else 0.0
+                for key, cap in self._caps.items()
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _normalize_cost(self, cost: Mapping[str, float | int]) -> dict[str, float]:
+        normalized = {key: 0.0 for key in self._FIELD_KEYS}
+        for key, raw_value in cost.items():
+            try:
+                field = self._COST_KEYS[key]
+            except KeyError as exc:  # pragma: no cover - defensive branch
+                raise BudgetError(f"Unsupported cost key: {key!r}") from exc
+            normalized[field] += float(raw_value)
+        return normalized

--- a/pkgs/dsl/runner.py
+++ b/pkgs/dsl/runner.py
@@ -1,0 +1,260 @@
+"""Minimal FlowRunner implementation with budget enforcement and tracing."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .budget import BudgetBreachHard, BudgetError, BudgetMeter
+from .models import mapping_proxy
+
+__all__ = ["FlowRunner", "RunResult"]
+
+
+TraceEvent = Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class RunResult:
+    """Structured result returned by :class:`FlowRunner.run`."""
+
+    run_id: str
+    status: str
+    outputs: Mapping[str, Sequence[Mapping[str, Any]]]
+    trace: Sequence[TraceEvent]
+    stop_reasons: Sequence[Mapping[str, Any]]
+
+
+class FlowRunner:
+    """Execute flow control loops with budget enforcement."""
+
+    def __init__(
+        self,
+        *,
+        tool_adapters: Mapping[str, Callable[..., Mapping[str, Any]]],
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._tool_adapters = dict(tool_adapters)
+        self._clock = clock or time.time
+        self._trace_buffer: list[dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self, spec: Mapping[str, Any], vars: Mapping[str, Any]) -> RunResult:
+        run_id = uuid.uuid4().hex
+        self._trace_buffer = []
+
+        globals_section = spec.get("globals", {})
+        run_budget_config = globals_section.get("run_budget") or {}
+        run_meter = BudgetMeter(
+            kind="run",
+            subject=run_id,
+            config=run_budget_config,
+            mode=run_budget_config.get("mode"),
+        )
+
+        nodes_section = spec.get("graph", {}).get("nodes", [])
+        nodes: dict[str, Mapping[str, Any]] = {}
+        node_meters: dict[str, BudgetMeter] = {}
+        for entry in nodes_section:
+            node_id = entry["id"]
+            nodes[node_id] = entry
+            budget_cfg = entry.get("budget")
+            if budget_cfg:
+                node_meters[node_id] = BudgetMeter(
+                    kind="node",
+                    subject=node_id,
+                    config=budget_cfg,
+                    mode=budget_cfg.get("mode"),
+                )
+
+        outputs: dict[str, list[Mapping[str, Any]]] = {}
+        stop_reasons: list[Mapping[str, Any]] = []
+
+        for loop in spec.get("control", []):
+            self._execute_loop(
+                run_id=run_id,
+                loop=loop,
+                nodes=nodes,
+                run_meter=run_meter,
+                node_meters=node_meters,
+                outputs=outputs,
+                stop_reasons=stop_reasons,
+            )
+
+        result_outputs = {
+            node_id: tuple(mapping_proxy(entry) for entry in data)
+            for node_id, data in outputs.items()
+        }
+
+        return RunResult(
+            run_id=run_id,
+            status="ok",
+            outputs=mapping_proxy(result_outputs),
+            trace=tuple(mapping_proxy(event) for event in self._trace_buffer),
+            stop_reasons=tuple(stop_reasons),
+        )
+
+    # ------------------------------------------------------------------
+    # Execution helpers
+    # ------------------------------------------------------------------
+    def _execute_loop(
+        self,
+        *,
+        run_id: str,
+        loop: Mapping[str, Any],
+        nodes: Mapping[str, Mapping[str, Any]],
+        run_meter: BudgetMeter,
+        node_meters: Mapping[str, BudgetMeter],
+        outputs: dict[str, list[Mapping[str, Any]]],
+        stop_reasons: list[Mapping[str, Any]],
+    ) -> None:
+        loop_id = loop["id"]
+        stop_config = loop.get("stop", {})
+        max_iterations = stop_config.get("max_iterations")
+        budget_config = stop_config.get("budget") or {}
+        loop_meter: BudgetMeter | None = None
+        if budget_config:
+            loop_meter = BudgetMeter(
+                kind="loop",
+                subject=loop_id,
+                config=budget_config,
+                mode=budget_config.get("mode"),
+                breach_action=budget_config.get("breach_action"),
+            )
+
+        iteration = 0
+        while True:
+            if max_iterations is not None and iteration >= max_iterations:
+                stop_reasons.append(
+                    mapping_proxy({"scope": "loop", "id": loop_id, "reason": "max_iterations"})
+                )
+                break
+
+            self._emit(
+                "loop_iter",
+                run_id,
+                {"loop_id": loop_id, "iteration": iteration},
+            )
+
+            for node_id in loop.get("target_subgraph", []):
+                node = nodes.get(node_id)
+                if node is None:
+                    raise BudgetError(
+                        f"Loop '{loop_id}' references unknown node '{node_id}'"
+                    )
+                self._execute_node(
+                    run_id=run_id,
+                    node=node,
+                    iteration=iteration,
+                    loop_id=loop_id,
+                    run_meter=run_meter,
+                    loop_meter=loop_meter,
+                    node_meter=node_meters.get(node_id),
+                    outputs=outputs,
+                )
+
+            iteration += 1
+            if loop_meter:
+                remaining = loop_meter.remaining()
+                exhausted = any(
+                    value is not None and value <= 0 for value in remaining.values()
+                )
+                breached = loop_meter.exceeded
+            else:
+                remaining = mapping_proxy({})
+                exhausted = False
+                breached = False
+
+            if loop_meter and (breached or exhausted):
+                event_payload = {
+                    "meter": "loop",
+                    "scope": "loop",
+                    "loop_id": loop_id,
+                    "iteration": iteration,
+                    "action": loop_meter.breach_action,
+                    "overages": loop_meter.overages(),
+                    "remaining": remaining,
+                    "breached": breached,
+                    "exhausted": exhausted,
+                }
+                self._emit("budget_breach", run_id, event_payload)
+                stop_reasons.append(
+                    mapping_proxy({"scope": "loop", "id": loop_id, "reason": "budget"})
+                )
+                if loop_meter.breach_action == "stop":
+                    break
+                raise BudgetBreachHard(loop_meter.scope, loop_meter.overages())
+
+    def _execute_node(
+        self,
+        *,
+        run_id: str,
+        node: Mapping[str, Any],
+        iteration: int,
+        loop_id: str,
+        run_meter: BudgetMeter,
+        loop_meter: BudgetMeter | None,
+        node_meter: BudgetMeter | None,
+        outputs: dict[str, list[Mapping[str, Any]]],
+    ) -> None:
+        node_id = node["id"]
+        spec = node.get("spec", {})
+        tool_ref = spec.get("tool_ref")
+        if tool_ref is None:
+            raise BudgetError(f"Node '{node_id}' missing spec.tool_ref")
+
+        adapter = self._tool_adapters.get(tool_ref)
+        if adapter is None:
+            raise BudgetError(f"No adapter configured for tool '{tool_ref}'")
+
+        payload = adapter(
+            node=node,
+            iteration=iteration,
+            loop_id=loop_id,
+        )
+        node_outputs = payload.get("outputs", {})
+        outputs.setdefault(node_id, []).append(node_outputs)
+        cost_payload = payload.get("cost", {})
+
+        meters: list[tuple[str, BudgetMeter | None]] = [
+            ("run", run_meter),
+            ("loop", loop_meter),
+            ("node", node_meter),
+        ]
+        for meter_label, meter in meters:
+            if meter is None:
+                continue
+            charge = meter.charge(cost_payload)
+            self._emit(
+                "budget_charge",
+                run_id,
+                {
+                    "meter": meter_label,
+                    "scope": meter.kind,
+                    "subject": meter.subject,
+                    "node_id": node_id,
+                    "loop_id": loop_id,
+                    "cost": charge.cost,
+                    "remaining": charge.remaining,
+                    "overages": charge.overages,
+                    "breached": charge.breached,
+                    "mode": charge.mode,
+                },
+            )
+
+    # ------------------------------------------------------------------
+    # Tracing helpers
+    # ------------------------------------------------------------------
+    def _emit(self, event: str, run_id: str, data: Mapping[str, Any]) -> None:
+        record = {
+            "event": event,
+            "ts": self._clock(),
+            "run_id": run_id,
+            "data": mapping_proxy(dict(data)),
+        }
+        self._trace_buffer.append(record)

--- a/tests/e2e/test_runner_budget_stop.py
+++ b/tests/e2e/test_runner_budget_stop.py
@@ -1,0 +1,75 @@
+"""Flow runner integration tests for loop-level budget stops."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pkgs.dsl.runner import FlowRunner, RunResult
+
+
+def test_runner_loop_stops_when_loop_budget_reaches_cap() -> None:
+    calls: list[int] = []
+
+    def mock_tool(**_: Any) -> dict[str, Any]:
+        iteration = len(calls)
+        calls.append(iteration)
+        return {
+            "outputs": {"result": f"iteration-{iteration}"},
+            "cost": {"usd": 0.25, "calls": 1},
+        }
+
+    spec: dict[str, Any] = {
+        "globals": {
+            "run_budget": {"mode": "hard", "max_calls": 5, "max_usd": 5.0},
+            "tools": {
+                "mock.tool": {"type": "tool", "pricing": {"per_call_usd": 0.25}},
+            },
+        },
+        "graph": {
+            "nodes": [
+                {
+                    "id": "worker",
+                    "kind": "unit",
+                    "inputs": {},
+                    "outputs": ["result"],
+                    "spec": {"type": "tool", "tool_ref": "mock.tool"},
+                    "budget": {"mode": "hard", "max_calls": 5},
+                }
+            ]
+        },
+        "control": [
+            {
+                "id": "self_loop",
+                "kind": "loop",
+                "target_subgraph": ["worker"],
+                "stop": {"budget": {"max_calls": 3, "breach_action": "stop"}},
+            }
+        ],
+    }
+
+    runner = FlowRunner(tool_adapters={"mock.tool": mock_tool})
+    result = runner.run(spec, vars={})
+
+    assert isinstance(result, RunResult)
+    assert result.status == "ok"
+    assert len(calls) == 3
+
+    loop_breaches = [
+        event
+        for event in result.trace
+        if event["event"] == "budget_breach" and event["data"].get("scope") == "loop"
+    ]
+    assert loop_breaches, "loop breach should be recorded in the trace"
+    assert loop_breaches[0]["data"]["loop_id"] == "self_loop"
+    assert loop_breaches[0]["data"]["action"] == "stop"
+
+    assert result.stop_reasons == (
+        {"scope": "loop", "id": "self_loop", "reason": "budget"},
+    )
+
+    run_charge_events = [
+        event
+        for event in result.trace
+        if event["event"] == "budget_charge" and event["data"]["meter"] == "run"
+    ]
+    assert run_charge_events, "run-level budget charges should be tracked"

--- a/tests/unit/test_budget_meter_limits.py
+++ b/tests/unit/test_budget_meter_limits.py
@@ -1,0 +1,58 @@
+"""Budget meter enforcement behaviour as defined in the runner spec."""
+
+from __future__ import annotations
+
+import pytest
+
+from pkgs.dsl.budget import BudgetBreachHard, BudgetMeter
+
+
+def test_budget_meter_hard_cap_blocks_charge() -> None:
+    meter = BudgetMeter(
+        kind="node",
+        subject="seed",
+        config={"max_usd": 1.0},
+        mode="hard",
+    )
+
+    assert meter.can_spend({"usd": 0.4}) is True
+
+    charge = meter.charge({"usd": 0.4})
+    assert pytest.approx(0.6) == charge.remaining["usd"]
+    assert meter.can_spend({"usd": 0.7}) is False
+
+    with pytest.raises(BudgetBreachHard):
+        meter.charge({"usd": 0.7})
+
+
+def test_budget_meter_soft_mode_flags_breach_without_raising() -> None:
+    meter = BudgetMeter(
+        kind="node",
+        subject="draft",
+        config={"max_tokens": 2_000},
+        mode="soft",
+    )
+
+    assert meter.can_spend({"tokens": 2_500}) is True
+
+    charge = meter.charge({"tokens": 2_500})
+    assert charge.breached is True
+    assert "tokens" in charge.overages
+    assert pytest.approx(500.0) == meter.overages()["tokens"]
+    assert meter.exceeded is True
+
+
+def test_budget_meter_stop_action_defers_hard_breach() -> None:
+    meter = BudgetMeter(
+        kind="loop",
+        subject="refine",
+        config={"max_calls": 3, "breach_action": "stop"},
+        mode="hard",
+    )
+
+    meter.charge({"calls": 2})
+    charge = meter.charge({"calls": 2})
+
+    assert charge.breached is True
+    assert charge.overages["calls"] == 1
+    assert meter.exceeded is True


### PR DESCRIPTION
## Summary
- implement `BudgetMeter` and budget breach exceptions to enforce run/node/loop caps per spec
- add a minimal `FlowRunner` execution path that wires meters into loops and emits budget charge/breach traces
- cover hard/soft budget behaviour and loop stop conditions with new unit and e2e tests

## Testing
- ./scripts/ensure_green.sh


------
https://chatgpt.com/codex/tasks/task_e_68e87910ae88832cac6051626b61f24c