### PR TITLE
Implement BudgetMeter and FlowRunner budget enforcement scaffolding

### DIFF
--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,5 +1,11 @@
 """DSL package exports for policy engine components."""
 
+from .budget import (  # noqa: F401
+    BudgetDecision,
+    BudgetExceededError,
+    BudgetMeter,
+    Cost,
+)
 from .models import (  # noqa: F401
     PolicyDecision,
     PolicyDenial,
@@ -14,8 +20,13 @@ from .policy import (  # noqa: F401
     PolicyTraceRecorder,
     PolicyViolationError,
 )
+from .runner import FlowRunner, NodeExecution, RunResult  # noqa: F401
 
 __all__ = [
+    "BudgetDecision",
+    "BudgetExceededError",
+    "BudgetMeter",
+    "Cost",
     "PolicyDecision",
     "PolicyDenial",
     "PolicyResolution",
@@ -25,5 +36,8 @@ __all__ = [
     "PolicyTraceEvent",
     "PolicyTraceRecorder",
     "PolicyViolationError",
+    "FlowRunner",
+    "NodeExecution",
+    "RunResult",
     "ToolDescriptor",
 ]

--- a/pkgs/dsl/budget.py
+++ b/pkgs/dsl/budget.py
@@ -1,0 +1,243 @@
+"""Budget accounting utilities for the FlowRunner."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass, replace
+
+__all__ = [
+    "Cost",
+    "BudgetDecision",
+    "BudgetExceededError",
+    "BudgetMeter",
+]
+
+
+_EPSILON = 1e-9
+
+
+def _coerce_optional_number(value: object) -> float | None:
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class Cost:
+    """Normalized cost payload tracked across budgets."""
+
+    usd: float = 0.0
+    tokens: float = 0.0
+    calls: float = 0.0
+    time_ms: float = 0.0
+
+    def __add__(self, other: Cost) -> Cost:
+        return Cost(
+            usd=self.usd + other.usd,
+            tokens=self.tokens + other.tokens,
+            calls=self.calls + other.calls,
+            time_ms=self.time_ms + other.time_ms,
+        )
+
+    def __sub__(self, other: Cost) -> Cost:
+        return Cost(
+            usd=self.usd - other.usd,
+            tokens=self.tokens - other.tokens,
+            calls=self.calls - other.calls,
+            time_ms=self.time_ms - other.time_ms,
+        )
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "usd": float(self.usd),
+            "tokens": float(self.tokens),
+            "calls": float(self.calls),
+            "time_ms": float(self.time_ms),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetDecision:
+    """Result of applying or previewing a budget charge."""
+
+    scope: str
+    allowed: bool
+    breached: tuple[str, ...]
+    soft_breach: bool
+    remaining: Cost
+    spent: Cost
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "scope": self.scope,
+            "allowed": self.allowed,
+            "breached": self.breached,
+            "soft_breach": self.soft_breach,
+            "remaining": self.remaining.as_dict(),
+            "spent": self.spent.as_dict(),
+        }
+
+
+class BudgetExceededError(RuntimeError):
+    """Raised when a hard budget refuses a charge."""
+
+    def __init__(self, decision: BudgetDecision) -> None:
+        message = "Budget exceeded"
+        if decision.breached:
+            message = (
+                f"Budget exceeded for {decision.scope}: "
+                + ", ".join(decision.breached)
+            )
+        super().__init__(message)
+        self.decision = decision
+
+
+class BudgetMeter:
+    """Track spend and enforce hard/soft budgets for a scope."""
+
+    def __init__(
+        self,
+        *,
+        scope: str,
+        limits: Mapping[str, float | int | None] | None = None,
+        mode: str | None = None,
+    ) -> None:
+        self._scope = scope
+        self._mode = (mode or "hard").lower()
+        if self._mode not in {"hard", "soft"}:
+            raise ValueError(f"Unsupported budget mode: {mode!r}")
+        normalized = self._normalize_limits(limits or {})
+        self._limits: MutableMapping[str, float | None] = normalized
+        self._spent = Cost()
+        self._last_decision: BudgetDecision | None = None
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_budget(
+        cls, budget: Mapping[str, object] | None, *, scope: str
+    ) -> BudgetMeter:
+        raw = dict(budget) if isinstance(budget, Mapping) else {}
+        mode_value = raw.get("mode")
+        mode = mode_value if isinstance(mode_value, str) else None
+        limits = {
+            "max_usd": _coerce_optional_number(raw.get("max_usd")),
+            "max_tokens": _coerce_optional_number(raw.get("max_tokens")),
+            "max_calls": _coerce_optional_number(raw.get("max_calls")),
+            "time_limit_sec": _coerce_optional_number(raw.get("time_limit_sec")),
+            "max_time_ms": _coerce_optional_number(raw.get("max_time_ms")),
+        }
+        return cls(scope=scope, limits=limits, mode=mode)
+
+    @staticmethod
+    def _normalize_limits(
+        limits: Mapping[str, float | int | None]
+    ) -> MutableMapping[str, float | None]:
+        def _norm_number(value: float | int | None) -> float | None:
+            if value is None:
+                return None
+            number = float(value)
+            if number <= 0:
+                return None
+            return number
+
+        normalized: MutableMapping[str, float | None] = {
+            "usd": _norm_number(limits.get("max_usd")),
+            "tokens": _norm_number(limits.get("max_tokens")),
+            "calls": _norm_number(limits.get("max_calls")),
+            "time_ms": None,
+        }
+        if "time_limit_sec" in limits and limits["time_limit_sec"] is not None:
+            seconds = float(limits["time_limit_sec"])
+            normalized["time_ms"] = seconds * 1000.0 if seconds > 0 else None
+        elif "max_time_ms" in limits and limits["max_time_ms"] is not None:
+            millis = float(limits["max_time_ms"])
+            normalized["time_ms"] = millis if millis > 0 else None
+        return normalized
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def scope(self) -> str:
+        return self._scope
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def spent(self) -> Cost:
+        return self._spent
+
+    @property
+    def remaining(self) -> Cost:
+        return Cost(
+            usd=self._remaining_for("usd"),
+            tokens=self._remaining_for("tokens"),
+            calls=self._remaining_for("calls"),
+            time_ms=self._remaining_for("time_ms"),
+        )
+
+    @property
+    def last_decision(self) -> BudgetDecision | None:
+        return self._last_decision
+
+    def can_spend(self, cost: Cost) -> bool:
+        decision = self._evaluate(cost)
+        self._last_decision = decision
+        return decision.allowed
+
+    def charge(self, cost: Cost) -> BudgetDecision:
+        decision = self._evaluate(cost)
+        if not decision.allowed and self._mode == "hard":
+            self._last_decision = decision
+            raise BudgetExceededError(decision)
+        self._spent = self._spent + cost
+        applied = replace(decision, spent=self._spent)
+        self._last_decision = applied
+        return applied
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _remaining_for(self, key: str) -> float:
+        limit = self._limits[key]
+        if limit is None:
+            return math.inf
+        value = getattr(self._spent, key)
+        remaining = limit - value
+        # Ensure we do not surface negative zeros.
+        if abs(remaining) < _EPSILON:
+            return 0.0
+        return remaining
+
+    def _evaluate(self, cost: Cost) -> BudgetDecision:
+        breaches: list[str] = []
+        future_spent = self._spent + cost
+        remaining_values: dict[str, float] = {}
+
+        for key, limit in self._limits.items():
+            future_value = getattr(future_spent, key)
+            if limit is None:
+                remaining_values[key] = math.inf
+                continue
+            remaining = limit - future_value
+            if remaining < 0 and abs(remaining) < _EPSILON:
+                remaining = 0.0
+            remaining_values[key] = remaining
+            if future_value - limit > _EPSILON:
+                breaches.append(key)
+
+        allowed = not breaches or self._mode == "soft"
+        decision = BudgetDecision(
+            scope=self._scope,
+            allowed=allowed,
+            breached=tuple(breaches),
+            soft_breach=bool(breaches) and self._mode == "soft",
+            remaining=Cost(**remaining_values),
+            spent=future_spent,
+        )
+        return decision

--- a/pkgs/dsl/runner.py
+++ b/pkgs/dsl/runner.py
@@ -1,0 +1,396 @@
+"""Minimal FlowRunner implementation focused on budget enforcement."""
+
+from __future__ import annotations
+
+import math
+import time
+import uuid
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .budget import BudgetDecision, BudgetExceededError, BudgetMeter, Cost
+
+__all__ = [
+    "NodeExecution",
+    "RunResult",
+    "FlowRunner",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class NodeExecution:
+    """Result from executing a single node."""
+
+    node_id: str
+    outputs: Mapping[str, object]
+    cost: Cost
+
+
+@dataclass(frozen=True, slots=True)
+class RunResult:
+    """Structured outcome from :meth:`FlowRunner.run`."""
+
+    run_id: str
+    status: str
+    outputs: Mapping[str, Mapping[str, object]]
+    trace: Sequence[Mapping[str, object]]
+
+
+class FlowRunner:
+    """Execute flow specs with budget enforcement hooks."""
+
+    def __init__(
+        self,
+        *,
+        id_factory: Callable[[], uuid.UUID] | None = None,
+        now_factory: Callable[[], float] | None = None,
+    ) -> None:
+        self._id_factory = id_factory or uuid.uuid4
+        self._now_factory = now_factory or time.time
+        self.policy_stack = None
+        self.budget_meter: BudgetMeter | None = None
+        self.adapters: dict[str, object] = {}
+        self._trace: list[dict[str, object]] = []
+        self._node_meters: dict[str, BudgetMeter] = {}
+        self._soft_node_meters: dict[str, BudgetMeter] = {}
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+    def run(self, spec: Mapping[str, object], vars: Mapping[str, object]) -> RunResult:
+        run_id = str(self._id_factory())
+        self._trace = []
+        context_outputs: dict[str, Mapping[str, object]] = {}
+        status = "ok"
+
+        self._trace_event(
+            "run_start",
+            {
+                "run_id": run_id,
+                "ts": self._now_factory(),
+            },
+        )
+
+        globals_cfg = self._as_mapping(spec.get("globals"))
+        run_budget_cfg = self._as_mapping(globals_cfg.get("run_budget"))
+        run_budget = run_budget_cfg if run_budget_cfg else None
+        self.budget_meter = BudgetMeter.from_budget(run_budget, scope="run")
+
+        try:
+            graph = self._as_mapping(spec.get("graph"))
+            nodes = self._index_nodes(graph.get("nodes"))
+            control_nodes = tuple(self._iter_mappings(graph.get("control")))
+            for loop in control_nodes:
+                if loop.get("kind") != "loop":
+                    continue
+                self._run_loop(loop, nodes, context_outputs)
+        except BudgetExceededError as exc:
+            status = "error"
+            self._trace_event(
+                "run_error",
+                {
+                    "run_id": run_id,
+                    "reason": "budget_exceeded",
+                    "details": exc.decision.as_dict(),
+                },
+            )
+        finally:
+            self._trace_event(
+                "run_end",
+                {
+                    "run_id": run_id,
+                    "status": status,
+                    "ts": self._now_factory(),
+                },
+            )
+
+        return RunResult(
+            run_id=run_id,
+            status=status,
+            outputs=context_outputs,
+            trace=tuple(self._trace),
+        )
+
+    # ------------------------------------------------------------------
+    # Loop execution
+    # ------------------------------------------------------------------
+    def _run_loop(
+        self,
+        loop_spec: Mapping[str, object],
+        nodes: Mapping[str, Mapping[str, object]],
+        context_outputs: dict[str, Mapping[str, object]],
+    ) -> None:
+        loop_mapping = self._as_mapping(loop_spec)
+        loop_id = str(loop_mapping.get("id", "loop"))
+        stop_config = self._as_mapping(loop_mapping.get("stop"))
+        max_iterations = self._coerce_max_iterations(stop_config.get("max_iterations"))
+
+        budget_cfg = self._as_mapping(stop_config.get("budget"))
+        loop_meter = BudgetMeter.from_budget(
+            budget_cfg if budget_cfg else None,
+            scope=f"loop:{loop_id}",
+        )
+        breach_action = "error"
+        action_value = budget_cfg.get("breach_action") if budget_cfg else None
+        if isinstance(action_value, str):
+            breach_action = action_value.lower()
+
+        target_nodes = tuple(self._iter_strings(loop_mapping.get("target_subgraph")))
+
+        self._trace_event(
+            "loop_start",
+            {
+                "loop_id": loop_id,
+                "target": target_nodes,
+            },
+        )
+
+        iteration = 0
+        while iteration < max_iterations:
+            if loop_meter:
+                hint = self._iteration_cost_hint(loop_spec, iteration)
+                if not loop_meter.can_spend(hint):
+                    decision = loop_meter.last_decision
+                    if decision is None:
+                        decision = BudgetDecision(
+                            scope=loop_meter.scope,
+                            allowed=False,
+                            breached=(),
+                            soft_breach=False,
+                            remaining=loop_meter.remaining,
+                            spent=loop_meter.spent,
+                        )
+                    if breach_action == "stop":
+                        self._emit_loop_stop(loop_id, "budget_stop", decision, iteration)
+                        return
+                    raise BudgetExceededError(decision)
+
+            self._trace_event(
+                "loop_iter",
+                {
+                    "loop_id": loop_id,
+                    "iteration": iteration,
+                },
+            )
+
+            stop_reason: str | None = None
+            for node_id_str in target_nodes:
+                if node_id_str not in nodes:
+                    continue
+                node = nodes[node_id_str]
+                execution = self._execute_node(
+                    node,
+                    context_outputs,
+                    loop_id=loop_id,
+                )
+                stop_reason = self._apply_costs(
+                    node=node,
+                    cost=execution.cost,
+                    loop_id=loop_id,
+                    loop_meter=loop_meter,
+                    loop_breach_action=breach_action,
+                )
+                context_outputs[node_id_str] = execution.outputs
+                if stop_reason:
+                    break
+
+            if stop_reason is not None:
+                self._emit_loop_stop(loop_id, stop_reason, loop_meter.last_decision, iteration)
+                return
+
+            iteration += 1
+
+        self._emit_loop_stop(loop_id, "max_iterations", loop_meter.last_decision, iteration)
+
+    def _emit_loop_stop(
+        self,
+        loop_id: str,
+        reason: str,
+        decision: BudgetDecision | None,
+        iteration: int,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "loop_id": loop_id,
+            "reason": reason,
+            "iteration": iteration,
+        }
+        if decision is not None:
+            payload["details"] = decision.as_dict()
+        self._trace_event("loop_stop", payload)
+
+    # ------------------------------------------------------------------
+    # Cost enforcement
+    # ------------------------------------------------------------------
+    def _apply_costs(
+        self,
+        *,
+        node: Mapping[str, object],
+        cost: Cost,
+        loop_id: str,
+        loop_meter: BudgetMeter | None,
+        loop_breach_action: str,
+    ) -> str | None:
+        node_id = str(node.get("id"))
+        stop_reason: str | None = None
+
+        if self.budget_meter is not None:
+            self._charge_and_trace(
+                meter=self.budget_meter,
+                cost=cost,
+                scope="run",
+                context={"node_id": node_id, "loop_id": loop_id},
+            )
+
+        if loop_meter is not None:
+            stop_reason = self._charge_and_trace(
+                meter=loop_meter,
+                cost=cost,
+                scope=f"loop:{loop_id}",
+                context={"node_id": node_id, "loop_id": loop_id},
+                breach_action=loop_breach_action,
+            )
+            if stop_reason is not None:
+                return stop_reason
+
+        node_meter = self._node_meters.get(node_id)
+        node_budget_cfg = self._as_mapping(node.get("budget"))
+        if node_meter is None and node_budget_cfg:
+            node_meter = BudgetMeter.from_budget(node_budget_cfg, scope=f"node:{node_id}")
+            self._node_meters[node_id] = node_meter
+        if node_meter is not None:
+            self._charge_and_trace(
+                meter=node_meter,
+                cost=cost,
+                scope=f"node:{node_id}",
+                context={"loop_id": loop_id},
+            )
+
+        spec_cfg = self._as_mapping(node.get("spec"))
+        soft_cfg = self._as_mapping(spec_cfg.get("budget"))
+        if soft_cfg:
+            soft_meter = self._soft_node_meters.get(node_id)
+            if soft_meter is None:
+                soft_budget_payload = dict(soft_cfg)
+                soft_budget_payload.setdefault("mode", "soft")
+                soft_meter = BudgetMeter.from_budget(
+                    soft_budget_payload,
+                    scope=f"node_soft:{node_id}",
+                )
+                self._soft_node_meters[node_id] = soft_meter
+            self._charge_and_trace(
+                meter=soft_meter,
+                cost=cost,
+                scope=f"node_soft:{node_id}",
+                context={"loop_id": loop_id},
+                allow_soft=True,
+            )
+
+        return None
+
+    def _charge_and_trace(
+        self,
+        *,
+        meter: BudgetMeter,
+        cost: Cost,
+        scope: str,
+        context: Mapping[str, object],
+        breach_action: str | None = None,
+        allow_soft: bool = False,
+    ) -> str | None:
+        try:
+            decision = meter.charge(cost)
+        except BudgetExceededError as exc:
+            decision = exc.decision
+            self._trace_event(
+                "budget_charge",
+                {
+                    "scope": scope,
+                    "cost": cost.as_dict(),
+                    "allowed": False,
+                    "decision": decision.as_dict(),
+                    "context": dict(context),
+                },
+            )
+            if breach_action == "stop":
+                return "budget_stop"
+            if allow_soft:
+                return None
+            raise
+        else:
+            self._trace_event(
+                "budget_charge",
+                {
+                    "scope": scope,
+                    "cost": cost.as_dict(),
+                    "allowed": decision.allowed,
+                    "decision": decision.as_dict(),
+                    "context": dict(context),
+                },
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # Helpers / overridables
+    # ------------------------------------------------------------------
+    def _execute_node(
+        self,
+        node: Mapping[str, object],
+        context: Mapping[str, Mapping[str, object]],
+        *,
+        loop_id: str | None = None,
+    ) -> NodeExecution:
+        node_id = str(node.get("id", "node"))
+        return NodeExecution(node_id=node_id, outputs={}, cost=Cost())
+
+    def _iteration_cost_hint(
+        self, loop: Mapping[str, object], iteration_index: int
+    ) -> Cost:
+        return Cost()
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _trace_event(self, event: str, payload: Mapping[str, object]) -> None:
+        data = dict(payload)
+        data["event"] = event
+        self._trace.append(data)
+
+    @staticmethod
+    def _as_mapping(value: object) -> Mapping[str, object]:
+        if isinstance(value, Mapping):
+            return value
+        return {}
+
+    def _index_nodes(self, nodes: object) -> Mapping[str, Mapping[str, object]]:
+        index: dict[str, Mapping[str, object]] = {}
+        for node in self._iter_mappings(nodes):
+            identifier = str(node.get("id"))
+            index[identifier] = node
+        return index
+
+    @staticmethod
+    def _iter_mappings(value: object) -> Iterable[Mapping[str, object]]:
+        if isinstance(value, Mapping):
+            yield value
+        elif isinstance(value, Iterable) and not isinstance(value, str | bytes):
+            for item in value:
+                if isinstance(item, Mapping):
+                    yield item
+
+    @staticmethod
+    def _iter_strings(value: object) -> Iterable[str]:
+        if isinstance(value, str):
+            yield value
+            return
+        if isinstance(value, Iterable) and not isinstance(value, str | bytes):
+            for item in value:
+                yield str(item)
+
+    @staticmethod
+    def _coerce_max_iterations(value: object) -> float:
+        if isinstance(value, int | float):
+            numeric = float(value)
+            if numeric > 0:
+                return numeric
+        return math.inf

--- a/tests/e2e/test_runner_budget_stop.py
+++ b/tests/e2e/test_runner_budget_stop.py
@@ -1,0 +1,98 @@
+"""FlowRunner budget guard integration tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from pkgs.dsl.budget import Cost
+from pkgs.dsl.runner import FlowRunner, NodeExecution, RunResult
+
+
+class DummyFlowRunner(FlowRunner):
+    """FlowRunner subclass that injects deterministic costs for testing."""
+
+    def __init__(self, iteration_cost: Cost) -> None:
+        super().__init__(id_factory=lambda: "run-test", now_factory=lambda: 0.0)
+        self._iteration_cost = iteration_cost
+        self.invocations: list[str] = []
+
+    def _iteration_cost_hint(
+        self, loop: Mapping[str, object], iteration_index: int
+    ) -> Cost:
+        return self._iteration_cost
+
+    def _execute_node(
+        self,
+        node: Mapping[str, object],
+        context: Mapping[str, object],
+        *,
+        loop_id: str | None = None,
+    ) -> NodeExecution:
+        node_id = str(node["id"])
+        self.invocations.append(node_id)
+        primary_output = node.get("outputs", [f"out_{node_id}"])[0]
+        return NodeExecution(
+            node_id=node_id,
+            outputs={primary_output: f"payload-{len(self.invocations)}"},
+            cost=self._iteration_cost,
+        )
+
+
+@pytest.fixture
+def loop_spec() -> dict:
+    return {
+        "version": "0.1",
+        "globals": {
+            "tools": {"mock": {"type": "mock", "tags": []}},
+            "run_budget": {"max_calls": 9, "mode": "hard"},
+        },
+        "graph": {
+            "nodes": [
+                {
+                    "id": "worker",
+                    "kind": "unit",
+                    "spec": {"type": "tool", "tool_ref": "mock"},
+                    "outputs": ["result"],
+                    "budget": {"max_calls": 5, "mode": "hard"},
+                }
+            ],
+            "control": [
+                {
+                    "id": "loop",
+                    "kind": "loop",
+                    "target_subgraph": ["worker"],
+                    "stop": {
+                        "max_iterations": 10,
+                        "budget": {"max_calls": 3, "breach_action": "stop"},
+                    },
+                }
+            ],
+        },
+    }
+
+
+def test_loop_budget_stop_halts_iterations(loop_spec: dict) -> None:
+    runner = DummyFlowRunner(iteration_cost=Cost(calls=1))
+    result = runner.run(loop_spec, vars={"root": {}})
+
+    assert isinstance(result, RunResult)
+    assert result.status == "ok"
+    assert runner.invocations == ["worker", "worker", "worker"]
+
+    loop_events = [event for event in result.trace if event["event"] == "loop_stop"]
+    assert loop_events, "expected loop_stop event"
+    stop_event = loop_events[-1]
+    assert stop_event["loop_id"] == "loop"
+    assert stop_event["reason"] == "budget_stop"
+    assert stop_event["details"]["breached"] == ("calls",)
+
+    # The run budget should accumulate the same number of calls as executed iterations.
+    run_spend = [
+        event
+        for event in result.trace
+        if event["event"] == "budget_charge" and event["scope"] == "run"
+    ]
+    assert len(run_spend) == 3
+    assert run_spend[-1]["decision"]["remaining"]["calls"] == 6

--- a/tests/unit/test_budget_meter_limits.py
+++ b/tests/unit/test_budget_meter_limits.py
@@ -1,0 +1,80 @@
+"""BudgetMeter behavior contract tests."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from pkgs.dsl.budget import BudgetExceededError, BudgetMeter, Cost
+
+
+@pytest.mark.parametrize(
+    "charges",
+    [
+        [Cost(usd=0.25), Cost(usd=0.35)],
+        [Cost(usd=0.4), Cost(usd=0.6)],
+    ],
+)
+def test_hard_budget_blocks_spend_when_limit_reached(charges: list[Cost]) -> None:
+    meter = BudgetMeter.from_budget({"max_usd": 0.5, "mode": "hard"}, scope="run")
+
+    for cost in charges[:-1]:
+        decision = meter.charge(cost)
+        assert decision.allowed is True
+        assert not decision.breached
+
+    expected_remaining = 0.5 - sum(cost.usd for cost in charges[:-1])
+    assert math.isclose(meter.remaining.usd, expected_remaining, rel_tol=1e-9)
+
+    with pytest.raises(BudgetExceededError) as excinfo:
+        meter.charge(charges[-1])
+
+    decision = excinfo.value.decision
+    assert decision.allowed is False
+    assert decision.breached == ("usd",)
+    # Meter should not mutate when a hard cap blocks the charge.
+    assert math.isclose(meter.spent.usd, sum(c.usd for c in charges[:-1]), rel_tol=1e-9)
+    assert math.isclose(meter.remaining.usd, expected_remaining, rel_tol=1e-9)
+
+
+def test_soft_budget_emits_breach_without_blocking() -> None:
+    meter = BudgetMeter.from_budget({"max_tokens": 1000, "mode": "soft"}, scope="node")
+
+    first = meter.charge(Cost(tokens=900))
+    assert first.allowed is True
+    assert not first.soft_breach
+    assert first.breached == ()
+
+    second = meter.charge(Cost(tokens=250))
+    assert second.allowed is True
+    assert second.soft_breach is True
+    assert second.breached == ("tokens",)
+    assert meter.spent.tokens == 1150
+    assert meter.remaining.tokens == -150
+
+
+def test_zero_or_none_limits_mean_unlimited() -> None:
+    meter = BudgetMeter.from_budget({"max_calls": 0, "max_usd": None}, scope="node")
+
+    for _ in range(5):
+        decision = meter.charge(Cost(calls=1, usd=2.5))
+        assert decision.allowed is True
+        assert not decision.breached
+
+    assert meter.spent.calls == 5
+    assert meter.remaining.calls is math.inf
+    assert math.isclose(meter.spent.usd, 12.5, rel_tol=1e-9)
+
+
+def test_can_spend_preview_does_not_mutate_state() -> None:
+    meter = BudgetMeter.from_budget({"max_usd": 1.0}, scope="run")
+
+    assert meter.can_spend(Cost(usd=0.75)) is True
+    assert meter.spent.usd == 0.0
+    assert meter.remaining.usd == 1.0
+
+    # A preview that would breach should not mutate either.
+    assert meter.can_spend(Cost(usd=1.5)) is False
+    assert meter.spent.usd == 0.0
+    assert meter.remaining.usd == 1.0


### PR DESCRIPTION
## Summary
- add a `BudgetMeter` utility that normalizes limits, records spend, and throws `BudgetExceededError` for hard caps
- introduce a minimal `FlowRunner` skeleton wired to the new meter, with loop stop logic and tracing for budget events
- cover the behaviour with unit tests for the meter and an end-to-end loop budget stop scenario

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68e885f56c9c832cb7c889daf3b34e64