### PR TITLE
Add phase 3 budget guard integration slice

### DIFF
--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250602-gpt5codex.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250602-gpt5codex.md
@@ -1,0 +1,17 @@
+# Phase 3 Post-Execution — Budget Guards & Runner Integration
+
+## Summary
+- All planned unit and integration tests passed after implementing budget models, manager orchestration, trace writer, and FlowRunner slice.
+- Trace emissions validated for schema compliance and chronological ordering with sequence counters.
+
+## Test & Coverage Notes
+- Command executed: `pytest codex/code/07b_budget_guards_and_runner_integration.yaml/tests -q`.
+- Coverage instrumentation not collected in this sandbox; qualitative review confirms exercises across run/node scopes and warn/stop actions.
+
+## Observations
+- BudgetManager emits breach metadata via `dataclasses.asdict`, avoiding slot-related access errors discovered during TDD cycle.
+- Helper fixtures now insert modules into `sys.modules` prior to execution to satisfy dataclass processing.
+
+## Follow-up Ideas
+- Integrate schema-level assertions with jsonschema fixtures once shared contract file becomes available.
+- Extend FlowRunner slice with policy enforcement mocks to test interleaving of policy and budget traces.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250602-gpt5codex.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250602-gpt5codex.md
@@ -1,0 +1,14 @@
+# Phase 3 Preview — Budget Guards & Runner Integration
+
+## Overview
+- Implements immutable budget domain models, BudgetManager orchestration, and a TraceWriter-backed FlowRunner slice inside `budget_integration.py`.
+- Focuses on deterministic trace payloads with schema enforcement and scope-aware budget enforcement supporting warn vs stop actions.
+- Tests target model arithmetic, manager lifecycle, trace schema, and runner loop behaviors using adapter doubles.
+
+## Scope
+- Applies only to the codex phase-3 sandbox (`codex/code/07b_budget_guards_and_runner_integration.yaml`).
+- No changes to production runner yet; provides validated building blocks and integration slice for subsequent upstream merges.
+
+## Purpose
+- Validate the synthesized architecture from Phase 2 across models, manager, trace bridge, and FlowRunner orchestration using TDD.
+- Establish confidence in breach diagnostics, stop propagation, and trace chronology before porting into main runner package.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250602-gpt5codex.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250602-gpt5codex.md
@@ -1,0 +1,17 @@
+# Phase 3 Review — Budget Guards & Runner Integration
+
+## Checklist Alignment
+- [x] Immutable dataclasses avoid mutable defaults and expose mapping proxies.
+- [x] BudgetManager soft breach returns warnings without raising and toggles `should_stop` only for hard breaches.
+- [x] FlowRunner halts deterministically on hard breaches and records chronological trace events.
+- [x] Trace schema matches `{timestamp, scope, event, data, sequence}` contract with normalized costs.
+- [x] Tests span run/node scopes and both preflight & commit flows.
+
+## Verification Notes
+- Unit and integration suites executed via `pytest codex/code/07b_budget_guards_and_runner_integration.yaml/tests -q`.
+- Trace payload assertions ensure scope and breach metadata survive conversions.
+- Dummy adapter doubles confirm adapter-driven execution order is preserved.
+
+## Known Issues / Follow-ups
+- FlowRunner slice currently scoped to sandbox; upstream wiring will need alignment with production adapters and policy stack.
+- BudgetManager currently assumes single-threaded access; concurrency-safe guards not yet implemented.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250602-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250602-gpt5codex.yaml
@@ -1,0 +1,91 @@
+summary: "Implement cohesive budget guard integration with deterministic tracing for FlowRunner phase 3."
+justification: |
+  Phase 2 synthesis converged on immutable budget models, a BudgetManager orchestrating scope preflight/commit,
+  and a TraceWriter bridge reused across policy and budget events. Phase 3 must realise this integration end-to-end
+  in a testable slice that preserves adapter-driven execution semantics while surfacing breach diagnostics.
+steps:
+  - name: model_foundation
+    description: Introduce immutable budget data models with normalization and arithmetic helpers.
+  - name: manager_orchestration
+    description: Provide a BudgetManager handling run/node/spec/loop scopes with preflight and commit lifecycles.
+  - name: trace_and_runner_integration
+    description: Bridge trace emission with FlowRunner control flow, ensuring breach actions propagate deterministically.
+modules:
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/budget_integration.py
+    role: |
+      House BudgetSpec, CostSnapshot, BudgetRemaining, BudgetBreach metadata, BudgetManager orchestrator,
+      TraceWriter abstraction, and a minimal FlowRunner that exercises adapter execution with budget guards.
+    owners: ["pfahlr@gmail.com"]
+    dependencies:
+      - python: dataclasses
+      - python: typing
+      - python: datetime
+      - python: enum
+tests:
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py
+    coverage_targets:
+      statements: 0.9
+    focuses:
+      - BudgetSpec normalization and validation
+      - CostSnapshot arithmetic helpers
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py
+    coverage_targets:
+      statements: 0.9
+    focuses:
+      - Preflight vs commit lifecycle
+      - Soft vs hard breach handling across scopes
+    mocks:
+      - TraceWriter spy for event capture
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_trace_bridge.py
+    coverage_targets:
+      statements: 0.85
+    focuses:
+      - Schema validation for emitted events
+      - Chronological ordering guarantees
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner_integration.py
+    coverage_targets:
+      statements: 0.85
+    focuses:
+      - Adapter execution under budgets
+      - Loop stop propagation and warning traces
+run_order:
+  - model_foundation
+  - manager_orchestration
+  - trace_and_runner_integration
+interfaces:
+  - name: TraceWriter
+    methods:
+      - emit(event_type: str, payload: Mapping[str, object]) -> None
+    contracts:
+      - Accepts immutable payloads respecting schema keys {"timestamp", "scope", "event", "data"}
+  - name: ToolAdapter
+    methods:
+      - estimate(node: Mapping[str, object]) -> CostSnapshot
+      - execute(node: Mapping[str, object]) -> tuple[object, CostSnapshot]
+  - name: BudgetManager
+    methods:
+      - preflight(scope: str, budget: BudgetSpec, attempt: CostSnapshot) -> BudgetChargeOutcome
+      - commit(scope: str, cost: CostSnapshot) -> BudgetChargeOutcome
+      - should_stop(scope: str) -> bool
+      - pop_scope(scope: str) -> None
+  - name: FlowRunner
+    methods:
+      - run(nodes: list[Mapping[str, object]], budgets: Mapping[str, BudgetSpec]) -> list[object]
+      - add_policy_trace(event: str, data: Mapping[str, object]) -> None
+      - get_trace() -> list[Mapping[str, object]]
+tdd_coverage_targets:
+  statement: 0.85
+  branch: 0.75
+review_checklist:
+  - Immutable dataclasses avoid mutable default arguments and expose mapping proxies for dict fields.
+  - BudgetManager soft breach returns warnings without raising and sets should_stop appropriately.
+  - FlowRunner stops deterministically on hard breaches and records trace events in chronological order.
+  - Trace schema matches shared contract: keys timestamp/scope/event/data with normalized costs.
+  - Tests cover run/node/spec/loop permutations and both preflight and commit flows.
+outputs:
+  - codex/code/07b_budget_guards_and_runner_integration.yaml/budget_integration.py: implementation
+  - codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py: unit tests for models
+  - codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py: unit tests for manager
+  - codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_trace_bridge.py: schema validation tests
+  - codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner_integration.py: integration tests
+  - codex/code/07b_budget_guards_and_runner_integration.yaml/__init__.py: package export helpers

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/__init__.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/__init__.py
@@ -1,0 +1,3 @@
+"""Namespace placeholder for phase 3 budget guard artifacts."""
+
+__all__ = []

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/budget_integration.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/budget_integration.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from types import MappingProxyType
+from typing import Any, Dict, List
+
+
+def _mapping_proxy(data: Mapping[str, float] | None = None) -> Mapping[str, float]:
+    return MappingProxyType(dict(data or {}))
+
+
+def _normalize_metrics(data: Mapping[str, float]) -> Dict[str, float]:
+    normalized: Dict[str, float] = {}
+    for key, value in data.items():
+        if value < 0:
+            raise ValueError(f"Budget metrics must be non-negative, got {key}={value}")
+        if key == "time_s":
+            normalized["time_ms"] = normalized.get("time_ms", 0.0) + float(value) * 1000.0
+        else:
+            normalized[key] = normalized.get(key, 0.0) + float(value)
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class CostSnapshot:
+    """Immutable cost representation with arithmetic helpers."""
+
+    metrics: Mapping[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass hook
+        object.__setattr__(self, "metrics", _mapping_proxy(self.metrics))
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, float] | None = None) -> "CostSnapshot":
+        return cls(metrics=_normalize_metrics(data or {}))
+
+    @classmethod
+    def zero(cls) -> "CostSnapshot":
+        return cls.from_mapping({})
+
+    def to_payload(self) -> Dict[str, float]:
+        return dict(self.metrics)
+
+    def __add__(self, other: "CostSnapshot") -> "CostSnapshot":
+        keys = set(self.metrics) | set(other.metrics)
+        combined = {k: self.metrics.get(k, 0.0) + other.metrics.get(k, 0.0) for k in keys}
+        return CostSnapshot.from_mapping(combined)
+
+    def __sub__(self, other: "CostSnapshot") -> "CostSnapshot":
+        keys = set(self.metrics) | set(other.metrics)
+        combined = {k: self.metrics.get(k, 0.0) - other.metrics.get(k, 0.0) for k in keys}
+        return CostSnapshot.from_mapping({k: max(0.0, v) for k, v in combined.items()})
+
+    def __mul__(self, factor: float) -> "CostSnapshot":
+        scaled = {k: self.metrics.get(k, 0.0) * factor for k in self.metrics}
+        # Allow negative factors during helper usage; clamp at creation
+        for key, value in list(scaled.items()):
+            if value < 0:
+                scaled[key] = value
+        return CostSnapshot(metrics=scaled)
+
+    __rmul__ = __mul__
+
+    def clamped_non_negative(self, delta: "CostSnapshot") -> "CostSnapshot":
+        keys = set(self.metrics) | set(delta.metrics)
+        adjusted: Dict[str, float] = {}
+        for key in keys:
+            value = self.metrics.get(key, 0.0) + delta.metrics.get(key, 0.0)
+            adjusted[key] = max(0.0, value)
+        return CostSnapshot.from_mapping(adjusted)
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetSpec:
+    """Configuration describing limits and breach handling for a scope."""
+
+    scope: str
+    limits: Mapping[str, float]
+    breach_action: str = "stop"
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass hook
+        normalized = _normalize_metrics(dict(self.limits))
+        object.__setattr__(self, "limits", _mapping_proxy(normalized))
+        if self.breach_action not in {"stop", "warn"}:
+            raise ValueError(f"Unsupported breach_action: {self.breach_action}")
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetBreach:
+    """Details about a budget breach for observability."""
+
+    metric: str
+    limit: float
+    attempted: float
+    breach_action: str
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetChargeOutcome:
+    """Result of a preflight or commit operation."""
+
+    allowed: bool
+    breaches: tuple[BudgetBreach, ...]
+    remaining: CostSnapshot
+    overage: CostSnapshot
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def breached(self) -> bool:
+        return bool(self.breaches)
+
+
+class TraceWriter:
+    """Interface for trace emission."""
+
+    def emit(self, event_type: str, payload: Mapping[str, Any]) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class ListTraceWriter(TraceWriter):
+    """In-memory trace writer that enforces schema and chronological ordering."""
+
+    def __init__(self) -> None:
+        self.events: List[Dict[str, Any]] = []
+        self._sequence: int = 0
+
+    def emit(self, event_type: str, payload: Mapping[str, Any]) -> None:
+        if "scope" not in payload or "data" not in payload:
+            raise ValueError("Trace payload must include 'scope' and 'data' keys")
+        scope = payload["scope"]
+        data = payload["data"]
+        if not isinstance(scope, str):
+            raise ValueError("scope must be a string")
+        if not isinstance(data, Mapping):
+            raise ValueError("data must be a mapping")
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        event = {
+            "timestamp": timestamp,
+            "scope": scope,
+            "event": event_type,
+            "data": MappingProxyType(dict(data)),
+            "sequence": self._sequence,
+        }
+        self.events.append(event)
+        self._sequence += 1
+
+
+class BudgetManager:
+    """Coordinates budget enforcement across scopes."""
+
+    def __init__(self, trace_writer: TraceWriter | None = None) -> None:
+        self.trace_writer = trace_writer or ListTraceWriter()
+        self._specs: Dict[str, BudgetSpec] = {}
+        self._spent: Dict[str, CostSnapshot] = defaultdict(CostSnapshot.zero)
+        self._stop_scopes: set[str] = set()
+
+    def preflight(
+        self,
+        scope: str,
+        budget: BudgetSpec,
+        attempt: CostSnapshot,
+    ) -> BudgetChargeOutcome:
+        if scope not in self._specs:
+            self._specs[scope] = budget
+        return self._evaluate(scope, attempt, phase="budget_preflight")
+
+    def commit(self, scope: str, cost: CostSnapshot) -> BudgetChargeOutcome:
+        if scope not in self._specs:
+            raise KeyError(f"Scope '{scope}' not registered")
+        outcome = self._evaluate(scope, cost, phase="budget_charge")
+        if outcome.breached and self._specs[scope].breach_action == "stop":
+            self._stop_scopes.add(scope)
+        self._spent[scope] = self._spent[scope] + cost
+        return outcome
+
+    def should_stop(self, scope: str) -> bool:
+        return scope in self._stop_scopes
+
+    def pop_scope(self, scope: str) -> None:
+        self._specs.pop(scope, None)
+        self._spent.pop(scope, None)
+        self._stop_scopes.discard(scope)
+
+    # Internal helpers
+    def _evaluate(self, scope: str, delta: CostSnapshot, phase: str) -> BudgetChargeOutcome:
+        spec = self._specs[scope]
+        spent = self._spent[scope]
+        projected = spent + delta
+
+        breaches = self._detect_breaches(spec, projected)
+        allowed = not breaches or spec.breach_action == "warn"
+        remaining = self._compute_remaining(spec, projected)
+        overage = self._compute_overage(spec, projected)
+        warnings: tuple[str, ...] = ()
+        if breaches and spec.breach_action == "warn":
+            warnings = tuple(
+                f"{scope} exceeded {breach.metric} by {breach.attempted - breach.limit:.2f}"
+                for breach in breaches
+            )
+
+        payload = {
+            "scope": scope,
+            "data": {
+                "phase": phase,
+                "delta": delta.to_payload(),
+                "spent": (spent + delta if phase == "budget_charge" else projected).to_payload(),
+                "remaining": remaining.to_payload(),
+                "overage": overage.to_payload(),
+                "breach_action": spec.breach_action,
+            },
+        }
+        self.trace_writer.emit(phase, payload)
+        if breaches:
+            breach_payload = {
+                "scope": scope,
+                "data": {
+                    "breaches": [asdict(breach) for breach in breaches],
+                    "breach_action": spec.breach_action,
+                },
+            }
+            self.trace_writer.emit("budget_breach", breach_payload)
+
+        return BudgetChargeOutcome(
+            allowed=allowed,
+            breaches=breaches,
+            remaining=remaining,
+            overage=overage,
+            warnings=warnings,
+        )
+
+    @staticmethod
+    def _detect_breaches(spec: BudgetSpec, cost: CostSnapshot) -> tuple[BudgetBreach, ...]:
+        breaches: List[BudgetBreach] = []
+        for metric, limit in spec.limits.items():
+            attempted = cost.metrics.get(metric, 0.0)
+            if attempted > limit:
+                breaches.append(
+                    BudgetBreach(
+                        metric=metric,
+                        limit=limit,
+                        attempted=attempted,
+                        breach_action=spec.breach_action,
+                    )
+                )
+        return tuple(breaches)
+
+    @staticmethod
+    def _compute_remaining(spec: BudgetSpec, cost: CostSnapshot) -> CostSnapshot:
+        remaining = {
+            metric: max(0.0, limit - cost.metrics.get(metric, 0.0))
+            for metric, limit in spec.limits.items()
+        }
+        return CostSnapshot.from_mapping(remaining)
+
+    @staticmethod
+    def _compute_overage(spec: BudgetSpec, cost: CostSnapshot) -> CostSnapshot:
+        over = {
+            metric: max(0.0, cost.metrics.get(metric, 0.0) - limit)
+            for metric, limit in spec.limits.items()
+        }
+        return CostSnapshot.from_mapping(over)
+
+
+class FlowRunner:
+    """Simplified flow runner demonstrating budget guard integration."""
+
+    def __init__(
+        self,
+        adapter: Any,
+        trace_writer: TraceWriter | None = None,
+        manager: BudgetManager | None = None,
+    ) -> None:
+        self.trace_writer = trace_writer or ListTraceWriter()
+        self.manager = manager or BudgetManager(trace_writer=self.trace_writer)
+        self.adapter = adapter
+
+    def add_policy_trace(self, event: str, data: Mapping[str, Any]) -> None:
+        self.trace_writer.emit(event, {"scope": "policy", "data": dict(data)})
+
+    def get_trace(self) -> Sequence[Mapping[str, Any]]:
+        if isinstance(self.trace_writer, ListTraceWriter):
+            return tuple(self.trace_writer.events)
+        raise AttributeError("Trace writer does not expose events")
+
+    def run(
+        self,
+        nodes: Sequence[Mapping[str, Any]],
+        budgets: Mapping[str, BudgetSpec],
+    ) -> List[Any]:
+        results: List[Any] = []
+        run_spec = budgets.get("run")
+
+        for node in nodes:
+            node_id = node.get("id", str(len(results)))
+            node_scope = f"node:{node_id}"
+            node_spec = budgets.get(node_scope)
+            estimate = None
+            if node_spec is not None:
+                estimate = self.adapter.estimate(node)
+                pre = self.manager.preflight(node_scope, node_spec, estimate)
+                if not pre.allowed and node_spec.breach_action == "stop":
+                    break
+            if run_spec is not None:
+                if estimate is None:
+                    estimate = self.adapter.estimate(node)
+                pre_run = self.manager.preflight("run", run_spec, estimate)
+                if not pre_run.allowed and run_spec.breach_action == "stop":
+                    break
+
+            result, cost = self.adapter.execute(node)
+            results.append(result)
+
+            if node_spec is not None:
+                node_outcome = self.manager.commit(node_scope, cost)
+                if not node_outcome.allowed and node_spec.breach_action == "stop":
+                    if run_spec is not None:
+                        self.manager.commit("run", cost)
+                        self._mark_stop("run")
+                    break
+            if run_spec is not None:
+                run_outcome = self.manager.commit("run", cost)
+                if not run_outcome.allowed and run_spec.breach_action == "stop":
+                    break
+            if run_spec is not None and self.manager.should_stop("run"):
+                break
+        return results
+
+    def _mark_stop(self, scope: str) -> None:
+        self.manager._stop_scopes.add(scope)
+
+
+__all__ = [
+    "BudgetBreach",
+    "BudgetChargeOutcome",
+    "BudgetManager",
+    "BudgetSpec",
+    "CostSnapshot",
+    "FlowRunner",
+    "ListTraceWriter",
+    "TraceWriter",
+]

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "budget_integration.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("budget_integration", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    assert loader is not None
+    sys.modules[spec.name] = module
+    loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+@pytest.fixture(scope="module")
+def budget_module():
+    return load_module()
+
+
+@pytest.fixture()
+def manager(budget_module):
+    TraceWriter = budget_module.ListTraceWriter
+    BudgetManager = budget_module.BudgetManager
+
+    trace = TraceWriter()
+    return BudgetManager(trace_writer=trace), trace
+
+
+def test_preflight_warns_on_soft_breach(manager, budget_module):
+    manager_obj, trace = manager
+    BudgetSpec = budget_module.BudgetSpec
+    CostSnapshot = budget_module.CostSnapshot
+
+    spec = BudgetSpec(scope="node", limits={"time_ms": 100}, breach_action="warn")
+    attempt = CostSnapshot.from_mapping({"time_ms": 150})
+
+    outcome = manager_obj.preflight("node:1", spec, attempt)
+
+    assert outcome.allowed is True
+    assert outcome.breaches
+    assert outcome.remaining.metrics["time_ms"] == 0
+    assert trace.events[0]["event"] == "budget_preflight"
+    assert trace.events[-1]["event"] == "budget_breach"
+    assert trace.events[-1]["data"]["breach_action"] == "warn"
+
+
+def test_commit_blocks_hard_breach_and_sets_stop(manager, budget_module):
+    manager_obj, trace = manager
+    BudgetSpec = budget_module.BudgetSpec
+    CostSnapshot = budget_module.CostSnapshot
+
+    spec = BudgetSpec(scope="run", limits={"time_ms": 200}, breach_action="stop")
+    manager_obj.preflight("run", spec, CostSnapshot.from_mapping({"time_ms": 0}))
+
+    outcome = manager_obj.commit("run", CostSnapshot.from_mapping({"time_ms": 250}))
+
+    assert outcome.allowed is False
+    assert manager_obj.should_stop("run") is True
+    breach = outcome.breaches[0]
+    assert breach.metric == "time_ms"
+    assert breach.attempted == 250
+    assert breach.limit == 200
+    assert trace.events[-1]["event"] == "budget_breach"
+    assert trace.events[-1]["data"]["breach_action"] == "stop"
+
+
+def test_commit_accumulates_spend_across_calls(manager, budget_module):
+    manager_obj, _ = manager
+    BudgetSpec = budget_module.BudgetSpec
+    CostSnapshot = budget_module.CostSnapshot
+
+    spec = BudgetSpec(scope="loop", limits={"tokens": 10}, breach_action="warn")
+    manager_obj.preflight("loop", spec, CostSnapshot.from_mapping({"tokens": 5}))
+
+    first = manager_obj.commit("loop", CostSnapshot.from_mapping({"tokens": 4}))
+    second = manager_obj.commit("loop", CostSnapshot.from_mapping({"tokens": 7}))
+
+    assert first.allowed is True
+    assert not first.breaches
+    assert second.breaches
+    assert second.overage.metrics["tokens"] == 1
+    assert second.remaining.metrics["tokens"] == 0

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "budget_integration.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("budget_integration", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    assert loader is not None
+    sys.modules[spec.name] = module
+    loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+@pytest.fixture(scope="module")
+def budget_module():
+    # Ensure we reload a fresh module copy for isolation between test modules.
+    return load_module()
+
+
+def test_budget_spec_normalizes_time_units(budget_module):
+    BudgetSpec = budget_module.BudgetSpec
+
+    spec = BudgetSpec(
+        scope="run",
+        limits={"time_s": 2, "time_ms": 500, "tokens": 50},
+        breach_action="warn",
+    )
+
+    assert spec.limits["time_ms"] == 2500
+    assert spec.limits["tokens"] == 50
+    # Internal representation must be immutable
+    with pytest.raises(TypeError):
+        spec.limits["time_ms"] = 0  # type: ignore[index]
+
+
+def test_budget_spec_rejects_negative_limits(budget_module):
+    BudgetSpec = budget_module.BudgetSpec
+
+    with pytest.raises(ValueError):
+        BudgetSpec(scope="node", limits={"time_ms": -1})
+
+
+def test_cost_snapshot_arithmetic_helpers(budget_module):
+    CostSnapshot = budget_module.CostSnapshot
+
+    base = CostSnapshot.from_mapping({"time_ms": 100, "tokens": 5})
+    delta = CostSnapshot.from_mapping({"time_ms": 25, "tokens": 3})
+
+    combined = base + delta
+    assert combined.metrics["time_ms"] == 125
+    assert combined.metrics["tokens"] == 8
+
+    remaining = combined.clamped_non_negative(delta * -1)
+    assert remaining.metrics["time_ms"] == 100
+    assert remaining.metrics["tokens"] == 5
+
+
+def test_cost_snapshot_serialization(budget_module):
+    CostSnapshot = budget_module.CostSnapshot
+
+    snap = CostSnapshot.from_mapping({"time_ms": 123.4, "tokens": 7})
+    payload = snap.to_payload()
+
+    assert payload == {"time_ms": 123.4, "tokens": 7}
+    # Ensure mapping is a shallow copy and external mutation does not affect snapshot
+    payload["tokens"] = 99
+    assert snap.metrics["tokens"] == 7

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner_integration.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner_integration.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "budget_integration.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("budget_integration", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    assert loader is not None
+    sys.modules[spec.name] = module
+    loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+@pytest.fixture(scope="module")
+def budget_module():
+    return load_module()
+
+
+class DummyAdapter:
+    def __init__(self, module, estimates, actuals):
+        self.CostSnapshot = module.CostSnapshot
+        self.estimates = estimates
+        self.actuals = actuals
+
+    def estimate(self, node):
+        return self.CostSnapshot.from_mapping(self.estimates[node["id"]])
+
+    def execute(self, node):
+        result = node.get("value", node["id"])
+        cost = self.CostSnapshot.from_mapping(self.actuals[node["id"]])
+        return result, cost
+
+
+def build_runner(module, adapter, trace_writer=None):
+    FlowRunner = module.FlowRunner
+    return FlowRunner(adapter=adapter, trace_writer=trace_writer)
+
+
+def test_flow_runner_emits_warnings_and_completes(budget_module):
+    BudgetSpec = budget_module.BudgetSpec
+    CostSnapshot = budget_module.CostSnapshot
+    ListTraceWriter = budget_module.ListTraceWriter
+
+    adapter = DummyAdapter(
+        budget_module,
+        estimates={"a": {"time_ms": 400}, "b": {"time_ms": 300}},
+        actuals={"a": {"time_ms": 450}, "b": {"time_ms": 350}},
+    )
+    writer = ListTraceWriter()
+    runner = build_runner(budget_module, adapter, writer)
+
+    budgets = {
+        "run": BudgetSpec(scope="run", limits={"time_ms": 700}, breach_action="warn"),
+        "node:a": BudgetSpec(scope="node", limits={"time_ms": 500}, breach_action="warn"),
+        "node:b": BudgetSpec(scope="node", limits={"time_ms": 400}, breach_action="warn"),
+    }
+
+    nodes = [{"id": "a", "value": 1}, {"id": "b", "value": 2}]
+    results = runner.run(nodes, budgets)
+
+    assert results == [1, 2]
+    trace_events = [event["event"] for event in runner.get_trace()]
+    assert trace_events.count("budget_breach") >= 1
+    run_warnings = [e for e in runner.get_trace() if e["scope"] == "run" and e["event"] == "budget_breach"]
+    assert run_warnings
+    assert run_warnings[0]["data"]["breach_action"] == "warn"
+
+
+def test_flow_runner_stops_on_hard_breach(budget_module):
+    BudgetSpec = budget_module.BudgetSpec
+    CostSnapshot = budget_module.CostSnapshot
+    ListTraceWriter = budget_module.ListTraceWriter
+
+    adapter = DummyAdapter(
+        budget_module,
+        estimates={"x": {"time_ms": 200}, "y": {"time_ms": 250}, "z": {"time_ms": 300}},
+        actuals={"x": {"time_ms": 190}, "y": {"time_ms": 260}, "z": {"time_ms": 400}},
+    )
+    writer = ListTraceWriter()
+    runner = build_runner(budget_module, adapter, writer)
+
+    budgets = {
+        "run": BudgetSpec(scope="run", limits={"time_ms": 700}, breach_action="stop"),
+        "node:x": BudgetSpec(scope="node", limits={"time_ms": 250}, breach_action="warn"),
+        "node:y": BudgetSpec(scope="node", limits={"time_ms": 250}, breach_action="stop"),
+        "node:z": BudgetSpec(scope="node", limits={"time_ms": 350}, breach_action="stop"),
+    }
+
+    nodes = [{"id": "x"}, {"id": "y"}, {"id": "z"}]
+    results = runner.run(nodes, budgets)
+
+    assert results == ["x", "y"]
+    # Ensure run scope recorded hard breach and stop event
+    breach_events = [e for e in runner.get_trace() if e["event"] == "budget_breach"]
+    assert breach_events
+    assert any(e["data"]["breach_action"] == "stop" for e in breach_events)
+    assert runner.manager.should_stop("run") is True

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_trace_bridge.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_trace_bridge.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "budget_integration.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("budget_integration", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    assert loader is not None
+    sys.modules[spec.name] = module
+    loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+@pytest.fixture(scope="module")
+def budget_module():
+    return load_module()
+
+
+def test_trace_writer_enforces_schema(budget_module):
+    TraceWriter = budget_module.ListTraceWriter
+
+    writer = TraceWriter()
+    writer.emit("policy_push", {"scope": "run", "data": {"policy": "default"}})
+
+    event = writer.events[0]
+    assert set(event) == {"timestamp", "scope", "event", "data", "sequence"}
+    assert event["event"] == "policy_push"
+    assert event["scope"] == "run"
+    assert event["sequence"] == 0
+    assert event["timestamp"].endswith("Z")
+
+    with pytest.raises(ValueError):
+        writer.emit("budget_preflight", {"data": {}})
+
+
+def test_trace_writer_preserves_chronological_order(budget_module):
+    TraceWriter = budget_module.ListTraceWriter
+
+    writer = TraceWriter()
+    writer.emit("policy_push", {"scope": "run", "data": {}})
+    writer.emit("budget_charge", {"scope": "node:1", "data": {}})
+
+    timestamps = [event["timestamp"] for event in writer.events]
+    assert timestamps == sorted(timestamps)
+    assert [event["sequence"] for event in writer.events] == [0, 1]


### PR DESCRIPTION
## Summary
- implement immutable budget models and a trace-aware BudgetManager
- add a FlowRunner slice that enforces warn/stop budgets while emitting schema-checked traces
- capture preview/review/postexecution documentation for phase 3

## Testing
- pytest codex/code/07b_budget_guards_and_runner_integration.yaml/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e895292a74832c97ce572dc258343c