### PR TITLE
Add P2 comparative review and plan for budget guards integration

### DIFF
--- a/codex/agents/POSTEXECUTION/P2/07b_budget_guards_and_runner_integration.yaml-20250427T160000Z-gpt5codex
+++ b/codex/agents/POSTEXECUTION/P2/07b_budget_guards_and_runner_integration.yaml-20250427T160000Z-gpt5codex
@@ -1,0 +1,19 @@
+post_execution_feedback:
+  was_successful: null
+  failed_tasks: []
+  recommended_revisions: []
+  synthesis_notes:
+    - reason: opportunity to consolidate trace emission logic across branches
+      recommendation: extract shared `trace_event_emitter` to shared module
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+
+codex_directives:
+  must:
+    - reference branch contributions precisely
+    - verify all traceability expectations
+  do_not:
+    - hallucinate trace events
+    - assume success without validation

--- a/codex/agents/PREVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427T160000Z-gpt5codex
+++ b/codex/agents/PREVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427T160000Z-gpt5codex
@@ -1,0 +1,30 @@
+plan_preview:
+  branch_reuse:
+    codex/integrate-budget-guards-with-runner:
+      - Preserve adapter/policy orchestration entrypoints and baseline acceptance fixtures to ensure FlowRunner remains runnable while budgets are refactored.
+    codex/integrate-budget-guards-with-runner-zwi2ny:
+      - Adopt `BudgetSpec`, `CostSnapshot`, and `BudgetChargeOutcome` value objects plus the pluggable `TraceWriter` interface for deterministic trace emission.
+    codex/integrate-budget-guards-with-runner-pbdel9:
+      - Reuse structured `BudgetCharge` payloads with `remaining`/`overages` accounting for richer diagnostics.
+    codex/implement-budget-guards-with-test-first-approach:
+      - Integrate the `BudgetManager` preflight/commit lifecycle to coordinate run/node/spec scopes and centralize breach handling.
+    codex/implement-budget-guards-with-test-first-approach-qhq0jq:
+      - Keep `BudgetMode` semantics and preview decision helpers to cleanly separate warn vs hard-stop flows.
+    codex/implement-budget-guards-with-test-first-approach-8wxk32:
+      - Borrow immutable `NodeExecution` records and cost arithmetic helpers after reconciling unit conversions.
+    codex/implement-budget-guards-with-test-first-approach-fa0vm9:
+      - Use the adapter protocol, loop stop signaling, and streaming trace hooks as the execution backbone.
+  conflicts:
+    - Duplicate cost normalization pipelines disagree on units (`seconds` vs `milliseconds`) and metric keys; resolve by creating a single normalization module invoked by BudgetManager before both preview and charge.
+    - Trace schemas differ (bespoke `_record_event`, structured TraceWriter, streaming callbacks); consolidate on the TraceWriter API while adding policy/budget event builders shared across manager and runner.
+    - Soft budget handling varies (immediate raise, silent continue, warning-only); standardize on BudgetMode + breach_action semantics where preview determines stop reason and charge enforces according to spec.
+    - Branches diverge on loop context storage; reconcile by layering 8wxk32 `NodeExecution`/`LoopSummary` on top of fa0vm9’s loop controller, ensuring stack safety and trace fidelity.
+  dsl_engine_redesign:
+    - Refactor BudgetManager to own scope stack state (run → loop → node → spec) and expose explicit hooks to PolicyStack so policy/budget enforcement order is deterministic.
+    - Simplify budget DTO surface by unifying `BudgetChargeOutcome`, `BudgetDecision`, and `BudgetCharge` into a single immutable snapshot with nested spend/remaining/overage metrics.
+    - Extract trace emission into a `TraceEventEmitter` helper that formats policy and budget events against the spec schemas, reducing duplicate logic across branches.
+  open_questions:
+    - Should soft `breach_action: warn` accumulate repeated warnings per loop iteration or deduplicate per scope to avoid trace spam?
+    - Do we need asynchronous adapter hooks in this milestone, or can synchronous protocols satisfy acceptance criteria while leaving async for later tasks?
+    - How should policy violations and budget breaches interact when both occur in the same node—does budget enforcement happen before or after policy stack evaluation?
+    - What is the canonical stop reason payload for loops when a soft warn occurs but the flow voluntarily stops for other reasons?

--- a/codex/agents/REVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427T160000Z-gpt5codex
+++ b/codex/agents/REVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427T160000Z-gpt5codex
@@ -1,0 +1,67 @@
+metadata:
+  last_updated: 2025-04-27
+  repo: pfahlr/ragx
+  tags:
+    - dsl
+    - flow-runner
+    - budget-guards
+    - traceability
+  execution_mode: comparative_review
+analysis:
+  branches:
+    - name: codex/integrate-budget-guards-with-runner
+      notes:
+        - Maintains the only end-to-end FlowRunner that still wires adapters, policies, and trace hooks, so it is our functional baseline even though tracing relies on bespoke `_record_event` helpers rather than the shared TraceWriter abstraction.
+        - Budget enforcement is strictly hard-stop: `BudgetMeter.charge` raises `BudgetBreachError` immediately and never returns structured warnings, so soft budgets and `breach_action: stop` semantics cannot be expressed.
+        - Scope handling is shallow—there is a single run-level meter and ad-hoc loop counters—so nested scopes (node, loop, spec) from the DSL spec are not enforced.
+        - Test coverage passes but is narrow: unit tests only assert exception raising; there are no fixtures validating loop stop reasons or trace payload schema.
+    - name: codex/integrate-budget-guards-with-runner-zwi2ny
+      notes:
+        - Rebuilds FlowRunner around immutable value objects (`BudgetSpec`, `CostSnapshot`, `BudgetChargeOutcome`) and introduces an injectable `TraceWriter`, which dramatically improves observability and fits the spec’s trace contract.
+        - Loop execution integrates per-node meters and emits `budget_charge` / `budget_breach` events with deterministic payloads; remaining/overage math is precise thanks to mapping proxies.
+        - Hardcodes `BudgetMeter` to hard mode even when the spec provides `breach_action: warn`, so soft budgets still do not propagate correctly; stop reasons rely on deferred exceptions without updating runner state.
+        - Tool validation regresses: `_execute_node` is mocked and adapters/policy enforcement are bypassed, causing acceptance tests that rely on real adapter wiring to fail.
+    - name: codex/integrate-budget-guards-with-runner-pbdel9
+      notes:
+        - Focuses on the budget domain model: introduces `BudgetBreachHard`, `BudgetCharge`, `BudgetRemaining`, and richer overage accounting that preserves immutable snapshots via `mapping_proxy`.
+        - Provides explicit `remaining` and `overages` payloads ideal for trace diagnostics and downstream tooling, aligning with the DSL spec’s observability requirements.
+        - Soft budgets are effectively ignored—`breach_action` defaults to `error`, and `BudgetMeter.charge` suppresses raises when `breach_action == "stop"` without signaling the runner—so loop stops never trigger.
+        - Runner integration remains minimal; policy stack hooks and tool adapters are untouched, and test suites for loop stop and trace fidelity are missing.
+    - name: codex/implement-budget-guards-with-test-first-approach
+      notes:
+        - Introduces a layered `BudgetManager` orchestrator with explicit preflight/commit APIs and deterministic trace emission helpers, which matches the spec’s desire for scope-specific enforcement.
+        - Defines dataclasses for spent/remaining/cost snapshots and plumbs them through the manager, enabling node/run/spec scopes to be reasoned about consistently.
+        - FlowRunner itself is gutted (`run` and `plan` raise `NotImplementedError`), so integration coverage and acceptance tests regress to zero; adapter and policy orchestration must be reimplemented from scratch.
+        - Test scaffolding is planned but incomplete—manager tests assume stubbed runner state that is never constructed—so CI would fail.
+    - name: codex/implement-budget-guards-with-test-first-approach-qhq0jq
+      notes:
+        - Evolves the manager into strongly typed domain objects: `BudgetMode`, `BudgetCheck`, `_BudgetLimits`, and normalized `Cost` arithmetic, providing clear separation between preview and charge phases.
+        - Runner gains loop iteration tracking (`LoopIterationContext`, `LoopSummary`) and budget preview hooks, which improves stop reason reporting once wired.
+        - Still fabricates node execution outputs and bypasses adapters; PolicyStack enforcement is absent, so allowlist semantics are not honored.
+        - Trace emission is minimal (`run_start` / `run_end` only); node-level and policy/budget events demanded by the DSL are missing, and no tests cover the new preview logic.
+    - name: codex/implement-budget-guards-with-test-first-approach-8wxk32
+      notes:
+        - Embraces object-oriented design with immutable `NodeExecution` records, injectable clock/id factories, and consolidated `BudgetDecision` dataclasses that combine preview and charge information.
+        - Adds arithmetic helpers on `Cost` to track cumulative spend per metric, improving loop/spec rollups and aiding future analytics.
+        - Time metrics silently switch to milliseconds while adapters/tests still work in seconds, introducing hidden unit drift and violating spec normalization rules.
+        - Runner continues to mock execution and lacks trace/policy integration; soft breach diagnostics exist in data models but are never emitted or asserted in tests.
+    - name: codex/implement-budget-guards-with-test-first-approach-fa0vm9
+      notes:
+        - Provides the most complete runner loop: introduces a `ToolAdapter` protocol with estimate/execute separation, loop context management (`_LoopStopSignal`), and streaming trace emission with optional sinks.
+        - Budget domain introduces `BudgetBreach`, `BudgetCheck`, and `BudgetCharge` dataclasses, delivering structured payloads for both warnings and hard stops.
+        - Cost normalization drops unknown keys and stores time in milliseconds without aligning to the shared schema; policy enforcement hooks remain stubbed, so PolicyStack traces are still missing.
+        - Tests expect downstream code to supply adapter doubles but no fixtures are provided; coverage for loop stop reasons and trace sequencing is partial and brittle.
+  redundancy_and_hallucination_check:
+    - zwi2ny duplicates large portions of the baseline runner but replaces `_record_event` with `TraceWriter.emit`; no fabricated APIs detected, but mocked adapters hallucinate functionality the acceptance tests require.
+    - pbdel9, 8wxk32, and fa0vm9 each reinvent cost normalization differently, producing conflicting units (`seconds`, `milliseconds`, optional counts); these inconsistencies would surface as trace/stop regressions when merged.
+    - No branch introduces APIs that contradict the DSL, yet several omit mandatory trace events (`policy_resolved`, `budget_resolved`), so spec coverage is incomplete across the board.
+  synthesis_rationale:
+    - Use fa0vm9’s adapter orchestration and loop control as the execution backbone because it is the only branch that exercises estimate/execute separation and stop signals end-to-end.
+    - Merge zwi2ny’s `BudgetSpec`/`CostSnapshot` value objects and TraceWriter abstraction to obtain deterministic, immutable telemetry compatible with the spec.
+    - Adopt pbdel9’s remaining/overage accounting to enrich trace payloads, while layering the BudgetManager orchestration from test-first to coordinate run/node/spec scopes with preview/commit hooks.
+    - Normalize cost units/timefields per the master spec (seconds-in, ms stored) once at the BudgetManager boundary and share arithmetic helpers from 8wxk32 after unit fixes; retain qhq0jq’s `BudgetMode` semantics for clear soft/hard handling.
+  optional_enhancements:
+    - Add a shared `TraceEventSchema` validator to enforce payload shapes for both policy and budget events across runners.
+    - Extend the test suite with loop soft-breach scenarios that assert emitted stop reasons and `budget_breach` traces, plus PolicyStack enforcement tests under budget pressure.
+    - Introduce a dedicated cost normalization module (e.g., `pkgs/dsl/costs.py`) to avoid per-branch reimplementation and to centralize unit conversions.
+    - Provide adapter test doubles in fixtures to keep FlowRunner tests deterministic while exercising estimate/execute lifecycles.

--- a/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250427T160000Z-gpt5codex
+++ b/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250427T160000Z-gpt5codex
@@ -1,0 +1,115 @@
+version: 1
+id: 07b_budget_guards_and_runner_integration_P2
+title: Budget guards integrated in FlowRunner
+summary: Unify budget metering, manager orchestration, and runner traceability by merging the strongest concepts from divergent Codex branches into a cohesive FlowRunner implementation.
+description: >-
+  Reconcile the competing budget guard implementations by standardising cost normalization, adopting a reusable BudgetManager,
+  and wiring FlowRunner to emit schema-compliant policy and budget traces. The plan keeps adapters and PolicyStack integration
+  from the baseline while reusing structured telemetry and breach handling from the alternative branches.
+metadata:
+  owners: [pfahlr@gmail.com]
+  labels: [dsl, flow-runner, budget-guards]
+  priority: P2
+  risk: medium
+  last_updated: 2025-04-27
+  links:
+    - type: spec
+      url: https://github.com/pfahlr/ragx/blob/main/codex/specs/flow_runner_spec.yaml
+    - type: spec
+      url: https://github.com/pfahlr/ragx/blob/main/codex/specs/flow_runner_spec_ext.yaml
+strategy:
+  tests_first: true
+  deterministic: true
+  golden_management: manual
+scope:
+  goals:
+    - Normalise budget cost schemas and breach semantics across run, loop, node, and spec scopes.
+    - Integrate BudgetManager preflight/commit lifecycle with FlowRunner while preserving adapter and PolicyStack wiring.
+    - Emit deterministic budget and policy trace events that satisfy the DSL structured logging contract.
+    - Restore and extend automated tests covering budget meter limits, loop stop behaviour, and trace payload fidelity.
+  non_goals:
+    - Introducing asynchronous adapter execution or speculative concurrency features.
+    - Extending PolicyStack feature set beyond enforcing existing allowlist/denylist semantics.
+assumptions:
+  - Existing FlowRunner adapters remain synchronous and provide both estimate and execute hooks.
+  - Trace consumers expect JSONL payloads with immutable mappings as per current spec guidance.
+constraints:
+  - Preserve compatibility with `tests/e2e/test_runner_budget_stop.py` and related fixtures.
+  - Avoid altering CLI or configuration surfaces outside the DSL runner scope.
+component_ids:
+  - pkgs.dsl.budget
+  - pkgs.dsl.runner
+  - pkgs.dsl.trace
+  - tests.unit.budget
+  - tests.e2e.runner
+depends_on:
+  - 07a_policy_stack_refinement
+arg_spec:
+  - flow_id
+  - run_id
+config_flags:
+  - name: enforce_budgets
+    type: bool
+    default: true
+    desc: Toggle FlowRunner budget enforcement for diagnostic runs.
+    env: FLOW_RUNNER_ENFORCE_BUDGETS
+observability_requirements:
+  - Emit `budget_charge`, `budget_breach`, `policy_resolved`, and `policy_violation` events with immutable payloads.
+  - Capture loop iteration stop reasons and breach metadata in traces for postmortem analysis.
+structured_logging_contract:
+  format: jsonl
+  storage_path_prefix: logs/flow_runner/budgets
+  latest_symlink: logs/flow_runner/latest
+  retention: 30d
+  event_fields:
+    - event
+    - scope
+    - run_id
+    - node_id
+    - loop_iteration
+    - cost
+    - remaining
+    - overages
+    - stop_reason
+    - policy_stack_depth
+    - timestamp
+  metadata_fields:
+    - flow_id
+    - run_id
+    - environment
+    - tenant_id
+  volatile_fields:
+    - timestamp
+    - duration_ms
+ci:
+  xfail_marker: budget_guard_integration
+  workflows:
+    - name: ensure_green
+      gates:
+        - ./scripts/ensure_green.sh
+      artifacts:
+        - logs/flow_runner/budgets
+actions:
+  - stage: domain_model_alignment
+    summary: Consolidate budget cost models, breach outcomes, and supporting utilities into a single canonical module before wiring higher-level orchestration.
+    tasks:
+      - Refactor `pkgs/dsl/budget.py` to expose unified `BudgetSpec`, `CostSnapshot`, and `BudgetCharge` dataclasses adapted from codex/integrate-budget-guards-with-runner-zwi2ny and codex/integrate-budget-guards-with-runner-pbdel9.
+      - Extract a shared normalization helper (e.g., `pkgs/dsl/costs.py`) that converts seconds to milliseconds and validates metric keys, resolving conflicts across pbdel9, 8wxk32, and fa0vm9 branches.
+      - Reinstate deterministic soft/hard breach handling using `BudgetMode` semantics from codex/implement-budget-guards-with-test-first-approach-qhq0jq.
+  - stage: manager_and_trace_integration
+    summary: Introduce a cohesive BudgetManager and trace emission layer that coordinates scopes and reuses TraceWriter abstractions.
+    tasks:
+      - Implement BudgetManager preflight/commit lifecycle by adapting codex/implement-budget-guards-with-test-first-approach while storing scope state and remaining budgets via immutable snapshots.
+      - Create a shared `TraceEventEmitter` that wraps the TraceWriter from codex/integrate-budget-guards-with-runner-zwi2ny and enriches payloads with pbdel9 overage data.
+      - Add unit tests for BudgetManager, covering run/node/loop/spec scopes and soft-warning traces, extending `tests/unit/test_budget_meter_limits.py` and new fixtures as needed.
+  - stage: runner_execution_and_policy_wiring
+    summary: Rewire FlowRunner to consume the canonical BudgetManager, enforce policies, and emit end-to-end traces.
+    tasks:
+      - Integrate fa0vm9’s adapter protocol and loop stop signalling into the existing FlowRunner, ensuring stack safety and compatibility with PolicyStack enforcement from the baseline branch.
+      - Emit budget and policy trace events through the shared emitter, guaranteeing `policy_resolved`, `budget_charge`, and stop-reason events align with the structured logging contract.
+      - Restore end-to-end acceptance coverage by updating `tests/e2e/test_runner_budget_stop.py` and introducing regression tests for simultaneous policy violation and budget breach scenarios.
+acceptance:
+  - tests/unit/test_budget_meter_limits.py passes
+  - tests/unit/test_flow_runner_budget_manager.py passes
+  - tests/e2e/test_runner_budget_stop.py passes
+  - Structured traces validated against the TraceEventEmitter contract


### PR DESCRIPTION
## Summary
- add a P2 comparative review covering all budget guard branches with synthesis rationale
- capture a plan preview outlining reuse, conflicts, and redesign questions for FlowRunner budgets
- publish the schema-compliant final plan plus post-execution directives for follow-on implementation

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e8937d34ec832c8b4089b88d5c74a8