### PR TITLE
Add P2 synthesis review and plan for budget guard integration

### DIFF
--- a/codex/agents/POSTEXECUTION/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5
+++ b/codex/agents/POSTEXECUTION/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5
@@ -1,0 +1,18 @@
+post_execution_feedback:
+  was_successful: null
+  failed_tasks: []
+  recommended_revisions: []
+  synthesis_notes:
+    - reason: opportunity to consolidate trace emission logic across branches
+      recommendation: extract shared `trace_event_emitter` to shared module
+handoff_contract:
+  expected_consumer: gpt-5-codex
+  input_format: schema://codex/specs/schemas/full_task.schema.json
+  output_type: executable-python+unit-tests
+codex_directives:
+  must:
+    - reference branch contributions precisely
+    - verify all traceability expectations
+  do_not:
+    - hallucinate trace events
+    - assume success without validation

--- a/codex/agents/PREVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5
+++ b/codex/agents/PREVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5
@@ -1,0 +1,33 @@
+plan_preview:
+  branch_reuse:
+    - branch: codex/integrate-budget-guards-with-runner
+      elements:
+        - Preserve adapter-backed node execution, run/loop scaffolding, and baseline acceptance wiring as the integration backbone.
+    - branch: codex/integrate-budget-guards-with-runner-zwi2ny
+      elements:
+        - Reuse immutable budget models (`BudgetSpec`, `CostSnapshot`, `BudgetChargeOutcome`) and the `TraceWriter` abstraction for schema-aligned telemetry.
+    - branch: codex/integrate-budget-guards-with-runner-pbdel9
+      elements:
+        - Lift `BudgetCharge` remaining/overage accounting and immutable mapping-proxy payloads for diagnostic fidelity.
+    - branch: codex/implement-budget-guards-with-test-first-approach
+      elements:
+        - Integrate the layered `BudgetManager` preflight/commit orchestration plus warning aggregation hooks.
+    - branch: codex/implement-budget-guards-with-test-first-approach-8wxk32
+      elements:
+        - Reuse `BudgetDecision` snapshots, `NodeExecution` records, and deterministic id/time factories to keep the runner object-oriented and testable.
+    - branch: codex/implement-budget-guards-with-test-first-approach-fa0vm9
+      elements:
+        - Keep the `ToolAdapter` estimate/execute protocol, loop-context stack handling, and breach diagnostics as the realistic adapter surface.
+  conflicts_and_resolutions:
+    - Soft-budget semantics conflict across zwi2ny/pbdel9/8wxk32; resolve by centralising breach handling inside BudgetManager and ensuring runner inspects outcomes to enforce warn vs stop consistently.
+    - Cost normalization varies between seconds/milliseconds; consolidate into a single helper that accepts both and emits canonical milliseconds before persisting snapshots.
+    - Trace payload shapes diverge (mutable lists, custom event names); enforce a shared `TraceEventEmitter` that emits schema-validated immutable payloads for both policy and budget events.
+    - Runner branches disagree on adapter usage vs fabricated costs; require adapters in all execution paths and update tests to provide deterministic fake adapters.
+  policy_engine_redesign:
+    - Expose a policy trace emitter that mirrors the new budget trace pipeline so `push`/`pop`/`policy_resolved` events use the same immutable transport while remaining loosely coupled.
+    - Simplify PolicyStack enforcement hooks to accept normalized tool descriptors from the runner, preventing duplicate resolution logic within loop iterations.
+    - Document and enforce the combined policy+budget trace order in `docs/dsl/trace_contract.md` to avoid branch-specific inventions.
+  open_questions_and_tradeoffs:
+    - Should BudgetManager emit warnings for both run-level soft breaches and loop-level stop actions before halting execution, or should the runner coalesce warnings to reduce noise?
+    - Do we need to stream traces synchronously to external sinks (fa0vm9 style) or buffer them for deterministic unit tests (zwi2ny style); hybrid approach may require pluggable backpressure handling.
+    - How to surface simultaneous policy violations and budget breaches—raise both, prioritise policy, or expose composite trace events?

--- a/codex/agents/REVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5
+++ b/codex/agents/REVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5
@@ -1,0 +1,68 @@
+metadata:
+  reviewer: gpt-5-codex
+  repo: pfahlr/ragx
+  task: 07b_budget_guards_and_runner_integration
+  date: 2025-04-27
+comparative_review:
+  - branch: codex/integrate-budget-guards-with-runner
+    bullets:
+      - Maintains the original adapter-driven FlowRunner skeleton so node execution, loop control, and policy placeholders remain wired, giving us a dependable baseline for acceptance tests despite the lean budget API.
+      - Budget enforcement still hinges on mutable dict payloads and a single `BudgetBreachError`; it never differentiates run/node/loop scopes or soft vs hard semantics, so scope isolation and breach actions from the DSL spec are unmet.
+      - Trace emission is coarse (`record_event`-style) and omits immutable payloads or schema alignment; `policy_resolved` is not produced, leaving traceability expectations partially unsatisfied.
+      - Tests exercise only the pre-existing meter limits path; no dedicated loop stop or breach-action coverage means regressions around stop-on-soft budgets would slip through.
+  - branch: codex/integrate-budget-guards-with-runner-zwi2ny
+    bullets:
+      - Introduces immutable `BudgetSpec`/`CostSnapshot`/`BudgetChargeOutcome` models plus a `TraceWriter`, greatly improving data hygiene and observability hooks.
+      - `_execute_node` is stubbed to fabricate costs, severing adapters and making budget enforcement impossible to validate end-to-end; acceptance harnesses would fail because real tool execution disappears.
+      - Defaulting meters to `mode="hard"` while ignoring `breach_action` keeps soft budgets inert; loop stop behaviour therefore violates DSL semantics for warn/stop policies.
+      - Emits `budget_charge` and `budget_breach` events but invents payload shapes that diverge from the policy trace schema and omits `policy_resolved`, so cross-system trace fidelity remains broken.
+  - branch: codex/integrate-budget-guards-with-runner-pbdel9
+    bullets:
+      - Adds structured `BudgetCharge` payloads with `remaining`/`overages` plus `BudgetBreachHard`, giving downstream diagnostics the necessary context to display overrun metrics.
+      - `BudgetMeter.charge()` swallows breaches when `breach_action == "stop"`, and the runner never inspects the returned `breached` flag; loops therefore keep executing past hard stops, regressing enforcement guarantees.
+      - Trace payloads adopt immutable mapping proxies which align with observability requirements, yet the schema differs from DSL expectations (e.g., new event names) and policy traces remain absent.
+      - Time accounting mixes seconds and milliseconds without normalization, causing scope totals to drift between adapters and meters.
+      - Tests emphasise happy-path charging only; there is no regression asserting stop-on-breach or warning emission, so the failure above is uncaught.
+  - branch: codex/implement-budget-guards-with-test-first-approach
+    bullets:
+      - Supplies a comprehensive `BudgetManager` orchestrator with preflight/commit phases, warning aggregation, and hook points for run/node/loop scopes—the most modular abstraction among the branches.
+      - FlowRunner is gutted (`run`/`plan` raise `NotImplementedError`), so nothing actually exercises adapters or traces; this makes the branch unusable without additional integration work.
+      - Manager traces rely on bespoke events emitted via `emit_trace_event` but never reconcile with existing runner trace schemas or the policy stack; DSL contract alignment is deferred.
+      - The expanded unit suite covers manager edges (preview vs commit, warnings), yet end-to-end runner tests are disabled, leaving integration correctness unvalidated.
+  - branch: codex/implement-budget-guards-with-test-first-approach-qhq0jq
+    bullets:
+      - Re-centres on value objects—`BudgetMode`, `Cost`, `BudgetCheck`, `BudgetCharge`—with clear normalization helpers, clarifying soft vs hard semantics for each metric.
+      - FlowRunner fabricates node outputs and omits adapters/trace emitters; as a result, tool invocation, budget charging, and trace generation cannot be validated, regressing the integration contract.
+      - Loop reporting via `LoopSummary` improves observability, but the trace stream only publishes coarse run-level envelopes and never issues `policy_resolved`.
+      - Tests focus on budget math and summary reporting; there is still no coverage for policy enforcement or adapter errors, and fabricated outputs allow silent drift from the DSL spec.
+  - branch: codex/implement-budget-guards-with-test-first-approach-8wxk32
+    bullets:
+      - Evolves the qhq0jq domain into `BudgetDecision` snapshots, immutable `NodeExecution` records, and injectable time/id factories—strong foundations for deterministic, object-oriented runners.
+      - Budget time units silently switch to milliseconds while adapters still provide seconds, producing inconsistent spend tallies and breaking parity with earlier branches.
+      - Runner logic remains adapter-less; decisions never feed a trace sink, so warnings and stop hints are stranded in memory and violate traceability expectations.
+      - The richer test suite validates decision math but, again, lacks execution or policy coverage; stop-signal propagation across nested loops is untested.
+  - branch: codex/implement-budget-guards-with-test-first-approach-fa0vm9
+    bullets:
+      - Introduces a `ToolAdapter` protocol with `estimate_cost` vs `execute` phases and explicit loop-context stacks, finally reattaching budgets to adapters and surfacing `BudgetBreach` diagnostics.
+      - Trace handling accumulates events in mutable lists before optional sink forwarding; without immutable snapshots this breaks stack safety if shared across threads and diverges from DSL schemas.
+      - `BudgetMeter.charge()` mutates shared dictionaries and depends on adapters to normalise cost keys, risking cross-scope leakage and spec drift (time stored in ms, adapters emit seconds).
+      - Stop signals via `_LoopStopSignal` are promising yet bespoke; they should map to the DSL's canonical stop reason vocabulary to maintain consistency.
+      - Tests cover adapter orchestration paths but do not assert schema fidelity for emitted traces or combined policy/budget violations, leaving major acceptance gaps.
+redundancy_and_hallucination_check:
+  overlapping_patterns:
+    - Multiple branches independently implement cost normalization (`CostSnapshot`, `_normalize_cost`, `_normalize_float`) yet disagree on units; no branch fabricates entirely new budget concepts, but the duplicated helpers risk divergence.
+    - Several runners invent bespoke trace event names without updating schemas—these are genuine deviations, not hallucinations, but they must be normalised to the DSL contract.
+  hallucination_watch:
+    - No branch references non-existent spec fields; however, fabricated stop-reason enums (`_LoopStopSignal`, custom breach enums) lack supporting schema updates and must be treated as speculative.
+    - Preview/commit terminology from the BudgetManager branch is internally consistent, but downstream branches that removed the manager left dangling docstrings referencing commits—documentation drift should be corrected.
+synthesis_rationale:
+  - Adopt the typed budget models and TraceWriter abstraction from `codex/integrate-budget-guards-with-runner-zwi2ny` as the canonical data layer, because they enforce immutability and align with trace observability goals.
+  - Merge in the structured `BudgetCharge` diagnostics from `codex/integrate-budget-guards-with-runner-pbdel9` to preserve remaining/overage reporting, fixing stop-on-breach by inspecting outcomes in the runner.
+  - Reuse the `BudgetManager` orchestration pattern from `codex/implement-budget-guards-with-test-first-approach`, but back it with the object-oriented cost/decision model from `codex/implement-budget-guards-with-test-first-approach-8wxk32` to support predictive loop halts without losing adapter integration.
+  - Integrate the `ToolAdapter` protocol and loop stack wiring from `codex/implement-budget-guards-with-test-first-approach-fa0vm9`, tightening cost normalization and aligning stop signals with spec-approved reasons.
+  - Reinstate adapter-backed FlowRunner execution from the base branch while layering policy enforcement (missing in all variants) to satisfy traceability gates (`push`, `pop`, `policy_resolved`).
+optional_enhancements:
+  - Automate schema validation for runner and policy traces (jsonschema or pydantic-lite) to catch payload drift as new branches iterate.
+  - Introduce a shared `TraceEventEmitter` utility module referenced by both policy and budget layers to prevent the mutable-buffer regressions seen in fa0vm9.
+  - Expand tests with scenario matrices covering run/loop/node/spec scope combinations, ensuring both hard and soft budgets trigger expected traces and stop actions.
+  - Provide fixtures for adapter estimation vs execution to remove fabricated cost payloads and increase fidelity in integration tests.

--- a/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5
+++ b/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5
@@ -1,0 +1,90 @@
+version: 1
+id: 07b_budget_guards_and_runner_integration.plan
+title: Budget guards integrated with FlowRunner and policy traces
+summary: Unify budget data models, manager orchestration, and FlowRunner integration with policy-aligned tracing and acceptance coverage.
+description: |
+  Consolidate the strongest ideas from prior branches into a cohesive implementation that keeps FlowRunner adapter execution, adds a
+  reusable BudgetManager facade, and emits schema-aligned policy and budget traces. The work restores acceptance coverage while
+  preventing divergent cost normalization, soft-budget handling, and trace payload drift.
+metadata:
+  owners: [pfahlr@gmail.com]
+  labels: [dsl, budgets, runner]
+  priority: P1
+  risk: medium
+  last_updated: 2025-04-27
+  links:
+    - type: spec
+      url: https://github.com/pfahlr/ragx/blob/main/codex/specs/flow_runner_spec.yaml
+    - type: spec
+      url: https://github.com/pfahlr/ragx/blob/main/codex/specs/flow_runner_spec_ext.yaml
+strategy:
+  tests_first: true
+  deterministic: true
+  golden_management: manual
+scope:
+  goals:
+    - Unify budget data transfer objects (BudgetSpec, CostSnapshot, BudgetCharge/Decision) with consistent unit normalization and breach semantics.
+    - Integrate a BudgetManager that supports preflight/commit flows for run/node/loop/spec scopes while emitting immutable trace events.
+    - Wire FlowRunner to adapters, BudgetManager, and PolicyStack so `policy_resolved`, budget charge/breach, and loop stop traces satisfy the DSL contract.
+    - Expand unit and e2e coverage for hard/soft budgets, breach actions, and concurrent policy violations.
+  non_goals:
+    - Introducing asynchronous adapter execution or speculative budget prediction heuristics.
+    - Adding new DSL schema fields outside the published specifications.
+assumptions:
+  - Tool adapters exposed in existing tests remain synchronous and deterministic once wrapped with the new BudgetManager.
+  - PolicyStack APIs from task 07a remain stable and can be consumed without structural changes.
+constraints:
+  - Preserve the synchronous adapter interface defined in fa0vm9 while avoiding mutable trace buffers.
+  - Emit traces that validate against `codex/specs/schemas/dsl_trace_event.schema.json` to satisfy observability gating.
+structured_logging_contract:
+  format: jsonl
+  storage_path_prefix: logs/runner/budgets
+  latest_symlink: logs/runner/latest
+  retention: 30d
+  event_fields: [timestamp, event, scope_type, scope_id, run_id, node_id, payload]
+  metadata_fields: [flow_id, run_id, branch, build_sha]
+  volatile_fields: [timestamp]
+ci:
+  xfail_marker: xfail
+  workflows:
+    - name: ensure_green
+      gates: [ruff, mypy, yamllint, pytest]
+    - name: targeted_budgets
+      gates: [pytest]
+      artifacts: [coverage.xml]
+actions:
+  - stage: budget_domain_consolidation
+    summary: Establish canonical budget models, normalization helpers, and shared trace emitters.
+    tasks:
+      - execution_mode=always reusable=true :: Merge zwi2ny `BudgetSpec`/`CostSnapshot` with pbdel9 remaining/overage fields and 8wxk32 decision math inside pkgs/dsl/budget.py.
+      - execution_mode=always reusable=true :: Extract a shared TraceEventEmitter module that serves both budget and policy traces with immutable payloads.
+  - stage: manager_and_runner_integration
+    summary: Implement BudgetManager orchestration and wire FlowRunner with adapters, policies, and stop semantics.
+    tasks:
+      - execution_mode=always reusable=true :: Build BudgetManager preflight/commit APIs using test-first orchestration and integrate ToolAdapter estimate/execute hooks from fa0vm9.
+      - execution_mode=always reusable=false :: Thread BudgetManager into FlowRunner, enforce PolicyStack decisions, and honour breach_action stop/warn outcomes in loop/run scopes.
+  - stage: validation_and_observability
+    summary: Harden trace schema alignment and expand automated coverage.
+    tasks:
+      - execution_mode=always reusable=true :: Validate emitted traces against the DSL schema and document combined policy+budget ordering in docs/dsl/trace_contract.md.
+      - execution_mode=always reusable=false :: Add pytest coverage for loop hard-stop warnings, simultaneous policy violations, and multi-scope budget exhaustion (unit + e2e).
+acceptance:
+  - pytest tests/unit/test_budget_meter_limits.py
+  - pytest tests/unit/test_flow_runner_budget_manager.py
+  - pytest tests/e2e/test_runner_budget_stop.py
+  - pytest tests/unit/test_policy_stack_enforce.py
+  - pytest tests/e2e/test_runner_policy_budget_overlap.py
+structured_review_alignment:
+  reuse_sources:
+    - codex/integrate-budget-guards-with-runner
+    - codex/integrate-budget-guards-with-runner-zwi2ny
+    - codex/integrate-budget-guards-with-runner-pbdel9
+    - codex/implement-budget-guards-with-test-first-approach
+    - codex/implement-budget-guards-with-test-first-approach-8wxk32
+    - codex/implement-budget-guards-with-test-first-approach-fa0vm9
+  exclusions:
+    - Discard bespoke trace payload names introduced in pbdel9/fa0vm9 that lack schema support.
+    - Avoid mocked `_execute_node` implementations from zwi2ny/8wxk32 when integrating adapters.
+  outstanding_questions:
+    - Define how soft run-budget warnings combine with loop-level stop reasons without flooding the trace sink.
+    - Decide whether policy and budget traces share a sink instance or inject distinct writers referencing a shared emitter.


### PR DESCRIPTION
## Summary
- document comparative review across all budget-guard branches and identify reusable components
- outline P2 plan preview resolving branch conflicts and highlighting policy trace redesign questions
- author schema-compliant implementation plan and post-execution directives for runner-budget integration

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e8937d34ec832c8b4089b88d5c74a8