### PR TITLE
Implement budget manager and FlowRunner integration harness

### DIFF
--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
@@ -1,0 +1,13 @@
+# Phase 3 Post-Execution — 07b_budget_guards_and_runner_integration
+
+## Execution Notes
+- All planned unit tests executed successfully via `pytest codex/code/07b_budget_guards_and_runner_integration.yaml/tests -q`.
+- Trace inspection confirmed spec-level preflight breaches produce dedicated `budget_breach` events alongside node-level warnings.
+- Warning aggregation verified that run-level warnings emit once even when multiple nodes exceed the soft budget.
+
+## Coverage & Validation
+- Targeted tests cover value objects, manager semantics, and FlowRunner integration. No additional coverage tooling was run; pytest assertions ensure behaviour parity with the review checklist.
+
+## Follow-up Recommendations
+- Consider upstreaming the trace schema dictionary to a shared observability module to avoid duplication across future phases.
+- Extend FlowRunner scenarios with nested loops or spec combinations once broader DSL contracts are available.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
@@ -1,0 +1,15 @@
+# Phase 3 Preview — 07b_budget_guards_and_runner_integration
+
+## Overview
+- Implemented canonical budget value objects (`BudgetSpec`, `CostSnapshot`, `BudgetDecision`) with strict millisecond normalization and immutable payload helpers.
+- Built a scope-aware `BudgetManager` coordinating preflight/commit enforcement with warning aggregation and immutable snapshots.
+- Added a schema-validated `TraceEventEmitter` to unify policy and budget telemetry.
+- Wired a simplified, adapter-driven `FlowRunner` that exercises run/spec/loop/node budgets, orchestrates policy traces, and propagates breach diagnostics to stop reasons.
+
+## Planned Test Coverage
+- Unit tests target budget models, manager semantics, and FlowRunner end-to-end budget behaviour with mocked adapters.
+- Trace schema validation is performed inline via emitter enforcement, ensuring payload parity across events.
+
+## Dependencies & Assumptions
+- Tests rely on lightweight loader helpers to import modules from the task-specific directory without polluting global packages.
+- Flow specifications in tests model sequential node execution; parallelism and asynchronous adapters remain out of scope for this phase.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
@@ -1,0 +1,18 @@
+# Phase 3 Review — 07b_budget_guards_and_runner_integration
+
+## Summary
+- Budget models normalise all limits/costs to milliseconds and expose immutable payload projections for trace usage.
+- BudgetManager tracks run/spec/loop/node scopes, differentiating warn vs stop behaviour and capturing warnings without duplicates.
+- TraceEventEmitter validates schema compliance for policy and budget events, ensuring deterministic payload shapes.
+- FlowRunner integrates adapters, policy stack, and BudgetManager to surface stop reasons, warnings, and trace emissions.
+
+## Verification Checklist
+- [x] Budget normalization matches milliseconds-only contract (unit tests in `test_budget_models.py`).
+- [x] Hard vs soft breach actions propagate correctly to run results and traces (`test_budget_manager.py`, `test_flow_runner.py`).
+- [x] Trace payloads satisfy schema validation for policy and budget events (emitter enforces schema; exercised in integration tests).
+- [x] FlowRunner preserves adapter execution order when budgets permit (integration tests ensure node sequencing and outputs).
+- [x] Warnings accumulate deterministically without duplicate emissions (manager warning aggregation verified in tests).
+
+## Known Issues / Follow-ups
+- Current FlowRunner assumes sequential node execution and synchronous adapters; concurrency handling remains future work.
+- Trace emitter schema is local to this task directory; upstream integration should reconcile with global observability schemas.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.yaml
@@ -1,0 +1,107 @@
+summary: Integrate typed budget management and traceable FlowRunner collaboration for Phase 3
+justification: |
+  Phase 2 converged on typed budget models, a reusable BudgetManager, and adapter-driven FlowRunner
+  orchestration. Phase 3 needs executable code plus coverage that proves run/node/spec/loop budgets
+  and trace emissions behave deterministically. The plan lifts the synthesised architecture into a
+  small, testable code surface that mirrors the branch synthesis decisions while remaining sandbox
+  friendly.
+steps:
+  - id: design_budget_models
+    description: Port immutable budget data models with normalization helpers and arithmetic.
+  - id: implement_budget_manager
+    description: Build BudgetManager preflight/commit orchestration enforcing scope budgets.
+    depends_on: [design_budget_models]
+  - id: implement_trace_emitter
+    description: Provide schema-enforced trace emitter for policy and budget events.
+    depends_on: [design_budget_models]
+  - id: integrate_flow_runner
+    description: Wire FlowRunner to adapters, policy stack, and BudgetManager with trace outputs.
+    depends_on: [implement_budget_manager, implement_trace_emitter]
+modules:
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/budget_models.py
+    role: Canonical budget value objects
+    responsibilities:
+      - Normalize cost inputs to milliseconds and expose arithmetic helpers.
+      - Represent BudgetSpec, BudgetDecision, and BudgetBreach snapshots immutably.
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/budget_manager.py
+    role: Scope-aware budget enforcement
+    responsibilities:
+      - Register scopes for run/node/spec/loop budgets.
+      - Provide preflight and commit evaluations returning immutable decisions and breaches.
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/trace_emitter.py
+    role: Schema-validated trace bridge
+    responsibilities:
+      - Emit policy and budget trace events with deterministic payloads.
+      - Validate payload schema at emit time for observability parity.
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/flow_runner.py
+    role: Adapter-driven FlowRunner integration point
+    responsibilities:
+      - Execute nodes using adapters while consulting BudgetManager.
+      - Coordinate policy stack traces and propagate breach decisions into stop reasons.
+      - Surface run results with warnings and stop diagnostics.
+tests:
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py
+    targets: [budget_models]
+    coverage: 0.9
+    mocks: []
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py
+    targets: [budget_manager, budget_models]
+    coverage: 0.9
+    mocks: []
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner.py
+    targets: [flow_runner, budget_manager, trace_emitter]
+    coverage: 0.85
+    mocks:
+      - Fake adapters implementing estimate_cost/execute
+      - In-memory TraceEventEmitter spy
+run_order:
+  - codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py
+  - codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py
+  - codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner.py
+interfaces:
+  - name: CostSnapshot
+    inputs: duration_ms|duration_seconds|cost_payload
+    outputs: immutable cost values with arithmetic helpers
+  - name: BudgetManager
+    inputs: scope registrations, preflight/commit requests with CostSnapshot
+    outputs: BudgetDecision outcomes, BudgetBreach metadata
+  - name: TraceEventEmitter
+    inputs: event_type, payload dicts
+    outputs: ordered immutable trace payloads, validation errors on schema drift
+  - name: FlowRunner
+    inputs: flow specification, adapters, budget manager, trace emitter, policy stack
+    outputs: RunResult with nodes executed, warnings, stop_reason, trace emissions
+tdd_coverage_targets:
+  - module: budget_models
+    minimum: 0.9
+  - module: budget_manager
+    minimum: 0.9
+  - module: trace_emitter
+    minimum: 0.85
+  - module: flow_runner
+    minimum: 0.85
+review_checklist:
+  - Budget normalization matches milliseconds-only contract.
+  - Hard vs soft breach actions propagate correctly to run results and traces.
+  - Trace payloads satisfy schema validation for policy and budget events.
+  - FlowRunner preserves adapter execution order when budgets permit.
+  - Warnings accumulate deterministically without duplicate emissions.
+outputs:
+  - artifact: implementation_plan
+    path: codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.yaml
+  - artifact: budget_models_module
+    path: codex/code/07b_budget_guards_and_runner_integration.yaml/budget_models.py
+  - artifact: budget_manager_module
+    path: codex/code/07b_budget_guards_and_runner_integration.yaml/budget_manager.py
+  - artifact: trace_emitter_module
+    path: codex/code/07b_budget_guards_and_runner_integration.yaml/trace_emitter.py
+  - artifact: flow_runner_module
+    path: codex/code/07b_budget_guards_and_runner_integration.yaml/flow_runner.py
+  - artifact: unit_tests
+    path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests
+  - artifact: preview_doc
+    path: codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+  - artifact: review_doc
+    path: codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+  - artifact: postexecution_doc
+    path: codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/budget_manager.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/budget_manager.py
@@ -1,0 +1,136 @@
+"""BudgetManager orchestrates scoped budget enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from .budget_models import (
+    BreachAction,
+    BudgetBreach,
+    BudgetDecision,
+    BudgetSpec,
+    CostSnapshot,
+    ScopeKey,
+    ScopeSnapshot,
+)
+
+
+@dataclass
+class _ScopeState:
+    spec: BudgetSpec
+    spent: CostSnapshot = CostSnapshot.zero()
+
+
+class BudgetBreachError(RuntimeError):
+    """Raised when a hard budget breach occurs during commit."""
+
+    def __init__(self, decision: BudgetDecision):
+        message = (
+            f"Budget breach for {decision.scope.category}:{decision.scope.identifier}"
+        )
+        super().__init__(message)
+        self.decision = decision
+
+
+class BudgetManager:
+    """Coordinates budget evaluations across scopes."""
+
+    def __init__(self) -> None:
+        self._scopes: Dict[Tuple[str, str], _ScopeState] = {}
+        self._warnings: List[str] = []
+        self._warned_scopes: set[Tuple[str, str]] = set()
+
+    def register_scope(self, spec: BudgetSpec) -> None:
+        key = spec.scope.as_tuple()
+        if key in self._scopes:
+            raise ValueError(f"Scope already registered: {key}")
+        self._scopes[key] = _ScopeState(spec=spec)
+
+    def has_scope(self, scope: ScopeKey) -> bool:
+        return scope.as_tuple() in self._scopes
+
+    def preflight(self, scope: ScopeKey, attempted: CostSnapshot) -> BudgetDecision:
+        return self._evaluate(scope, attempted, stage="preflight", mutate=False)
+
+    def commit(self, scope: ScopeKey, attempted: CostSnapshot) -> BudgetDecision:
+        decision = self._evaluate(scope, attempted, stage="commit", mutate=True)
+        if not decision.allowed and decision.action == BreachAction.STOP:
+            raise BudgetBreachError(decision)
+        return decision
+
+    def snapshot(self, scope: ScopeKey) -> ScopeSnapshot:
+        state = self._require_scope(scope)
+        return ScopeSnapshot(scope=scope, limit_ms=state.spec.limit_ms, spent=state.spent)
+
+    def drain_warnings(self) -> List[str]:
+        warnings = list(self._warnings)
+        self._warnings.clear()
+        return warnings
+
+    def spec_for(self, scope: ScopeKey) -> BudgetSpec:
+        return self._require_scope(scope).spec
+
+    def _require_scope(self, scope: ScopeKey) -> _ScopeState:
+        key = scope.as_tuple()
+        if key not in self._scopes:
+            raise KeyError(f"Scope not registered: {key}")
+        return self._scopes[key]
+
+    def _evaluate(
+        self,
+        scope: ScopeKey,
+        attempted: CostSnapshot,
+        *,
+        stage: str,
+        mutate: bool,
+    ) -> BudgetDecision:
+        state = self._require_scope(scope)
+        remaining_ms = max(0.0, state.spec.limit_ms - state.spent.milliseconds)
+        remaining_snapshot = CostSnapshot(remaining_ms)
+        breach: Optional[BudgetBreach] = None
+        allowed = True
+
+        if attempted.milliseconds > remaining_ms:
+            breach = BudgetBreach(
+                scope=scope,
+                attempted=attempted,
+                limit_ms=state.spec.limit_ms,
+                remaining=remaining_snapshot,
+                action=state.spec.breach_action,
+            )
+            allowed = state.spec.breach_action == BreachAction.WARN
+
+        if mutate and allowed:
+            new_spent = state.spent + attempted
+            self._scopes[scope.as_tuple()] = _ScopeState(spec=state.spec, spent=new_spent)
+            if breach is not None:
+                self._append_warning(scope, breach)
+            remaining_snapshot = CostSnapshot(
+                max(0.0, state.spec.limit_ms - new_spent.milliseconds)
+            )
+        elif mutate and not allowed:
+            # Preserve existing spent totals and produce decision for caller.
+            pass
+
+        decision = BudgetDecision(
+            scope=scope,
+            stage=stage,
+            attempted=attempted,
+            remaining=remaining_snapshot if mutate and allowed else remaining_snapshot,
+            allowed=allowed,
+            action=state.spec.breach_action,
+            breach=breach,
+        )
+        return decision
+
+    def _append_warning(self, scope: ScopeKey, breach: BudgetBreach) -> None:
+        key = scope.as_tuple()
+        if key in self._warned_scopes:
+            return
+        message = (
+            f"{scope.category}:{scope.identifier} warning: attempted {breach.attempted.milliseconds:.1f}ms "
+            f"limit {breach.limit_ms:.1f}ms"
+        )
+        self._warnings.append(message)
+        self._warned_scopes.add(key)

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/budget_models.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/budget_models.py
@@ -1,0 +1,187 @@
+"""Typed budget value objects for FlowRunner integration tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Dict, Mapping, Optional
+
+
+class BreachAction(str, Enum):
+    """Enumerates the supported breach actions."""
+
+    STOP = "stop"
+    WARN = "warn"
+
+    @classmethod
+    def from_value(cls, value: Optional[str]) -> "BreachAction":
+        if value is None:
+            return cls.STOP
+        value_normalized = value.lower()
+        for member in cls:
+            if member.value == value_normalized:
+                return member
+        raise ValueError(f"Unsupported breach_action: {value}")
+
+
+@dataclass(frozen=True)
+class ScopeKey:
+    """Identifies a budget scope (run, node, spec, loop)."""
+
+    category: str
+    identifier: str
+
+    VALID_CATEGORIES = {"run", "node", "spec", "loop"}
+
+    def __post_init__(self) -> None:
+        if self.category not in self.VALID_CATEGORIES:
+            raise ValueError(f"Unsupported scope category: {self.category}")
+        if not self.identifier:
+            raise ValueError("Scope identifier must be provided")
+
+    def as_tuple(self) -> tuple[str, str]:
+        return self.category, self.identifier
+
+
+@dataclass(frozen=True)
+class CostSnapshot:
+    """Represents a normalized cost in milliseconds."""
+
+    milliseconds: float
+
+    def __post_init__(self) -> None:
+        if self.milliseconds < 0:
+            raise ValueError("Cost cannot be negative")
+
+    @classmethod
+    def zero(cls) -> "CostSnapshot":
+        return cls(0.0)
+
+    @classmethod
+    def from_inputs(
+        cls,
+        *,
+        duration_ms: Optional[float] = None,
+        duration_seconds: Optional[float] = None,
+        payload: Optional[Mapping[str, float]] = None,
+    ) -> "CostSnapshot":
+        total_ms = 0.0
+        if payload is not None:
+            if "duration_ms" in payload:
+                duration_ms = payload["duration_ms"]
+            elif "duration_seconds" in payload:
+                duration_seconds = payload["duration_seconds"]
+        if duration_ms is not None:
+            total_ms += float(duration_ms)
+        if duration_seconds is not None:
+            total_ms += float(duration_seconds) * 1000.0
+        if payload is None and duration_ms is None and duration_seconds is None:
+            raise ValueError("At least one cost input must be supplied")
+        if total_ms < 0.0:
+            raise ValueError("Cost cannot be negative")
+        return cls(total_ms)
+
+    def __add__(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot(self.milliseconds + other.milliseconds)
+
+    def __sub__(self, other: "CostSnapshot") -> "CostSnapshot":
+        result = self.milliseconds - other.milliseconds
+        if result < 0:
+            result = 0.0
+        return CostSnapshot(result)
+
+    def to_payload(self) -> Mapping[str, float]:
+        return MappingProxyType({"duration_ms": self.milliseconds})
+
+
+@dataclass(frozen=True)
+class BudgetSpec:
+    """Immutable budget specification for a scope."""
+
+    scope: ScopeKey
+    limit_ms: float
+    breach_action: BreachAction
+
+    @classmethod
+    def from_config(cls, scope: ScopeKey, config: Mapping[str, float]) -> "BudgetSpec":
+        if "limit_ms" in config:
+            limit_ms = float(config["limit_ms"])
+        elif "limit_seconds" in config:
+            limit_ms = float(config["limit_seconds"]) * 1000.0
+        else:
+            raise ValueError("Budget config must provide limit_ms or limit_seconds")
+        if limit_ms <= 0:
+            raise ValueError("Budget limit must be positive")
+        action_value = config.get("breach_action") if hasattr(config, "get") else None
+        action = BreachAction.from_value(action_value)
+        return cls(scope=scope, limit_ms=limit_ms, breach_action=action)
+
+
+@dataclass(frozen=True)
+class BudgetBreach:
+    """Describes an attempted spend that exceeded the limit."""
+
+    scope: ScopeKey
+    attempted: CostSnapshot
+    limit_ms: float
+    remaining: CostSnapshot
+    action: BreachAction
+
+    def to_payload(self) -> Mapping[str, object]:
+        return MappingProxyType(
+            {
+                "scope": self.scope.category,
+                "scope_id": self.scope.identifier,
+                "attempted_ms": self.attempted.milliseconds,
+                "limit_ms": self.limit_ms,
+                "remaining_ms": self.remaining.milliseconds,
+                "action": self.action.value,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    """Outcome of a budget evaluation stage."""
+
+    scope: ScopeKey
+    stage: str
+    attempted: CostSnapshot
+    remaining: CostSnapshot
+    allowed: bool
+    action: BreachAction
+    breach: Optional[BudgetBreach] = None
+
+    def to_payload(self) -> Mapping[str, object]:
+        payload: Dict[str, object] = {
+            "scope": self.scope.category,
+            "scope_id": self.scope.identifier,
+            "stage": self.stage,
+            "attempted_ms": self.attempted.milliseconds,
+            "remaining_ms": self.remaining.milliseconds,
+            "allowed": self.allowed,
+            "action": self.action.value,
+        }
+        if self.breach is not None:
+            payload["breach"] = self.breach.to_payload()
+        return MappingProxyType(payload)
+
+
+@dataclass(frozen=True)
+class ScopeSnapshot:
+    """Represents an immutable view of scope spend."""
+
+    scope: ScopeKey
+    limit_ms: float
+    spent: CostSnapshot
+
+    def to_payload(self) -> Mapping[str, object]:
+        return MappingProxyType(
+            {
+                "scope": self.scope.category,
+                "scope_id": self.scope.identifier,
+                "limit_ms": self.limit_ms,
+                "spent_ms": self.spent.milliseconds,
+            }
+        )

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/flow_runner.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/flow_runner.py
@@ -1,0 +1,227 @@
+"""Simplified FlowRunner integrating budget management and policy traces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from .budget_manager import BudgetBreachError, BudgetManager
+from .budget_models import BreachAction, BudgetDecision, BudgetSpec, CostSnapshot, ScopeKey
+from .trace_emitter import TraceEventEmitter
+
+
+@dataclass(frozen=True)
+class NodeExecution:
+    node_id: str
+    adapter: str
+    output: Any
+    cost: CostSnapshot
+
+
+@dataclass
+class RunResult:
+    executions: List[NodeExecution] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    stop_reason: Optional[str] = None
+
+
+class PolicyStack:
+    """Tracks active policies and emits trace events."""
+
+    def __init__(self, emitter: TraceEventEmitter) -> None:
+        self._emitter = emitter
+        self._stack: List[tuple[str, str]] = []
+
+    def push(self, policy_id: Optional[str], node_id: str) -> None:
+        if policy_id is None:
+            return
+        self._stack.append((policy_id, node_id))
+        self._emitter.emit("policy_push", {"policy_id": policy_id, "node_id": node_id})
+
+    def resolve(self, policy_id: Optional[str], node_id: str, status: str = "completed") -> None:
+        if policy_id is None:
+            return
+        self._emitter.emit(
+            "policy_resolved",
+            {"policy_id": policy_id, "node_id": node_id, "status": status},
+        )
+        if self._stack and self._stack[-1] == (policy_id, node_id):
+            self._stack.pop()
+
+    def violation(self, policy_id: Optional[str], node_id: str, reason: str) -> None:
+        if policy_id is None:
+            return
+        self._emitter.emit(
+            "policy_violation",
+            {"policy_id": policy_id, "node_id": node_id, "reason": reason},
+        )
+        if self._stack and self._stack[-1] == (policy_id, node_id):
+            self._stack.pop()
+
+
+class FlowRunner:
+    """Executes flow nodes while enforcing budgets and emitting traces."""
+
+    def __init__(
+        self,
+        *,
+        budget_manager: BudgetManager,
+        trace_emitter: TraceEventEmitter,
+        policy_stack: Optional[PolicyStack] = None,
+    ) -> None:
+        self._manager = budget_manager
+        self._trace = trace_emitter
+        self._policy = policy_stack or PolicyStack(trace_emitter)
+
+    def run(self, flow_spec: Mapping[str, Any], adapters: Mapping[str, Any]) -> RunResult:
+        run_id = flow_spec.get("run_id", "run")
+        result = RunResult()
+
+        run_scope = None
+        if "run_budget" in flow_spec:
+            run_scope = self._ensure_scope("run", run_id, flow_spec["run_budget"])
+
+        for spec_id, config in flow_spec.get("spec_budgets", {}).items():
+            self._ensure_scope("spec", spec_id, config)
+        for loop_id, config in flow_spec.get("loop_budgets", {}).items():
+            self._ensure_scope("loop", loop_id, config)
+
+        for node in flow_spec.get("nodes", []):
+            node_id = node["id"]
+            adapter_name = node["adapter"]
+            policy_id = node.get("policy")
+            loop_id = node.get("loop_id")
+            spec_id = node.get("spec_id")
+            node_scope = None
+            if "budget" in node and node["budget"] is not None:
+                node_scope = self._ensure_scope("node", node_id, node["budget"])
+
+            adapter = adapters[adapter_name]
+            context = {"run_id": run_id, "node": node}
+            self._policy.push(policy_id, node_id)
+
+            estimate_kwargs: Dict[str, Any] = {}
+            if node.get("estimate_ms") is not None:
+                estimate_kwargs["duration_ms"] = node.get("estimate_ms")
+            elif node.get("estimate_seconds") is not None:
+                estimate_kwargs["duration_seconds"] = node.get("estimate_seconds")
+            elif node.get("execute_ms") is not None:
+                estimate_kwargs["duration_ms"] = node.get("execute_ms")
+            else:
+                estimate_kwargs["duration_ms"] = 0
+            estimated = CostSnapshot.from_inputs(**estimate_kwargs)
+            scopes = self._scopes_for_node(run_scope, spec_id, loop_id, node_scope)
+
+            stop_reason = self._run_preflight(scopes, estimated, policy_id, node_id)
+            if stop_reason:
+                result.stop_reason = stop_reason
+                result.warnings.extend(self._manager.drain_warnings())
+                break
+
+            execution = adapter.execute(context)
+            cost_payload = execution.get("cost")
+            if cost_payload is None:
+                fallback = node.get("execute_ms") or estimated.milliseconds
+                cost_payload = {"duration_ms": fallback}
+            actual_cost = CostSnapshot.from_inputs(payload=cost_payload)
+
+            stop_reason = self._commit_costs(scopes, actual_cost, policy_id, node_id)
+            result.warnings.extend(self._manager.drain_warnings())
+            if stop_reason:
+                result.stop_reason = stop_reason
+                break
+
+            result.executions.append(
+                NodeExecution(
+                    node_id=node_id,
+                    adapter=adapter_name,
+                    output=execution.get("output"),
+                    cost=actual_cost,
+                )
+            )
+            self._policy.resolve(policy_id, node_id)
+
+        result.warnings.extend(self._manager.drain_warnings())
+        return result
+
+    def _scopes_for_node(
+        self,
+        run_scope: Optional[ScopeKey],
+        spec_id: Optional[str],
+        loop_id: Optional[str],
+        node_scope: Optional[ScopeKey],
+    ) -> List[ScopeKey]:
+        scopes: List[ScopeKey] = []
+        if run_scope is not None:
+            scopes.append(run_scope)
+        if spec_id is not None:
+            scopes.append(ScopeKey("spec", spec_id))
+        if loop_id is not None:
+            scopes.append(ScopeKey("loop", loop_id))
+        if node_scope is not None:
+            scopes.append(node_scope)
+        return scopes
+
+    def _run_preflight(
+        self,
+        scopes: Iterable[ScopeKey],
+        estimated: CostSnapshot,
+        policy_id: Optional[str],
+        node_id: str,
+    ) -> Optional[str]:
+        for scope in scopes:
+            decision = self._manager.preflight(scope, estimated)
+            spec = self._manager.spec_for(scope)
+            self._emit_budget_event("budget_preflight", decision, spec.limit_ms)
+            if decision.breach is not None:
+                self._emit_budget_breach(decision, spec.limit_ms)
+            if not decision.allowed and decision.action == BreachAction.STOP:
+                reason = f"budget_breach:{scope.category}:{scope.identifier}"
+                self._policy.violation(policy_id, node_id, reason)
+                return reason
+        return None
+
+    def _commit_costs(
+        self,
+        scopes: Iterable[ScopeKey],
+        actual_cost: CostSnapshot,
+        policy_id: Optional[str],
+        node_id: str,
+    ) -> Optional[str]:
+        for scope in scopes:
+            spec = self._manager.spec_for(scope)
+            try:
+                decision = self._manager.commit(scope, actual_cost)
+            except BudgetBreachError as exc:
+                decision = exc.decision
+                self._emit_budget_event("budget_charge", decision, spec.limit_ms)
+                self._emit_budget_breach(decision, spec.limit_ms)
+                reason = f"budget_breach:{scope.category}:{scope.identifier}"
+                self._policy.violation(policy_id, node_id, reason)
+                return reason
+            self._emit_budget_event("budget_charge", decision, spec.limit_ms)
+            if decision.breach is not None:
+                self._emit_budget_breach(decision, spec.limit_ms)
+        return None
+
+    def _ensure_scope(self, category: str, identifier: str, config: Mapping[str, Any]) -> ScopeKey:
+        scope = ScopeKey(category, identifier)
+        if not self._manager.has_scope(scope):
+            spec = BudgetSpec.from_config(scope=scope, config=config)
+            self._manager.register_scope(spec)
+        return scope
+
+    def _emit_budget_event(
+        self,
+        event_type: str,
+        decision: BudgetDecision,
+        limit_ms: float,
+    ) -> None:
+        payload = dict(decision.to_payload())
+        payload["limit_ms"] = limit_ms
+        self._trace.emit(event_type, payload)
+
+    def _emit_budget_breach(self, decision: BudgetDecision, limit_ms: float) -> None:
+        payload = dict(decision.to_payload())
+        payload["limit_ms"] = limit_ms
+        self._trace.emit("budget_breach", payload)

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py
@@ -1,0 +1,109 @@
+from importlib import util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str):
+    if "codex" not in sys.modules:
+        codex_pkg = types.ModuleType("codex")
+        codex_pkg.__path__ = [str(MODULE_DIR.parent)]
+        sys.modules["codex"] = codex_pkg
+    if "codex.07b" not in sys.modules:
+        pkg = types.ModuleType("codex.07b")
+        pkg.__path__ = [str(MODULE_DIR)]
+        sys.modules["codex.07b"] = pkg
+    spec = util.spec_from_file_location(
+        f"codex.07b.{name}", MODULE_DIR / f"{name}.py"
+    )
+    module = util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+bm = load_module("budget_models")
+manager_mod = load_module("budget_manager")
+
+
+@pytest.fixture
+def manager():
+    return manager_mod.BudgetManager()
+
+
+def test_preflight_and_commit_enforce_hard_budget(manager):
+    run_scope = bm.ScopeKey("run", "run-1")
+    spec = bm.BudgetSpec.from_config(scope=run_scope, config={"limit_ms": 100, "breach_action": "stop"})
+    manager.register_scope(spec)
+
+    first_cost = bm.CostSnapshot.from_inputs(duration_ms=60)
+    decision = manager.preflight(run_scope, first_cost)
+    assert decision.allowed is True
+    assert decision.breach is None
+
+    commit_outcome = manager.commit(run_scope, first_cost)
+    assert commit_outcome.allowed is True
+    assert commit_outcome.remaining.milliseconds == pytest.approx(40)
+
+    second_cost = bm.CostSnapshot.from_inputs(duration_ms=50)
+    second_decision = manager.preflight(run_scope, second_cost)
+    assert second_decision.allowed is False
+    assert second_decision.breach is not None
+    assert second_decision.breach.limit_ms == 100
+
+    # Hard stop should not mutate spent totals on failed commit.
+    with pytest.raises(manager_mod.BudgetBreachError):
+        manager.commit(run_scope, second_cost)
+
+    # Remaining budget should still reflect the first commit only.
+    post_state = manager.snapshot(run_scope)
+    assert post_state.spent.milliseconds == pytest.approx(60)
+
+
+def test_soft_budget_allows_commit_but_records_warning(manager):
+    loop_scope = bm.ScopeKey("loop", "loop-a")
+    spec = bm.BudgetSpec.from_config(scope=loop_scope, config={"limit_ms": 90, "breach_action": "warn"})
+    manager.register_scope(spec)
+
+    cost = bm.CostSnapshot.from_inputs(duration_ms=70)
+    manager.commit(loop_scope, cost)
+
+    over_cost = bm.CostSnapshot.from_inputs(duration_ms=40)
+    decision = manager.preflight(loop_scope, over_cost)
+    assert decision.allowed is True
+    assert decision.breach is not None
+    assert decision.breach.action == bm.BreachAction.WARN
+
+    outcome = manager.commit(loop_scope, over_cost)
+    assert outcome.allowed is True
+    assert outcome.breach is not None
+    assert outcome.remaining.milliseconds == pytest.approx(0.0)
+
+    warnings = manager.drain_warnings()
+    assert len(warnings) == 1
+    assert loop_scope.identifier in warnings[0]
+
+
+def test_registering_scope_twice_raises(manager):
+    spec = bm.BudgetSpec.from_config(scope=bm.ScopeKey("spec", "embedding"), config={"limit_ms": 30})
+    manager.register_scope(spec)
+    with pytest.raises(ValueError):
+        manager.register_scope(spec)
+
+
+def test_snapshot_returns_immutable_view(manager):
+    node_scope = bm.ScopeKey("node", "node-1")
+    spec = bm.BudgetSpec.from_config(scope=node_scope, config={"limit_ms": 50})
+    manager.register_scope(spec)
+    manager.commit(node_scope, bm.CostSnapshot.from_inputs(duration_ms=20))
+
+    snapshot = manager.snapshot(node_scope)
+    payload = snapshot.to_payload()
+    assert payload["spent_ms"] == pytest.approx(20.0)
+    with pytest.raises(TypeError):
+        payload["spent_ms"] = 10  # type: ignore[index]

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py
@@ -1,0 +1,119 @@
+import math
+import types
+from importlib import util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str):
+    if "codex" not in sys.modules:
+        codex_pkg = types.ModuleType("codex")
+        codex_pkg.__path__ = [str(MODULE_DIR.parent)]
+        sys.modules["codex"] = codex_pkg
+    if "codex.07b" not in sys.modules:
+        pkg = types.ModuleType("codex.07b")
+        pkg.__path__ = [str(MODULE_DIR)]
+        sys.modules["codex.07b"] = pkg
+    spec = util.spec_from_file_location(
+        f"codex.07b.{name}", MODULE_DIR / f"{name}.py"
+    )
+    module = util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+bm = load_module("budget_models")
+
+
+def test_budget_spec_normalizes_seconds_to_milliseconds():
+    spec = bm.BudgetSpec.from_config(
+        scope=bm.ScopeKey("run", "run-123"),
+        config={"limit_seconds": 0.25, "breach_action": "warn"},
+    )
+    assert spec.limit_ms == 250
+    assert spec.breach_action == bm.BreachAction.WARN
+    assert spec.scope.identifier == "run-123"
+
+
+def test_budget_spec_requires_positive_limit():
+    with pytest.raises(ValueError):
+        bm.BudgetSpec.from_config(
+            scope=bm.ScopeKey("node", "n1"),
+            config={"limit_ms": 0},
+        )
+
+
+def test_cost_snapshot_supports_mixed_units_and_arithmetic():
+    base = bm.CostSnapshot.from_inputs(duration_ms=125.5)
+    increment = bm.CostSnapshot.from_inputs(duration_seconds=0.120)
+    total = base + increment
+    assert math.isclose(total.milliseconds, 245.5, rel_tol=1e-9)
+    remaining = total - bm.CostSnapshot.from_inputs(duration_ms=30.5)
+    assert math.isclose(remaining.milliseconds, 215.0, rel_tol=1e-9)
+
+
+def test_cost_snapshot_prevents_negative_values():
+    with pytest.raises(ValueError):
+        bm.CostSnapshot.from_inputs(duration_ms=-1)
+
+
+def test_budget_breach_payload_is_immutable_mapping():
+    spec = bm.BudgetSpec.from_config(
+        scope=bm.ScopeKey("spec", "embedding"),
+        config={"limit_ms": 90, "breach_action": "stop"},
+    )
+    breach = bm.BudgetBreach(
+        scope=spec.scope,
+        attempted=bm.CostSnapshot.from_inputs(duration_ms=120),
+        limit_ms=spec.limit_ms,
+        remaining=bm.CostSnapshot.zero(),
+        action=spec.breach_action,
+    )
+    payload = breach.to_payload()
+    assert isinstance(payload, types.MappingProxyType)
+    assert payload["scope"] == "spec"
+    with pytest.raises(TypeError):
+        payload["scope"] = "mutated"  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "config,expected_action",
+    [
+        ({"limit_ms": 10, "breach_action": "warn"}, bm.BreachAction.WARN),
+        ({"limit_ms": 10, "breach_action": "stop"}, bm.BreachAction.STOP),
+        ({"limit_ms": 10}, bm.BreachAction.STOP),
+    ],
+)
+def test_budget_spec_breach_actions_normalized(config, expected_action):
+    spec = bm.BudgetSpec.from_config(scope=bm.ScopeKey("loop", "loop-1"), config=config)
+    assert spec.breach_action == expected_action
+
+
+def test_budget_decision_to_payload_reflects_stage_and_breach():
+    spec = bm.BudgetSpec.from_config(scope=bm.ScopeKey("run", "run"), config={"limit_ms": 100})
+    decision = bm.BudgetDecision(
+        scope=spec.scope,
+        stage="preflight",
+        attempted=bm.CostSnapshot.from_inputs(duration_ms=120),
+        remaining=bm.CostSnapshot.from_inputs(duration_ms=0),
+        allowed=False,
+        action=spec.breach_action,
+        breach=bm.BudgetBreach(
+            scope=spec.scope,
+            attempted=bm.CostSnapshot.from_inputs(duration_ms=120),
+            limit_ms=spec.limit_ms,
+            remaining=bm.CostSnapshot.from_inputs(duration_ms=0),
+            action=spec.breach_action,
+        ),
+    )
+    payload = decision.to_payload()
+    assert payload["stage"] == "preflight"
+    assert payload["allowed"] is False
+    assert payload["breach"]["limit_ms"] == 100

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner.py
@@ -1,0 +1,152 @@
+from importlib import util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str):
+    if "codex" not in sys.modules:
+        codex_pkg = types.ModuleType("codex")
+        codex_pkg.__path__ = [str(MODULE_DIR.parent)]
+        sys.modules["codex"] = codex_pkg
+    if "codex.07b" not in sys.modules:
+        pkg = types.ModuleType("codex.07b")
+        pkg.__path__ = [str(MODULE_DIR)]
+        sys.modules["codex.07b"] = pkg
+    spec = util.spec_from_file_location(
+        f"codex.07b.{name}", MODULE_DIR / f"{name}.py"
+    )
+    module = util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+bm = load_module("budget_models")
+manager_mod = load_module("budget_manager")
+trace_mod = load_module("trace_emitter")
+runner_mod = load_module("flow_runner")
+
+
+class FakeAdapter:
+    def estimate_cost(self, context):
+        return {"duration_ms": context["node"]["estimate_ms"]}
+
+    def execute(self, context):
+        return {
+            "output": f"ran:{context['node']['id']}",
+            "cost": {"duration_ms": context["node"]["execute_ms"]},
+        }
+
+
+@pytest.fixture
+def adapter_registry():
+    return {
+        "alpha": FakeAdapter(),
+        "beta": FakeAdapter(),
+    }
+
+
+def test_flow_runner_stops_on_spec_budget_breach(adapter_registry):
+    manager = manager_mod.BudgetManager()
+    emitter = trace_mod.TraceEventEmitter()
+    runner = runner_mod.FlowRunner(budget_manager=manager, trace_emitter=emitter)
+
+    flow_spec = {
+        "run_id": "run-hard-stop",
+        "run_budget": {"limit_ms": 150, "breach_action": "stop"},
+        "spec_budgets": {
+            "embedding": {"limit_ms": 100, "breach_action": "stop"},
+        },
+        "nodes": [
+                {
+                    "id": "node-1",
+                    "adapter": "alpha",
+                    "policy": "policy-a",
+                    "spec_id": "embedding",
+                    "budget": {"limit_ms": 50, "breach_action": "warn"},
+                    "estimate_ms": 45,
+                    "execute_ms": 60,
+                },
+            {
+                "id": "node-2",
+                "adapter": "alpha",
+                "policy": "policy-a",
+                "spec_id": "embedding",
+                "budget": {"limit_ms": 70, "breach_action": "stop"},
+                "estimate_ms": 55,
+                "execute_ms": 65,
+            },
+        ],
+    }
+
+    result = runner.run(flow_spec, adapter_registry)
+
+    assert result.stop_reason == "budget_breach:spec:embedding"
+    assert [n.node_id for n in result.executions] == ["node-1"]
+    assert len(result.warnings) == 1
+    assert any("node:node-1" in warning for warning in result.warnings)
+
+    event_types = [event["type"] for event in emitter.events]
+    assert event_types[0] == "policy_push"
+    breach_events = [event for event in emitter.events if event["type"] == "budget_breach"]
+    assert any(event["payload"]["scope"] == "spec" for event in breach_events)
+    spec_breach = next(event for event in breach_events if event["payload"]["scope"] == "spec")
+    assert spec_breach["payload"]["scope_id"] == "embedding"
+    assert spec_breach["payload"]["stage"] == "preflight"
+    assert any(event["type"] == "policy_violation" for event in emitter.events)
+
+
+def test_flow_runner_accumulates_run_and_loop_warnings(adapter_registry):
+    manager = manager_mod.BudgetManager()
+    emitter = trace_mod.TraceEventEmitter()
+    runner = runner_mod.FlowRunner(budget_manager=manager, trace_emitter=emitter)
+
+    flow_spec = {
+        "run_id": "run-soft",
+        "run_budget": {"limit_ms": 60, "breach_action": "warn"},
+        "loop_budgets": {
+            "loop-1": {"limit_ms": 50, "breach_action": "warn"},
+        },
+        "nodes": [
+                {
+                    "id": "node-a",
+                    "adapter": "alpha",
+                    "policy": "policy-a",
+                    "loop_id": "loop-1",
+                    "budget": {"limit_ms": 30, "breach_action": "warn"},
+                    "estimate_ms": 30,
+                    "execute_ms": 35,
+                },
+                {
+                    "id": "node-b",
+                    "adapter": "beta",
+                    "policy": "policy-b",
+                    "loop_id": "loop-1",
+                    "budget": {"limit_ms": 20, "breach_action": "warn"},
+                    "estimate_ms": 25,
+                    "execute_ms": 30,
+                },
+        ],
+    }
+
+    result = runner.run(flow_spec, adapter_registry)
+
+    assert result.stop_reason is None
+    assert [n.node_id for n in result.executions] == ["node-a", "node-b"]
+    assert len(result.warnings) >= 3
+    expected_prefixes = {"node:node-a", "node:node-b", "loop:loop-1", "run:run-soft"}
+    for prefix in expected_prefixes:
+        assert any(warning.startswith(prefix) for warning in result.warnings)
+
+    run_warnings = [w for w in result.warnings if w.startswith("run:run-soft")]
+    assert len(run_warnings) == 1
+
+    charge_events = [event for event in emitter.events if event["type"] == "budget_charge"]
+    assert len(charge_events) >= 2
+    assert all(event["payload"]["stage"] == "commit" for event in charge_events)

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/trace_emitter.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/trace_emitter.py
@@ -1,0 +1,139 @@
+"""Schema-validating trace event emitter."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+
+class TraceSchemaError(ValueError):
+    """Raised when a trace payload violates the schema."""
+
+
+_TRACE_SCHEMA: Dict[str, Dict[str, Iterable[str]]] = {
+    "policy_push": {"required": ("policy_id", "node_id")},
+    "policy_resolved": {"required": ("policy_id", "node_id", "status")},
+    "policy_violation": {"required": ("policy_id", "node_id", "reason")},
+    "budget_preflight": {
+        "required": (
+            "scope",
+            "scope_id",
+            "stage",
+            "attempted_ms",
+            "remaining_ms",
+            "action",
+        ),
+        "optional": ("allowed", "limit_ms", "breach"),
+    },
+    "budget_charge": {
+        "required": (
+            "scope",
+            "scope_id",
+            "stage",
+            "attempted_ms",
+            "remaining_ms",
+            "action",
+            "allowed",
+        ),
+        "optional": ("limit_ms", "breach"),
+    },
+    "budget_breach": {
+        "required": (
+            "scope",
+            "scope_id",
+            "stage",
+            "attempted_ms",
+            "remaining_ms",
+            "action",
+        ),
+        "optional": ("limit_ms", "breach"),
+    },
+}
+
+
+def _validate_number(value: Any, field: str) -> float:
+    if not isinstance(value, (int, float)):
+        raise TraceSchemaError(f"Field '{field}' must be numeric")
+    return float(value)
+
+
+def _validate_string(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise TraceSchemaError(f"Field '{field}' must be a string")
+    return value
+
+
+def _validate_boolean(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise TraceSchemaError(f"Field '{field}' must be a boolean")
+    return value
+
+
+def _normalize_breach(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TraceSchemaError("Breach payload must be a mapping")
+    required = {"scope", "scope_id", "attempted_ms", "limit_ms", "remaining_ms", "action"}
+    if not required.issubset(value.keys()):
+        missing = sorted(required.difference(value.keys()))
+        raise TraceSchemaError(f"Breach payload missing fields: {missing}")
+    normalized: Dict[str, Any] = {
+        "scope": _validate_string(value["scope"], "breach.scope"),
+        "scope_id": _validate_string(value["scope_id"], "breach.scope_id"),
+        "attempted_ms": _validate_number(value["attempted_ms"], "breach.attempted_ms"),
+        "limit_ms": _validate_number(value["limit_ms"], "breach.limit_ms"),
+        "remaining_ms": _validate_number(value["remaining_ms"], "breach.remaining_ms"),
+        "action": _validate_string(value["action"], "breach.action"),
+    }
+    return MappingProxyType(normalized)
+
+
+class TraceEventEmitter:
+    """Collects trace events while enforcing schema compliance."""
+
+    def __init__(self) -> None:
+        self._events: List[Dict[str, Mapping[str, Any]]] = []
+
+    @property
+    def events(self) -> List[Mapping[str, Any]]:
+        return list(self._events)
+
+    def emit(self, event_type: str, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        if event_type not in _TRACE_SCHEMA:
+            raise TraceSchemaError(f"Unknown trace event type: {event_type}")
+        normalized_payload = self._normalize_payload(event_type, payload)
+        record: Dict[str, Mapping[str, Any]] = {
+            "type": event_type,
+            "payload": MappingProxyType(normalized_payload),
+        }
+        self._events.append(record)
+        return record
+
+    def clear(self) -> None:
+        self._events.clear()
+
+    def _normalize_payload(
+        self, event_type: str, payload: Mapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        schema = _TRACE_SCHEMA[event_type]
+        normalized: Dict[str, Any] = {}
+        for field in schema.get("required", ()):  # type: ignore[arg-type]
+            if field not in payload:
+                raise TraceSchemaError(f"Missing required field '{field}' for {event_type}")
+            normalized[field] = self._coerce(field, payload[field])
+        for field in schema.get("optional", ()):  # type: ignore[arg-type]
+            if field in payload:
+                normalized[field] = self._coerce(field, payload[field])
+        # Preserve ordering for deterministic assertions.
+        ordered = dict((key, normalized[key]) for key in normalized)
+        return ordered
+
+    def _coerce(self, field: str, value: Any) -> Any:
+        if field in {"scope", "scope_id", "stage", "action", "policy_id", "node_id", "status", "reason"}:
+            return _validate_string(value, field)
+        if field in {"attempted_ms", "remaining_ms", "limit_ms"}:
+            return _validate_number(value, field)
+        if field == "allowed":
+            return _validate_boolean(value, field)
+        if field == "breach":
+            return _normalize_breach(value)
+        return value


### PR DESCRIPTION
## Summary
- add typed budget value objects with immutable payload helpers for FlowRunner budgets
- implement a scope-aware BudgetManager plus schema-validated trace emitter
- build a simplified adapter-driven FlowRunner and unit tests covering budget enforcement and traces

## Testing
- `pytest codex/code/07b_budget_guards_and_runner_integration.yaml/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68e8953ec3ac832c8ef63d1594193619