### PR TITLE
Implement FlowRunner budget guards and tests

### DIFF
--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,5 +1,14 @@
 """DSL package exports for policy engine components."""
 
+from .budget import (  # noqa: F401
+    BudgetCharge,
+    BudgetCheck,
+    BudgetExceededError,
+    BudgetMeter,
+    BudgetMode,
+    Cost,
+    CostBreakdown,
+)
 from .models import (  # noqa: F401
     PolicyDecision,
     PolicyDenial,
@@ -14,8 +23,26 @@ from .policy import (  # noqa: F401
     PolicyTraceRecorder,
     PolicyViolationError,
 )
+from .runner import (  # noqa: F401
+    FlowRunner,
+    LoopIterationContext,
+    LoopIterationResult,
+    LoopSummary,
+    RunResult,
+)
 
 __all__ = [
+    "BudgetCharge",
+    "BudgetCheck",
+    "BudgetExceededError",
+    "BudgetMeter",
+    "BudgetMode",
+    "Cost",
+    "CostBreakdown",
+    "FlowRunner",
+    "LoopIterationContext",
+    "LoopIterationResult",
+    "LoopSummary",
     "PolicyDecision",
     "PolicyDenial",
     "PolicyResolution",
@@ -25,5 +52,6 @@ __all__ = [
     "PolicyTraceEvent",
     "PolicyTraceRecorder",
     "PolicyViolationError",
+    "RunResult",
     "ToolDescriptor",
 ]

--- a/pkgs/dsl/budget.py
+++ b/pkgs/dsl/budget.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, cast
+
+__all__ = [
+    "BudgetMode",
+    "BudgetExceededError",
+    "BudgetCheck",
+    "BudgetCharge",
+    "Cost",
+    "CostBreakdown",
+    "BudgetMeter",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class Cost:
+    usd: float = 0.0
+    tokens: int = 0
+    calls: int = 0
+    time_sec: float = 0.0
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass hook
+        object.__setattr__(self, "usd", float(self.usd or 0.0))
+        object.__setattr__(self, "tokens", int(self.tokens or 0))
+        object.__setattr__(self, "calls", int(self.calls or 0))
+        object.__setattr__(self, "time_sec", float(self.time_sec or 0.0))
+
+    def __add__(self, other: Cost) -> Cost:
+        return Cost(
+            usd=math.fsum((self.usd, other.usd)),
+            tokens=self.tokens + other.tokens,
+            calls=self.calls + other.calls,
+            time_sec=math.fsum((self.time_sec, other.time_sec)),
+        )
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "usd": self.usd,
+            "tokens": self.tokens,
+            "calls": self.calls,
+            "time_sec": self.time_sec,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CostBreakdown:
+    max_usd: float
+    max_tokens: float
+    max_calls: float
+    time_limit_sec: float
+    total_spent: Cost
+
+    def to_dict(self) -> dict[str, float | int | Mapping[str, float | int]]:
+        return {
+            "max_usd": self.max_usd,
+            "max_tokens": self.max_tokens,
+            "max_calls": self.max_calls,
+            "time_limit_sec": self.time_limit_sec,
+            "total_spent": self.total_spent.to_dict(),
+        }
+
+
+class BudgetMode(str, Enum):
+    HARD = "hard"
+    SOFT = "soft"
+
+    @classmethod
+    def from_value(cls, value: BudgetMode | str | None) -> BudgetMode:
+        if isinstance(value, BudgetMode):
+            return value
+        if value is None:
+            return cls.HARD
+        try:
+            return cls(value.lower())
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"invalid budget mode: {value!r}") from exc
+
+
+class BudgetExceededError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        scope: str,
+        metric: str,
+        limit: float,
+        spent: float,
+        attempted: float,
+        mode: BudgetMode,
+    ) -> None:
+        super().__init__(
+            f"Budget exceeded for {scope}:{metric} (limit={limit}, attempted={attempted})"
+        )
+        self.scope = scope
+        self.metric = metric
+        self.limit = float(limit)
+        self.spent = float(spent)
+        self.attempted = float(attempted)
+        self.mode = mode
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetCheck:
+    allowed: bool
+    breach_kind: str | None
+    metric: str | None
+    limit: float | None
+    attempted: float | None
+    remaining: CostBreakdown
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetCharge:
+    cost: Cost
+    breached: bool
+    breach_kind: str | None
+    metric: str | None
+    limit: float | None
+    attempted: float | None
+    remaining: CostBreakdown
+
+
+@dataclass(slots=True)
+class _BudgetLimits:
+    max_usd: float | None
+    max_tokens: int | None
+    max_calls: int | None
+    time_limit_sec: float | None
+
+    @classmethod
+    def from_spec(cls, spec: Mapping[str, object]) -> _BudgetLimits:
+        return cls(
+            max_usd=_normalize_float(spec.get("max_usd")),
+            max_tokens=_normalize_int(spec.get("max_tokens")),
+            max_calls=_normalize_int(spec.get("max_calls")),
+            time_limit_sec=_normalize_float(spec.get("time_limit_sec")),
+        )
+
+    def remaining(self, spent: Cost) -> CostBreakdown:
+        return CostBreakdown(
+            max_usd=_remaining(self.max_usd, spent.usd),
+            max_tokens=_remaining(self.max_tokens, spent.tokens),
+            max_calls=_remaining(self.max_calls, spent.calls),
+            time_limit_sec=_remaining(self.time_limit_sec, spent.time_sec),
+            total_spent=spent,
+        )
+
+
+def _normalize_float(value: object | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, int | float):
+        return None if float(value) <= 0 else float(value)
+    raise TypeError(f"expected numeric limit, got {type(value)!r}")
+
+
+def _normalize_int(value: object | None) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return None if value <= 0 else value
+    if isinstance(value, float):
+        normalized = int(value)
+        return None if normalized <= 0 else normalized
+    raise TypeError(f"expected integer limit, got {type(value)!r}")
+
+
+def _remaining(limit: float | int | None, spent: float | int) -> float:
+    if limit is None:
+        return math.inf
+    return float(limit) - float(spent)
+
+
+class BudgetMeter:
+    def __init__(
+        self,
+        *,
+        scope: str,
+        label: str,
+        limits: Mapping[str, object] | None = None,
+        mode: BudgetMode = BudgetMode.HARD,
+        breach_action: str | None = None,
+    ) -> None:
+        self._scope = scope
+        self._label = label
+        self._mode = BudgetMode.from_value(mode)
+        self._limits = _BudgetLimits.from_spec(limits or {})
+        self._spent = Cost()
+        self._breach_action = breach_action or "error"
+        self._epsilon = 1e-9
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @property
+    def mode(self) -> BudgetMode:
+        return self._mode
+
+    @property
+    def breach_action(self) -> str:
+        return self._breach_action
+
+    @property
+    def spent(self) -> Cost:
+        return self._spent
+
+    @property
+    def limits(self) -> CostBreakdown:
+        return self._limits.remaining(Cost())
+
+    def snapshot(self) -> CostBreakdown:
+        return self._limits.remaining(self._spent)
+
+    def preview(self, cost: Cost | Mapping[str, object] | None) -> BudgetCheck:
+        normalized = _normalize_cost(cost)
+        projected = self._spent + normalized
+        metric, limit_value, attempted_value, kind = self._first_breach(projected)
+        allowed = True
+        if kind == "hard":
+            allowed = False
+        elif kind == "soft":
+            allowed = True
+        remaining = self._limits.remaining(projected if allowed else self._spent)
+        return BudgetCheck(
+            allowed=allowed,
+            breach_kind=kind,
+            metric=metric,
+            limit=limit_value,
+            attempted=attempted_value,
+            remaining=remaining,
+        )
+
+    def can_spend(self, cost: Cost | Mapping[str, object] | None) -> bool:
+        check = self.preview(cost)
+        return check.allowed
+
+    def charge(self, cost: Cost | Mapping[str, object] | None) -> BudgetCharge:
+        normalized = _normalize_cost(cost)
+        projected = self._spent + normalized
+        metric, limit_value, attempted_value, kind = self._first_breach(projected)
+        if kind == "hard":
+            raise BudgetExceededError(
+                scope=self._label,
+                metric=metric or "usd",
+                limit=limit_value or 0.0,
+                spent=_resolve_spent(self._spent, metric),
+                attempted=attempted_value or 0.0,
+                mode=self._mode,
+            )
+        self._spent = projected
+        remaining = self._limits.remaining(self._spent)
+        breached = kind == "soft"
+        return BudgetCharge(
+            cost=normalized,
+            breached=breached,
+            breach_kind="soft" if breached else None,
+            metric=metric,
+            limit=limit_value,
+            attempted=attempted_value,
+            remaining=remaining,
+        )
+
+    @classmethod
+    def from_spec(
+        cls,
+        spec: Mapping[str, object] | None,
+        *,
+        scope: str,
+        label: str,
+        default_mode: BudgetMode | str = BudgetMode.HARD,
+        breach_action: str | None = None,
+    ) -> BudgetMeter:
+        data = dict(spec or {})
+        mode_value = cast(BudgetMode | str | None, data.get("mode", default_mode))
+        limits = {
+            key: value
+            for key, value in data.items()
+            if key in {"max_usd", "max_tokens", "max_calls", "time_limit_sec"}
+        }
+        return cls(
+            scope=scope,
+            label=label,
+            limits=limits,
+            mode=BudgetMode.from_value(mode_value),
+            breach_action=cast(str | None, data.get("breach_action", breach_action)),
+        )
+
+    def remaining(self) -> CostBreakdown:
+        return self._limits.remaining(self._spent)
+
+    def _first_breach(
+        self, projected: Cost
+    ) -> tuple[str | None, float | None, float | None, str | None]:
+        checks = [
+            ("usd", self._limits.max_usd, projected.usd),
+            ("tokens", self._limits.max_tokens, float(projected.tokens)),
+            ("calls", self._limits.max_calls, float(projected.calls)),
+            ("time_sec", self._limits.time_limit_sec, projected.time_sec),
+        ]
+        for metric, limit_value, attempted in checks:
+            if limit_value is None:
+                continue
+            if attempted - float(limit_value) > self._epsilon:
+                if self._mode is BudgetMode.SOFT:
+                    return metric, float(limit_value), attempted, "soft"
+                return metric, float(limit_value), attempted, "hard"
+        return None, None, None, None
+
+
+def _resolve_spent(spent: Cost, metric: str | None) -> float:
+    if metric == "tokens":
+        return float(spent.tokens)
+    if metric == "calls":
+        return float(spent.calls)
+    if metric == "time_sec":
+        return float(spent.time_sec)
+    return float(spent.usd)
+
+
+def _normalize_cost(cost: Cost | Mapping[str, object] | None) -> Cost:
+    if cost is None:
+        return Cost()
+    if isinstance(cost, Cost):
+        return cost
+    mapping = cast(Mapping[str, Any], cost)
+    return Cost(
+        usd=_coerce_float(mapping.get("usd")),
+        tokens=_coerce_int(mapping.get("tokens")),
+        calls=_coerce_int(mapping.get("calls")),
+        time_sec=_coerce_float(mapping.get("time_sec")),
+    )
+
+
+def _coerce_float(value: object | None) -> float:
+    if value is None:
+        return 0.0
+    if isinstance(value, int | float):
+        return float(value)
+    raise TypeError(f"expected numeric value, got {type(value)!r}")
+
+
+def _coerce_int(value: object | None) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    raise TypeError(f"expected integer value, got {type(value)!r}")

--- a/pkgs/dsl/runner.py
+++ b/pkgs/dsl/runner.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import cast
+
+from .budget import (
+    BudgetCharge,
+    BudgetCheck,
+    BudgetExceededError,
+    BudgetMeter,
+    BudgetMode,
+    Cost,
+)
+
+__all__ = [
+    "FlowRunner",
+    "RunResult",
+    "LoopSummary",
+    "LoopIterationContext",
+    "LoopIterationResult",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class RunResult:
+    run_id: str
+    status: str
+    outputs: Mapping[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class LoopSummary:
+    loop_id: str
+    iterations: int
+    stop_reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class LoopIterationContext:
+    run_id: str
+    loop_id: str
+    iteration: int
+    run_meter: BudgetMeter
+    loop_meter: BudgetMeter | None
+
+
+@dataclass(frozen=True, slots=True)
+class LoopIterationResult:
+    cost: Cost = field(default_factory=Cost)
+    should_stop: bool = False
+    outputs: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RunSummary:
+    status: str
+    loop_summaries: Sequence[LoopSummary]
+
+
+class FlowRunner:
+    def __init__(
+        self,
+        *,
+        cache_mode: str = "readwrite",
+        max_concurrency: int = 4,
+        fail_fast: bool = False,
+        trace_sink: Callable[[Mapping[str, object]], None] | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self.cache_mode = cache_mode
+        self.max_concurrency = max_concurrency
+        self.fail_fast = fail_fast
+        self._trace_sink = trace_sink
+        self._clock = clock or time.time
+        self._trace_events: list[dict[str, object]] = []
+        self.last_error: Exception | None = None
+        self.last_run: RunSummary | None = None
+        self.budget_meter: BudgetMeter | None = None
+        self._current_run_id: str | None = None
+
+    @property
+    def trace_events(self) -> Sequence[Mapping[str, object]]:
+        return tuple(self._trace_events)
+
+    def run(self, spec: Mapping[str, object], vars: Mapping[str, object]) -> RunResult:
+        run_id = uuid.uuid4().hex
+        self._current_run_id = run_id
+        self._trace_events = []
+        self.last_error = None
+        self.last_run = None
+
+        self._emit_trace(
+            "run_start", {"vars_present": cast(object, bool(vars))}
+        )
+
+        globals_section = cast(Mapping[str, object], spec.get("globals") or {})
+        run_budget_spec = cast(Mapping[str, object] | None, globals_section.get("run_budget"))
+        self.budget_meter = BudgetMeter.from_spec(
+            run_budget_spec,
+            scope="run",
+            label="run",
+            default_mode=BudgetMode.HARD,
+        )
+
+        loop_summaries: list[LoopSummary] = []
+        outputs: dict[str, object] = {}
+
+        try:
+            graph_section = cast(Mapping[str, object], spec.get("graph") or {})
+            control_nodes_obj = graph_section.get("control") or []
+            control_nodes = cast(Sequence[Mapping[str, object]], control_nodes_obj)
+            for loop_spec in control_nodes:
+                if loop_spec.get("kind") != "loop":
+                    continue
+                summary = self._execute_loop(run_id, loop_spec, self.budget_meter)
+                loop_summaries.append(summary)
+        except BudgetExceededError as exc:
+            self.last_error = exc
+            self.last_run = RunSummary(status="error", loop_summaries=tuple(loop_summaries))
+            self._emit_trace("run_end", {"status": "error"})
+            return RunResult(run_id=run_id, status="error", outputs=outputs)
+
+        self.last_run = RunSummary(status="ok", loop_summaries=tuple(loop_summaries))
+        self._emit_trace("run_end", {"status": "ok"})
+        return RunResult(run_id=run_id, status="ok", outputs=outputs)
+
+    # ------------------------------------------------------------------
+    # Loop execution helpers
+    # ------------------------------------------------------------------
+    def _execute_loop(
+        self,
+        run_id: str,
+        loop_spec: Mapping[str, object],
+        run_meter: BudgetMeter,
+    ) -> LoopSummary:
+        loop_id = str(loop_spec.get("id", "loop"))
+        stop_spec = cast(Mapping[str, object], loop_spec.get("stop") or {})
+        max_iterations = cast(int | None, stop_spec.get("max_iterations"))
+        loop_budget_spec = cast(Mapping[str, object] | None, stop_spec.get("budget"))
+        loop_breach_action = (
+            cast(str | None, loop_budget_spec.get("breach_action"))
+            if loop_budget_spec
+            else None
+        )
+        loop_meter = (
+            BudgetMeter.from_spec(
+                loop_budget_spec,
+                scope="loop",
+                label=loop_id,
+                default_mode=BudgetMode.HARD,
+                breach_action=loop_breach_action,
+            )
+            if loop_budget_spec
+            else None
+        )
+
+        iterations = 0
+        stop_reason = "completed"
+        while True:
+            if max_iterations is not None and iterations >= int(max_iterations):
+                stop_reason = "iteration_cap"
+                break
+
+            context = LoopIterationContext(
+                run_id=run_id,
+                loop_id=loop_id,
+                iteration=iterations,
+                run_meter=run_meter,
+                loop_meter=loop_meter,
+            )
+
+            estimate = self._estimate_loop_iteration_cost(loop_spec, iterations, context)
+
+            if loop_meter:
+                preview = loop_meter.preview(estimate)
+                if not preview.allowed:
+                    action = "stop" if loop_meter.breach_action == "stop" else "error"
+                    self._emit_budget_breach("loop", loop_id, preview, action=action)
+                    if action == "stop":
+                        stop_reason = "budget_stop"
+                        break
+                    raise self._error_from_preview(loop_meter, preview)
+                if preview.breach_kind == "soft":
+                    self._emit_budget_breach("loop", loop_id, preview, action="warn")
+
+            run_preview = run_meter.preview(estimate)
+            if not run_preview.allowed:
+                self._emit_budget_breach("run", loop_id, run_preview, action="error")
+                raise self._error_from_preview(run_meter, run_preview)
+            if run_preview.breach_kind == "soft":
+                self._emit_budget_breach("run", loop_id, run_preview, action="warn")
+
+            self._emit_trace(
+                "loop_iter",
+                {
+                    "loop_id": loop_id,
+                    "iteration": iterations,
+                    "estimate": cast(object, estimate.to_dict()),
+                },
+            )
+
+            result = self._run_loop_iteration(loop_spec, iterations, context)
+            actual_cost = result.cost
+
+            try:
+                run_charge = run_meter.charge(actual_cost)
+            except BudgetExceededError:
+                preview = run_meter.preview(actual_cost)
+                self._emit_budget_breach("run", loop_id, preview, action="error")
+                raise
+            else:
+                self._emit_budget_charge("run", loop_id, actual_cost, run_charge)
+                if run_charge.breached:
+                    self._emit_budget_breach(
+                        "run",
+                        loop_id,
+                        BudgetCheck(
+                            allowed=True,
+                            breach_kind=run_charge.breach_kind,
+                            metric=run_charge.metric,
+                            limit=run_charge.limit,
+                            attempted=run_charge.attempted,
+                            remaining=run_charge.remaining,
+                        ),
+                        action="warn",
+                    )
+
+            if loop_meter is not None:
+                try:
+                    loop_charge = loop_meter.charge(actual_cost)
+                except BudgetExceededError:
+                    preview = loop_meter.preview(actual_cost)
+                    action = "stop" if loop_meter.breach_action == "stop" else "error"
+                    self._emit_budget_breach("loop", loop_id, preview, action=action)
+                    if action == "stop":
+                        stop_reason = "budget_stop"
+                        break
+                    raise
+                else:
+                    self._emit_budget_charge("loop", loop_id, actual_cost, loop_charge)
+                    if loop_charge.breached:
+                        self._emit_budget_breach(
+                            "loop",
+                            loop_id,
+                            BudgetCheck(
+                                allowed=True,
+                                breach_kind=loop_charge.breach_kind,
+                                metric=loop_charge.metric,
+                                limit=loop_charge.limit,
+                                attempted=loop_charge.attempted,
+                                remaining=loop_charge.remaining,
+                            ),
+                            action="warn",
+                        )
+
+            iterations += 1
+            if result.should_stop:
+                stop_reason = "body_stop"
+                break
+
+        return LoopSummary(loop_id=loop_id, iterations=iterations, stop_reason=stop_reason)
+
+    # ------------------------------------------------------------------
+    # Overridable hooks
+    # ------------------------------------------------------------------
+    def _estimate_loop_iteration_cost(
+        self,
+        loop_spec: Mapping[str, object],
+        iteration: int,
+        context: LoopIterationContext,
+    ) -> Cost:
+        return Cost()
+
+    def _run_loop_iteration(
+        self,
+        loop_spec: Mapping[str, object],
+        iteration: int,
+        context: LoopIterationContext,
+    ) -> LoopIterationResult:
+        return LoopIterationResult(should_stop=True)
+
+    # ------------------------------------------------------------------
+    # Trace helpers
+    # ------------------------------------------------------------------
+    def _emit_trace(self, event: str, payload: Mapping[str, object]) -> None:
+        record: dict[str, object] = {
+            "event": event,
+            "run_id": self._current_run_id or "",
+            "ts": self._clock(),
+        }
+        record.update(payload)
+        self._trace_events.append(record)
+        if self._trace_sink is not None:
+            self._trace_sink(record)
+
+    def _emit_budget_charge(
+        self,
+        scope: str,
+        loop_id: str,
+        cost: Cost,
+        charge: BudgetCharge,
+    ) -> None:
+        event: dict[str, object] = {
+            "event": "budget_charge",
+            "run_id": self._current_run_id or "",
+            "scope": scope,
+            "loop_id": loop_id,
+            "ts": self._clock(),
+            "cost": cast(object, cost.to_dict()),
+            "remaining": cast(object, charge.remaining.to_dict()),
+        }
+        if charge.metric:
+            event["metric"] = charge.metric
+        self._trace_events.append(event)
+        if self._trace_sink is not None:
+            self._trace_sink(event)
+
+    def _emit_budget_breach(
+        self,
+        scope: str,
+        loop_id: str,
+        check: BudgetCheck,
+        *,
+        action: str,
+    ) -> None:
+        event: dict[str, object] = {
+            "event": "budget_breach",
+            "run_id": self._current_run_id or "",
+            "scope": scope,
+            "loop_id": loop_id,
+            "ts": self._clock(),
+            "action": action,
+            "breach_kind": check.breach_kind,
+            "metric": check.metric,
+            "remaining": cast(object, check.remaining.to_dict()),
+        }
+        self._trace_events.append(event)
+        if self._trace_sink is not None:
+            self._trace_sink(event)
+
+    def _error_from_preview(self, meter: BudgetMeter, check: BudgetCheck) -> BudgetExceededError:
+        metric = check.metric or "usd"
+        limit = check.limit or 0.0
+        attempted = check.attempted or limit
+        spent = meter.spent
+        if metric == "tokens":
+            spent_value = float(spent.tokens)
+        elif metric == "calls":
+            spent_value = float(spent.calls)
+        elif metric == "time_sec":
+            spent_value = float(spent.time_sec)
+        else:
+            spent_value = float(spent.usd)
+        return BudgetExceededError(
+            scope=meter.label,
+            metric=metric,
+            limit=limit,
+            spent=spent_value,
+            attempted=attempted,
+            mode=meter.mode,
+        )

--- a/tests/e2e/test_runner_budget_stop.py
+++ b/tests/e2e/test_runner_budget_stop.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from pkgs.dsl import (
+    BudgetExceededError,
+    Cost,
+    FlowRunner,
+    LoopIterationContext,
+    LoopIterationResult,
+)
+
+
+class StubRunner(FlowRunner):
+    def __init__(self, iteration_costs: list[float]) -> None:
+        super().__init__()
+        self._iteration_costs = iteration_costs
+
+    def _estimate_loop_iteration_cost(
+        self,
+        loop_spec: dict,
+        iteration: int,
+        context: LoopIterationContext,
+    ) -> Cost:
+        if iteration >= len(self._iteration_costs):
+            return Cost()
+        return Cost(usd=self._iteration_costs[iteration])
+
+    def _run_loop_iteration(
+        self,
+        loop_spec: dict,
+        iteration: int,
+        context: LoopIterationContext,
+    ) -> LoopIterationResult:
+        if iteration >= len(self._iteration_costs):
+            return LoopIterationResult(should_stop=True)
+        return LoopIterationResult(cost=Cost(usd=self._iteration_costs[iteration]))
+
+
+BASE_SPEC: dict = {
+    "version": "0.1",
+    "globals": {
+        "tools": {},
+        "run_budget": {"max_usd": 10.0, "mode": "hard"},
+    },
+    "graph": {
+        "nodes": [],
+        "control": [
+            {
+                "id": "loop",
+                "kind": "loop",
+                "target_subgraph": [],
+                "stop": {
+                    "max_iterations": 5,
+                    "budget": {"max_usd": 1.5, "breach_action": "stop"},
+                },
+            }
+        ],
+    },
+}
+
+
+@pytest.fixture
+def budget_flow_spec() -> dict:
+    return deepcopy(BASE_SPEC)
+
+
+def test_loop_budget_stop_halts_iteration_without_error(budget_flow_spec: dict) -> None:
+    runner = StubRunner([0.4, 0.7, 0.9, 0.2])
+
+    result = runner.run(budget_flow_spec, vars={})
+
+    assert result.status == "ok"
+    assert result.outputs == {}
+    assert runner.last_error is None
+    assert runner.last_run is not None
+    assert runner.last_run.loop_summaries
+
+    loop_summary = runner.last_run.loop_summaries[0]
+    assert loop_summary.loop_id == "loop"
+    assert loop_summary.iterations == 2
+    assert loop_summary.stop_reason == "budget_stop"
+
+    breach_events = [
+        event
+        for event in runner.trace_events
+        if event["event"] == "budget_breach" and event.get("scope") == "loop"
+    ]
+    assert breach_events
+    assert breach_events[-1]["action"] == "stop"
+    assert breach_events[-1]["remaining"]["max_usd"] == pytest.approx(0.4)
+
+
+def test_run_budget_hard_breach_sets_error_status(budget_flow_spec: dict) -> None:
+    spec = deepcopy(budget_flow_spec)
+    spec["globals"]["run_budget"] = {"max_usd": 1.0, "mode": "hard"}
+
+    runner = StubRunner([0.6, 0.6])
+    result = runner.run(spec, vars={})
+
+    assert result.status == "error"
+    assert isinstance(runner.last_error, BudgetExceededError)
+    assert runner.last_error.metric == "usd"
+
+    breach_events = [
+        event for event in runner.trace_events if event["event"] == "budget_breach"
+    ]
+    assert breach_events[-1]["scope"] == "run"
+    assert breach_events[-1]["breach_kind"] == "hard"

--- a/tests/unit/test_budget_meter_limits.py
+++ b/tests/unit/test_budget_meter_limits.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from pkgs.dsl import (
+    BudgetExceededError,
+    BudgetMeter,
+    BudgetMode,
+    Cost,
+    CostBreakdown,
+)
+
+
+@pytest.fixture
+def hard_meter() -> BudgetMeter:
+    return BudgetMeter.from_spec(
+        {"max_usd": 1.0, "max_tokens": 1200, "max_calls": 3, "mode": "hard"},
+        scope="run",
+        label="run_budget",
+    )
+
+
+def test_hard_budget_blocks_excess_spend(hard_meter: BudgetMeter) -> None:
+    assert hard_meter.can_spend(Cost(usd=0.4, tokens=200, calls=1))
+    charge = hard_meter.charge(Cost(usd=0.4, tokens=200, calls=1))
+    assert not charge.breached
+    assert charge.remaining.max_usd == pytest.approx(0.6)
+    assert charge.remaining.max_tokens == 1000
+    assert charge.remaining.max_calls == 2
+
+    assert hard_meter.can_spend(Cost(usd=0.6, tokens=600, calls=1))
+    hard_meter.charge(Cost(usd=0.5, tokens=500, calls=1))
+    with pytest.raises(BudgetExceededError) as excinfo:
+        hard_meter.charge(Cost(usd=0.2, tokens=300, calls=1))
+
+    err = excinfo.value
+    assert err.metric == "usd"
+    assert math.isclose(err.attempted, 1.1)
+    assert math.isclose(err.limit, 1.0)
+    assert err.scope == "run_budget"
+
+
+@pytest.mark.parametrize(
+    "limit,charges",
+    [
+        (0.0, [0.3, 0.5, 1.2]),
+        (None, [0.5, 0.4]),
+    ],
+)
+def test_zero_or_missing_limits_are_unbounded(limit: float | None, charges: list[float]) -> None:
+    meter = BudgetMeter.from_spec(
+        {"max_usd": limit, "mode": "hard"}, scope="node", label="node:alpha"
+    )
+    for amount in charges:
+        assert meter.can_spend(Cost(usd=amount))
+        outcome = meter.charge(Cost(usd=amount))
+        assert outcome.remaining.max_usd is math.inf
+
+
+@pytest.mark.parametrize("mode", [BudgetMode.SOFT, "soft"])
+def test_soft_budget_warns_but_allows_overage(mode: BudgetMode | str) -> None:
+    meter = BudgetMeter.from_spec({"max_usd": 1.0, "mode": mode}, scope="node", label="n1")
+    meter.charge(Cost(usd=0.4))
+    result = meter.charge(Cost(usd=0.7))
+    assert result.breached
+    assert result.breach_kind == "soft"
+    assert result.remaining.max_usd == pytest.approx(-0.1)
+    assert result.remaining.total_spent.usd == pytest.approx(1.1)
+
+
+@pytest.mark.parametrize(
+    "increments,limit",
+    [([0.1] * 10, 1.0), ([0.333333] * 3, 1.0)],
+)
+def test_float_precision_guard(increments: list[float], limit: float) -> None:
+    meter = BudgetMeter.from_spec({"max_usd": limit, "mode": "hard"}, scope="run", label="run")
+    total = 0.0
+    for amount in increments:
+        total += amount
+        meter.charge(Cost(usd=amount))
+
+    snapshot = meter.snapshot()
+    assert snapshot.total_spent.usd == pytest.approx(total)
+    assert snapshot.max_usd == pytest.approx(limit - total)
+
+
+def test_charge_returns_structured_breakdown(hard_meter: BudgetMeter) -> None:
+    result = hard_meter.charge(Cost(usd=0.25, tokens=100, calls=1, time_sec=2.5))
+    assert isinstance(result.remaining, CostBreakdown)
+    assert result.remaining.total_spent.usd == pytest.approx(0.25)
+    assert result.remaining.total_spent.tokens == 100
+    assert result.remaining.total_spent.calls == 1
+    assert result.remaining.total_spent.time_sec == pytest.approx(2.5)
+
+
+@pytest.mark.parametrize(
+    "cost",
+    [
+        Cost(),
+        Cost(usd=None, tokens=None, calls=None, time_sec=None),
+        Cost(usd=0.0, tokens=0, calls=0, time_sec=0.0),
+    ],
+)
+def test_cost_defaults_to_zero(cost: Cost) -> None:
+    meter = BudgetMeter.from_spec({}, scope="run", label="run")
+    result = meter.charge(cost)
+    assert not result.breached
+    assert result.remaining.total_spent.usd == 0.0
+    assert result.remaining.total_spent.tokens == 0
+    assert result.remaining.total_spent.calls == 0
+    assert result.remaining.total_spent.time_sec == 0.0


### PR DESCRIPTION
## Summary
- add a BudgetMeter with supporting types for tracking spend and enforcing hard/soft limits
- integrate FlowRunner loop execution with run/node budget checks and trace events
- cover budget handling with unit tests and an e2e loop stop scenario

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68e885f56c9c832cb7c889daf3b34e64