### PR TITLE
Implement budget metering and FlowRunner budget enforcement

### DIFF
--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,5 +1,12 @@
-"""DSL package exports for policy engine components."""
+"""DSL package exports for policy and budgeting components."""
 
+from .budget import (  # noqa: F401
+    BudgetBreach,
+    BudgetCharge,
+    BudgetCheck,
+    BudgetExceededError,
+    BudgetMeter,
+)
 from .models import (  # noqa: F401
     PolicyDecision,
     PolicyDenial,
@@ -16,6 +23,11 @@ from .policy import (  # noqa: F401
 )
 
 __all__ = [
+    "BudgetBreach",
+    "BudgetCharge",
+    "BudgetCheck",
+    "BudgetExceededError",
+    "BudgetMeter",
     "PolicyDecision",
     "PolicyDenial",
     "PolicyResolution",

--- a/pkgs/dsl/budget.py
+++ b/pkgs/dsl/budget.py
@@ -1,0 +1,227 @@
+"""Budget tracking utilities for the DSL runner."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+Number = float | int
+CostMapping = Mapping[str, Number]
+
+_EPSILON = 1e-9
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetBreach:
+    """Metadata describing a budget breach event."""
+
+    scope: str
+    metric: str
+    level: str
+    limit: Number | None
+    attempted: Number
+    spent_before: Number
+
+    @property
+    def remaining_before(self) -> Number | None:
+        if self.limit is None:
+            return None
+        remaining = self.limit - self.spent_before
+        return remaining if remaining > 0 else 0
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetCharge:
+    """Result of a successful budget charge."""
+
+    scope: str
+    cost: Mapping[str, Number]
+    spent: Mapping[str, Number]
+    breaches: tuple[BudgetBreach, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetCheck:
+    """Outcome of a preflight budget check."""
+
+    allowed: bool
+    breach: BudgetBreach | None = None
+
+
+class BudgetExceededError(RuntimeError):
+    """Raised when attempting to charge past a hard budget limit."""
+
+    def __init__(
+        self,
+        *,
+        scope: str,
+        metric: str,
+        limit: Number | None,
+        attempted: Number,
+    ) -> None:
+        message = (
+            f"Budget exceeded for {scope} ({metric}): attempted {attempted} "
+            f"with limit {limit}"
+        )
+        super().__init__(message)
+        self.scope = scope
+        self.metric = metric
+        self.limit = limit
+        self.attempted = attempted
+
+
+class BudgetMeter:
+    """Track spend across currencies/tokens/time with hard or soft limits."""
+
+    def __init__(
+        self,
+        *,
+        scope: str,
+        config: Mapping[str, object] | None = None,
+        default_mode: str = "hard",
+    ) -> None:
+        self.scope = scope
+        normalized = dict(config or {})
+        self.mode = str(normalized.get("mode", default_mode)).lower()
+        if self.mode not in {"hard", "soft"}:
+            raise ValueError(f"Unsupported budget mode: {self.mode!r}")
+
+        self.breach_action = normalized.get("breach_action")
+
+        self._limits: dict[str, Number | None] = {
+            "usd": _normalize_limit(normalized.get("max_usd")),
+            "tokens": _normalize_limit(normalized.get("max_tokens")),
+            "calls": _normalize_limit(normalized.get("max_calls")),
+            "time_ms": _normalize_time_limit(normalized.get("time_limit_sec")),
+        }
+        self._spent: dict[str, Number] = {key: 0 for key in self._limits}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def can_spend(self, cost: CostMapping | None) -> BudgetCheck:
+        """Return whether the provided cost can be applied without breach."""
+
+        if not cost:
+            return BudgetCheck(allowed=True, breach=None)
+
+        normalized_cost = _normalize_cost(cost)
+        soft_breach: BudgetBreach | None = None
+        for metric, limit in self._limits.items():
+            if limit is None:
+                continue
+            projected = self._spent[metric] + normalized_cost[metric]
+            if projected - limit > _EPSILON:
+                breach = BudgetBreach(
+                    scope=self.scope,
+                    metric=metric,
+                    level=self.mode,
+                    limit=limit,
+                    attempted=projected,
+                    spent_before=self._spent[metric],
+                )
+                if self.mode == "hard":
+                    return BudgetCheck(allowed=False, breach=breach)
+                soft_breach = soft_breach or breach
+        return BudgetCheck(allowed=True, breach=soft_breach)
+
+    def charge(self, cost: CostMapping | None) -> BudgetCharge:
+        """Apply a cost to the meter, raising if hard budgets are exceeded."""
+
+        if not cost:
+            return BudgetCharge(
+                scope=self.scope,
+                cost=MappingProxyType({}),
+                spent=self.spent_snapshot(),
+                breaches=(),
+            )
+
+        normalized_cost = _normalize_cost(cost)
+        breaches: list[BudgetBreach] = []
+        for metric, limit in self._limits.items():
+            if limit is None:
+                continue
+            projected = self._spent[metric] + normalized_cost[metric]
+            if projected - limit > _EPSILON:
+                breach = BudgetBreach(
+                    scope=self.scope,
+                    metric=metric,
+                    level=self.mode,
+                    limit=limit,
+                    attempted=projected,
+                    spent_before=self._spent[metric],
+                )
+                if self.mode == "hard":
+                    raise BudgetExceededError(
+                        scope=self.scope,
+                        metric=metric,
+                        limit=limit,
+                        attempted=projected,
+                    )
+                breaches.append(breach)
+
+        for metric, value in normalized_cost.items():
+            self._spent[metric] += value
+
+        return BudgetCharge(
+            scope=self.scope,
+            cost=_freeze(normalized_cost),
+            spent=self.spent_snapshot(),
+            breaches=tuple(breaches),
+        )
+
+    def remaining(self) -> Mapping[str, Number | None]:
+        """Return remaining budget for each metric (None if unlimited)."""
+
+        remaining: dict[str, Number | None] = {}
+        for metric, limit in self._limits.items():
+            if limit is None:
+                remaining[metric] = None
+            else:
+                remaining[metric] = max(limit - self._spent[metric], 0)
+        return MappingProxyType(remaining)
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+    def spent_snapshot(self) -> Mapping[str, Number]:
+        return MappingProxyType(dict(self._spent))
+
+
+def _normalize_limit(raw: object | None) -> Number | None:
+    if raw is None:
+        return None
+    if isinstance(raw, int | float):
+        value = float(raw)
+    else:
+        try:
+            value = float(raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise ValueError(f"Budget limit must be numeric or None, got {raw!r}") from None
+    if value <= 0:
+        return None
+    return value
+
+
+def _normalize_time_limit(raw: object | None) -> Number | None:
+    limit = _normalize_limit(raw)
+    if limit is None:
+        return None
+    return limit * 1000.0
+
+
+def _normalize_cost(cost: CostMapping) -> dict[str, Number]:
+    normalized: dict[str, Number] = {"usd": 0.0, "tokens": 0.0, "calls": 0.0, "time_ms": 0.0}
+    for key, value in cost.items():
+        if value is None:
+            continue
+        if key not in normalized:
+            raise ValueError(f"Unsupported cost metric: {key!r}")
+        normalized[key] = float(value)
+    return normalized
+
+
+def _freeze(cost: MutableMapping[str, Number] | Mapping[str, Number]) -> Mapping[str, Number]:
+    return MappingProxyType(dict(cost))
+

--- a/pkgs/dsl/runner.py
+++ b/pkgs/dsl/runner.py
@@ -1,0 +1,418 @@
+"""Minimal FlowRunner implementation with budget integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Protocol
+from uuid import uuid4
+
+from .budget import BudgetBreach, BudgetCharge, BudgetExceededError, BudgetMeter
+
+
+class ToolAdapter(Protocol):
+    """Adapter interface used by the runner tests."""
+
+    def estimate_cost(
+        self,
+        node: Mapping[str, Any],
+        inputs: Mapping[str, Any],
+    ) -> Mapping[str, float | int]:
+        ...
+
+    def execute(self, node: Mapping[str, Any], inputs: Mapping[str, Any]) -> Any:
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class RunResult:
+    """Execution result returned by :class:`FlowRunner`."""
+
+    run_id: str
+    status: str
+    outputs: Mapping[str, Mapping[str, Any]]
+
+
+@dataclass(slots=True)
+class MeterContext:
+    meter: BudgetMeter
+    scope: str
+    owner_id: str | None
+    breach_action: str
+
+
+@dataclass(slots=True)
+class LoopContext:
+    loop_id: str
+    meter: BudgetMeter | None
+    breach_action: str
+
+
+class _LoopStopSignal(RuntimeError):
+    def __init__(self, loop_id: str, breach: BudgetBreach | None = None) -> None:
+        super().__init__(f"Loop {loop_id} stopped")
+        self.loop_id = loop_id
+        self.breach = breach
+
+
+class FlowRunner:
+    """Execute a simplified DSL flow with budget enforcement."""
+
+    def __init__(
+        self,
+        *,
+        adapters: Mapping[str, ToolAdapter],
+        run_id_factory: Callable[[], str] | None = None,
+        trace_sink: Callable[[Mapping[str, Any]], None] | None = None,
+    ) -> None:
+        self.adapters = dict(adapters)
+        self._run_id_factory = run_id_factory or (lambda: str(uuid4()))
+        self._trace_sink = trace_sink
+        self._trace: list[dict[str, Any]] = []
+        self._loop_stack: list[LoopContext] = []
+        self._node_lookup: dict[str, Mapping[str, Any]] = {}
+        self._node_meters: dict[str, BudgetMeter] = {}
+        self._soft_node_meters: dict[str, BudgetMeter] = {}
+        self._loop_meters: dict[str, BudgetMeter] = {}
+        self._run_meter: BudgetMeter | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self, spec: Mapping[str, Any], vars: Mapping[str, Any]) -> RunResult:  # noqa: ARG002
+        self._trace.clear()
+        self._node_lookup = {node["id"]: node for node in spec.get("nodes", [])}
+        self._loop_stack.clear()
+        self._node_meters.clear()
+        self._soft_node_meters.clear()
+        self._loop_meters.clear()
+
+        run_budget = (spec.get("globals") or {}).get("run_budget")
+        self._run_meter = BudgetMeter(scope="run", config=run_budget)
+
+        loop_body_nodes = {
+            target
+            for node in spec.get("nodes", [])
+            if node.get("kind") == "loop"
+            for target in node.get("target_subgraph", [])
+        }
+
+        outputs: dict[str, Mapping[str, Any]] = {}
+        status = "ok"
+        try:
+            for node in spec.get("nodes", []):
+                node_id = node.get("id")
+                if not node_id:
+                    continue
+                if node_id in loop_body_nodes and node.get("kind") != "loop":
+                    # Executed as part of its parent loop.
+                    continue
+                if node.get("kind") == "loop":
+                    self._execute_loop(node, outputs)
+                elif node.get("kind") == "unit":
+                    self._execute_unit(node, outputs)
+                else:
+                    raise NotImplementedError(f"Unsupported node kind: {node.get('kind')!r}")
+        except BudgetExceededError as exc:
+            status = "error"
+            # Trace already recorded by the charging layer.
+            self._record_trace(
+                {
+                    "event": "run_error",
+                    "reason": "budget_exceeded",
+                    "scope": exc.scope,
+                    "metric": exc.metric,
+                    "attempted": exc.attempted,
+                }
+            )
+        return RunResult(
+            run_id=self._run_id_factory(),
+            status=status,
+            outputs=MappingProxyType(outputs),
+        )
+
+    @property
+    def trace_events(self) -> tuple[Mapping[str, Any], ...]:
+        return tuple(MappingProxyType(event) for event in self._trace)
+
+    # ------------------------------------------------------------------
+    # Node execution helpers
+    # ------------------------------------------------------------------
+    def _execute_unit(self, node: Mapping[str, Any], outputs: dict[str, Mapping[str, Any]]) -> None:
+        node_id = node["id"]
+        tool_ref = node.get("spec", {}).get("tool_ref")
+        if tool_ref not in self.adapters:
+            raise KeyError(f"Unknown tool adapter: {tool_ref!r}")
+        adapter = self.adapters[tool_ref]
+
+        inputs: Mapping[str, Any] = MappingProxyType({})
+        contexts = self._collect_meter_contexts(node)
+
+        estimate = adapter.estimate_cost(node, inputs)
+        try:
+            self._enforce_preflight(node_id, estimate, contexts)
+        except _LoopStopSignal:
+            raise
+        except BudgetExceededError as exc:
+            self._record_budget_breach(
+                node_id=node_id,
+                scope=exc.scope,
+                breach=BudgetBreach(
+                    scope=exc.scope,
+                    metric=exc.metric,
+                    level="hard",
+                    limit=exc.limit,
+                    attempted=exc.attempted,
+                    spent_before=self._current_spend(exc.scope, exc.metric),
+                ),
+            )
+            raise
+
+        self._record_trace({"event": "node_start", "node_id": node_id})
+        result = adapter.execute(node, inputs)
+
+        try:
+            self._apply_cost(node_id, result.cost if hasattr(result, "cost") else {})
+        except _LoopStopSignal as stop:
+            self._record_trace(
+                {
+                    "event": "node_end",
+                    "node_id": node_id,
+                    "outputs": dict(getattr(result, "outputs", {})),
+                    "cost": dict(getattr(result, "cost", {})),
+                    "stop_reason": "loop_budget",
+                    "loop_id": stop.loop_id,
+                }
+            )
+            raise
+
+        self._record_trace(
+            {
+                "event": "node_end",
+                "node_id": node_id,
+                "outputs": dict(getattr(result, "outputs", {})),
+                "cost": dict(getattr(result, "cost", {})),
+            }
+        )
+        outputs[node_id] = MappingProxyType(dict(getattr(result, "outputs", {})))
+
+    def _execute_loop(self, node: Mapping[str, Any], outputs: dict[str, Mapping[str, Any]]) -> None:
+        loop_id = node["id"]
+        stop_conf = (node.get("stop") or {}).get("budget")
+        loop_meter = None
+        breach_action = "stop"
+        if stop_conf:
+            loop_meter = self._loop_meters.get(loop_id)
+            if loop_meter is None:
+                loop_meter = BudgetMeter(scope=f"loop:{loop_id}", config=stop_conf)
+                self._loop_meters[loop_id] = loop_meter
+            breach_action = str(stop_conf.get("breach_action", "stop")).lower()
+        self._loop_stack.append(
+            LoopContext(loop_id=loop_id, meter=loop_meter, breach_action=breach_action)
+        )
+        iterations = 0
+        max_iterations = (node.get("stop") or {}).get("max_iterations")
+        try:
+            while True:
+                if max_iterations is not None and iterations >= max_iterations:
+                    self._record_trace(
+                        {
+                            "event": "loop_stop",
+                            "loop_id": loop_id,
+                            "reason": "max_iterations",
+                            "iterations": iterations,
+                        }
+                    )
+                    break
+                try:
+                    for target_id in node.get("target_subgraph", []):
+                        target = self._node_lookup.get(target_id)
+                        if target is None:
+                            raise KeyError(f"Loop target node not found: {target_id!r}")
+                        self._execute_unit(target, outputs)
+                except _LoopStopSignal as stop:
+                    if stop.loop_id != loop_id:
+                        raise
+                    self._record_trace(
+                        {
+                            "event": "loop_stop",
+                            "loop_id": loop_id,
+                            "reason": "budget_stop",
+                            "iterations": iterations,
+                            "breach": {
+                                "metric": stop.breach.metric if stop.breach else None,
+                                "limit": stop.breach.limit if stop.breach else None,
+                            },
+                        }
+                    )
+                    break
+                iterations += 1
+        finally:
+            self._loop_stack.pop()
+
+    # ------------------------------------------------------------------
+    # Budget helpers
+    # ------------------------------------------------------------------
+    def _collect_meter_contexts(self, node: Mapping[str, Any]) -> list[MeterContext]:
+        contexts: list[MeterContext] = []
+        if self._run_meter is not None:
+            contexts.append(
+                MeterContext(
+                    meter=self._run_meter,
+                    scope="run",
+                    owner_id=None,
+                    breach_action="error" if self._run_meter.mode == "hard" else "warn",
+                )
+            )
+        for loop_ctx in self._loop_stack:
+            if loop_ctx.meter is None:
+                continue
+            contexts.append(
+                MeterContext(
+                    meter=loop_ctx.meter,
+                    scope=f"loop:{loop_ctx.loop_id}",
+                    owner_id=loop_ctx.loop_id,
+                    breach_action=loop_ctx.breach_action,
+                )
+            )
+        node_budget = node.get("budget")
+        if node_budget:
+            meter = self._node_meters.get(node["id"])
+            if meter is None:
+                meter = BudgetMeter(scope=f"node:{node['id']}", config=node_budget)
+                self._node_meters[node["id"]] = meter
+            contexts.append(
+                MeterContext(
+                    meter=meter,
+                    scope=f"node:{node['id']}",
+                    owner_id=node["id"],
+                    breach_action="error" if meter.mode == "hard" else "warn",
+                )
+            )
+        soft_budget = node.get("spec", {}).get("budget")
+        if soft_budget:
+            meter = self._soft_node_meters.get(node["id"])
+            if meter is None:
+                meter = BudgetMeter(
+                    scope=f"node:{node['id']}:soft",
+                    config=soft_budget,
+                    default_mode="soft",
+                )
+                self._soft_node_meters[node["id"]] = meter
+            contexts.append(
+                MeterContext(
+                    meter=meter,
+                    scope=f"node:{node['id']}:soft",
+                    owner_id=node["id"],
+                    breach_action="warn",
+                )
+            )
+        return contexts
+
+    def _enforce_preflight(
+        self,
+        node_id: str,
+        cost: Mapping[str, float | int],
+        contexts: list[MeterContext],
+    ) -> None:
+        for context in contexts:
+            check = context.meter.can_spend(cost)
+            if not check.allowed:
+                breach = check.breach
+                if breach is None:
+                    continue
+                if context.breach_action == "stop" and context.owner_id:
+                    raise _LoopStopSignal(context.owner_id, breach)
+                raise BudgetExceededError(
+                    scope=breach.scope,
+                    metric=breach.metric,
+                    limit=breach.limit,
+                    attempted=breach.attempted,
+                )
+            if check.breach is not None:
+                self._record_budget_warning(
+                    node_id=node_id,
+                    scope=context.scope,
+                    breach=check.breach,
+                )
+
+    def _apply_cost(self, node_id: str, cost: Mapping[str, float | int]) -> None:
+        contexts = self._collect_meter_contexts(self._node_lookup[node_id])
+        for context in contexts:
+            try:
+                charge = context.meter.charge(cost)
+            except BudgetExceededError as exc:
+                spent_before = self._current_spend(context.scope, exc.metric)
+                breach = BudgetBreach(
+                    scope=context.scope,
+                    metric=exc.metric,
+                    level="hard",
+                    limit=exc.limit,
+                    attempted=exc.attempted,
+                    spent_before=spent_before,
+                )
+                self._record_budget_breach(node_id=node_id, scope=context.scope, breach=breach)
+                if context.breach_action == "stop" and context.owner_id:
+                    raise _LoopStopSignal(context.owner_id, breach) from None
+                raise
+            else:
+                self._handle_soft_breaches(node_id, context.scope, charge)
+
+    def _handle_soft_breaches(self, node_id: str, scope: str, charge: BudgetCharge) -> None:
+        for breach in charge.breaches:
+            self._record_budget_warning(node_id=node_id, scope=scope, breach=breach)
+
+    def _current_spend(self, scope: str, metric: str) -> float:
+        meter = None
+        if scope == "run":
+            meter = self._run_meter
+        elif scope.startswith("loop:"):
+            loop_id = scope.split(":", 1)[1]
+            meter = self._loop_meters.get(loop_id)
+        elif scope.startswith("node:"):
+            suffix = scope.split(":", 1)[1]
+            if suffix.endswith(":soft"):
+                node_id = suffix[:-5]
+                meter = self._soft_node_meters.get(node_id)
+            else:
+                meter = self._node_meters.get(suffix)
+        if meter is None:
+            return 0.0
+        return float(meter.spent_snapshot().get(metric, 0.0))
+
+    # ------------------------------------------------------------------
+    # Trace helpers
+    # ------------------------------------------------------------------
+    def _record_budget_warning(self, *, node_id: str, scope: str, breach: BudgetBreach) -> None:
+        self._record_trace(
+            {
+                "event": "budget_warning",
+                "node_id": node_id,
+                "scope": scope,
+                "level": "soft",
+                "metric": breach.metric,
+                "attempted": breach.attempted,
+                "remaining_before": breach.remaining_before,
+            }
+        )
+
+    def _record_budget_breach(self, *, node_id: str, scope: str, breach: BudgetBreach) -> None:
+        self._record_trace(
+            {
+                "event": "budget_breach",
+                "node_id": node_id,
+                "scope": scope,
+                "level": breach.level,
+                "metric": breach.metric,
+                "attempted": breach.attempted,
+                "limit": breach.limit,
+            }
+        )
+
+    def _record_trace(self, event: Mapping[str, Any]) -> None:
+        payload = dict(event)
+        self._trace.append(payload)
+        if self._trace_sink is not None:
+            self._trace_sink(MappingProxyType(payload))
+

--- a/tests/e2e/test_runner_budget_stop.py
+++ b/tests/e2e/test_runner_budget_stop.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from pkgs.dsl.runner import FlowRunner, RunResult
+
+
+@dataclass
+class FakeToolResult:
+    outputs: Mapping[str, Any]
+    cost: Mapping[str, float | int]
+
+
+class FakeToolAdapter:
+    def __init__(
+        self,
+        *,
+        cost: Mapping[str, float | int],
+        output: Mapping[str, Any] | None = None,
+    ) -> None:
+        default_output = {"result": "ok"}
+        self._cost = dict(cost)
+        self._output = dict(output or default_output)
+        self.calls = 0
+
+    def estimate_cost(
+        self,
+        node: Mapping[str, Any],
+        inputs: Mapping[str, Any],
+    ) -> Mapping[str, float | int]:
+        return dict(self._cost)
+
+    def execute(self, node: Mapping[str, Any], inputs: Mapping[str, Any]) -> FakeToolResult:
+        self.calls += 1
+        return FakeToolResult(outputs=self._output, cost=self._cost)
+
+
+@pytest.fixture()
+def runner() -> FlowRunner:
+    adapters = {
+        "expensive": FakeToolAdapter(cost={"usd": 3.0}),
+        "cheap": FakeToolAdapter(cost={"usd": 1.0}),
+        "loop-tool": FakeToolAdapter(cost={"calls": 1}),
+    }
+    return FlowRunner(adapters=adapters, run_id_factory=lambda: "run-budget")
+
+
+def test_run_budget_hard_limit_triggers_error(runner: FlowRunner) -> None:
+    spec = {
+        "globals": {"run_budget": {"max_usd": 5.0, "mode": "hard"}},
+        "nodes": [
+            {
+                "id": "first",
+                "kind": "unit",
+                "spec": {"type": "tool", "tool_ref": "expensive", "args": {}},
+                "outputs": ["result"],
+            },
+            {
+                "id": "second",
+                "kind": "unit",
+                "spec": {"type": "tool", "tool_ref": "expensive", "args": {}},
+                "outputs": ["result"],
+            },
+        ],
+    }
+
+    result = runner.run(spec, vars={})
+
+    assert isinstance(result, RunResult)
+    assert result.status == "error"
+    assert result.outputs.get("first", {}).get("result") == "ok"
+    assert "second" not in result.outputs  # halted before second node completed
+
+    breach_events = [evt for evt in runner.trace_events if evt["event"] == "budget_breach"]
+    assert breach_events, "Expected a budget breach to be recorded"
+    breach = breach_events[-1]
+    assert breach["scope"] == "run"
+    assert breach["level"] == "hard"
+    assert breach["metric"] == "usd"
+
+
+def test_soft_node_budget_emits_warning_and_continues(runner: FlowRunner) -> None:
+    spec = {
+        "globals": {},
+        "nodes": [
+            {
+                "id": "soft-node",
+                "kind": "unit",
+                "budget": {"mode": "soft", "max_usd": 0.5},
+                "spec": {"type": "tool", "tool_ref": "cheap", "args": {}},
+                "outputs": ["value"],
+            }
+        ],
+    }
+
+    result = runner.run(spec, vars={})
+
+    assert result.status == "ok"
+    assert result.outputs["soft-node"]["result"] == "ok"
+    warnings = [evt for evt in runner.trace_events if evt["event"] == "budget_warning"]
+    assert warnings, "Soft budget breaches should emit warnings"
+    assert warnings[0]["scope"] == "node:soft-node"
+
+
+def test_loop_budget_with_stop_action_halts_loop_without_error() -> None:
+    loop_runner = FlowRunner(
+        adapters={"loop-tool": FakeToolAdapter(cost={"calls": 1})},
+        run_id_factory=lambda: "loop-run",
+    )
+    spec = {
+        "globals": {},
+        "nodes": [
+            {
+                "id": "loop",
+                "kind": "loop",
+                "target_subgraph": ["body"],
+                "stop": {"budget": {"max_calls": 3, "breach_action": "stop"}},
+            },
+            {
+                "id": "body",
+                "kind": "unit",
+                "spec": {"type": "tool", "tool_ref": "loop-tool", "args": {}},
+                "outputs": ["value"],
+            },
+        ],
+    }
+
+    result = loop_runner.run(spec, vars={})
+
+    assert result.status == "ok"
+    assert loop_runner.adapters["loop-tool"].calls == 3
+    stop_events = [evt for evt in loop_runner.trace_events if evt["event"] == "loop_stop"]
+    assert stop_events, "Loop should emit a stop event"
+    stop = stop_events[-1]
+    assert stop["loop_id"] == "loop"
+    assert stop["reason"] == "budget_stop"
+
+
+def test_loop_budget_error_action_propagates() -> None:
+    loop_runner = FlowRunner(
+        adapters={"loop-tool": FakeToolAdapter(cost={"calls": 2})},
+        run_id_factory=lambda: "loop-run-error",
+    )
+    spec = {
+        "globals": {"run_budget": {"max_calls": 10}},
+        "nodes": [
+            {
+                "id": "loop",
+                "kind": "loop",
+                "target_subgraph": ["body"],
+                "stop": {"budget": {"max_calls": 3, "breach_action": "error"}},
+            },
+            {
+                "id": "body",
+                "kind": "unit",
+                "spec": {"type": "tool", "tool_ref": "loop-tool", "args": {}},
+                "outputs": ["value"],
+            },
+        ],
+    }
+
+    result = loop_runner.run(spec, vars={})
+
+    assert result.status == "error"
+    breach_events = [evt for evt in loop_runner.trace_events if evt["event"] == "budget_breach"]
+    assert any(evt["scope"] == "loop:loop" for evt in breach_events)
+

--- a/tests/unit/test_budget_meter_limits.py
+++ b/tests/unit/test_budget_meter_limits.py
@@ -1,0 +1,72 @@
+import math
+
+import pytest
+
+from pkgs.dsl.budget import (
+    BudgetBreach,
+    BudgetCharge,
+    BudgetExceededError,
+    BudgetMeter,
+)
+
+
+@pytest.fixture(name="hard_run_meter")
+def fixture_hard_run_meter() -> BudgetMeter:
+    return BudgetMeter(scope="run", config={"max_usd": 10.0, "max_tokens": 1000})
+
+
+def test_can_spend_and_charge_within_limits(hard_run_meter: BudgetMeter) -> None:
+    check = hard_run_meter.can_spend({"usd": 4.5, "tokens": 250})
+    assert check.allowed
+    assert check.breach is None
+
+    charge = hard_run_meter.charge({"usd": 4.5, "tokens": 250})
+    assert isinstance(charge, BudgetCharge)
+    assert charge.breaches == ()
+    remaining = hard_run_meter.remaining()
+    assert math.isclose(remaining["usd"], 5.5, rel_tol=1e-9)
+    assert remaining["tokens"] == 750
+
+
+def test_charge_raises_when_hard_limit_exceeded(hard_run_meter: BudgetMeter) -> None:
+    hard_run_meter.charge({"usd": 7.25})
+
+    with pytest.raises(BudgetExceededError) as exc_info:
+        hard_run_meter.charge({"usd": 3.0})
+
+    err = exc_info.value
+    assert err.metric == "usd"
+    assert err.scope == "run"
+    assert math.isclose(err.limit or 0.0, 10.0, rel_tol=1e-9)
+    assert math.isclose(err.attempted, 10.25, rel_tol=1e-9)
+
+
+def test_soft_budget_warns_but_allows_spend() -> None:
+    meter = BudgetMeter(scope="node:soft", config={"mode": "soft", "max_usd": 2.5})
+
+    preflight = meter.can_spend({"usd": 3.0})
+    assert preflight.allowed
+    assert isinstance(preflight.breach, BudgetBreach)
+    assert preflight.breach.level == "soft"
+
+    charge = meter.charge({"usd": 3.0})
+    assert charge.breaches and charge.breaches[0].level == "soft"
+    remaining = meter.remaining()
+    assert remaining["usd"] == 0
+
+
+@pytest.mark.parametrize("limit", [0, None])
+def test_zero_or_none_limits_treated_as_unbounded(limit: float | None) -> None:
+    meter = BudgetMeter(scope="unbounded", config={"max_usd": limit, "max_tokens": limit})
+    meter.charge({"usd": 10_000, "tokens": 500_000})
+    remaining = meter.remaining()
+    assert remaining["usd"] is None
+    assert remaining["tokens"] is None
+
+
+def test_time_limit_converted_to_milliseconds() -> None:
+    meter = BudgetMeter(scope="timer", config={"time_limit_sec": 1.25})
+    meter.charge({"time_ms": 1_000})
+    with pytest.raises(BudgetExceededError):
+        meter.charge({"time_ms": 300})
+


### PR DESCRIPTION
## Summary
- introduce a BudgetMeter utility with breach semantics for usd/tokens/calls/time tracking
- add a minimal FlowRunner that wires the meter into run/node/loop execution and emits trace events
- cover budget behavior with new unit tests and end-to-end flow tests for run, node, and loop scopes

## Testing
- ./scripts/ensure_green.sh

------
https://chatgpt.com/codex/tasks/task_e_68e885f56c9c832cb7c889daf3b34e64