### PR TITLE
Add budget manager and FlowRunner budget enforcement

### DIFF
--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
@@ -1,0 +1,14 @@
+# Phase 3 Post-execution — Budget Guards & Runner Integration
+
+## Execution Notes
+- Completed unit test suite via `pytest codex/code/07b_budget_guards_and_runner_integration.yaml/tests -q`.
+- Preflight handling now emits `budget_breach` traces before raising on hard budgets to preserve observability parity with commit pathways.
+- Loop summaries capture iteration counts and stop reasons (`budget_stop`, `max_iterations`) and are returned as mapping proxies.
+
+## Coverage / Quality
+- Unit tests span budget models, manager orchestration, and FlowRunner behaviour, exercising both happy paths and breach scenarios.
+- Trace immutability verified through attempted mutation checks in tests.
+
+## Follow-ups / TODOs
+- Consider integrating PolicyStack trace emission once cross-task interfaces stabilize.
+- Evaluate whether to surface aggregate run summaries (spend per metric) for downstream analytics in a future phase.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
@@ -1,0 +1,16 @@
+# Phase 3 Preview — Budget Guards & Runner Integration
+
+## Summary
+- Establish immutable budget value objects (`BudgetSpec`, `CostSnapshot`, `BudgetChargeResult`) with normalization helpers and mapping-proxy payloads.
+- Deliver a hierarchical `BudgetManager` that coordinates scope registration, preflight checks, commit accounting, and trace emission.
+- Extend `FlowRunner` to drive adapters through estimate/execute hooks, respect budget preflight stop signals, and emit structured loop stop and breach events via a shared `TraceEventEmitter`.
+
+## Planned Scope
+- Code lives under `codex/code/07b_budget_guards_and_runner_integration.yaml/` with task-local namespace packaging.
+- Tests cover models, manager orchestration, and runner behaviour with ≥85% coverage targets per plan.
+- Documentation + run artefacts produced in PREVIEW/REVIEW/POSTEXECUTION directories for downstream agents.
+
+## Key Considerations
+- Preflight breaches on hard budgets raise immediately while still emitting `budget_breach` traces for auditability.
+- Stop-on-soft budgets return structured decisions so loops can terminate gracefully without exceptions.
+- Trace payloads are recursively frozen (mapping proxies + tuples) to meet observability contracts and avoid mutation in tests.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
@@ -1,0 +1,19 @@
+# Phase 3 Review — Budget Guards & Runner Integration
+
+## Implementation Summary
+- Immutable budget data structures and normalization utilities implemented in `budget_models.py`.
+- Hierarchical `BudgetManager` with trace emission and strict preflight/commit semantics delivered in `budget_manager.py`.
+- `FlowRunner` now enforces budgets, halts loops on stop requests, raises on hard breaches, and emits `loop_stop` / `budget_breach` events while coordinating adapters via the shared emitter.
+
+## Review Checklist
+- [x] Budget normalization converts seconds to milliseconds deterministically and clamps negative limits.
+- [x] BudgetManager prevents spend leakage across parent/child scopes and returns immutable `BudgetDecision` payloads.
+- [x] FlowRunner halts loops when `breach_action == "stop"` and raises on hard run-level breaches.
+- [x] Trace payloads (charges, breaches, loop stops) are frozen via mapping proxies to enforce immutability in tests.
+- [x] Unit tests assert trace content, stop reasons, and exception semantics for regression coverage.
+
+## Verification
+- Unit suite (`pytest codex/code/07b_budget_guards_and_runner_integration.yaml/tests -q`) passes locally.
+
+## Known Issues / Follow-ups
+- None identified in Phase 3. Future work may integrate PolicyStack traces once task 07a contracts are finalized.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.yaml
@@ -1,0 +1,81 @@
+summary: Integrate hierarchical budget enforcement with FlowRunner using immutable models and structured traces.
+justification: |
+  Earlier phases identified strong patterns across divergent branches but lacked a cohesive
+  execution path where FlowRunner, BudgetManager, and trace emission collaborate. This plan
+  codifies the selected abstractions (immutable budget models, manager preflight/commit
+  lifecycle, shared trace emitter) into discrete modules with TDD coverage so loop stop
+  behaviour and breach semantics become deterministic and testable.
+steps:
+  - id: domain_models
+    summary: Define immutable budget value objects and metering helpers with consistent unit normalization.
+    details:
+      - Implement BudgetSpec, CostSnapshot, BudgetCharge, and BudgetChargeResult dataclasses with mapping_proxy payloads.
+      - Provide a BudgetMeter that records spend, remaining balances, overages, and breach detection for soft vs hard modes.
+      - Ensure normalization converts seconds to milliseconds and clamps negative limits to zero for stability.
+  - id: manager_orchestration
+    summary: Build BudgetManager orchestration that coordinates multiple scope meters and exposes preflight/commit APIs.
+    details:
+      - Maintain parent/child relationships across run, loop, node, and spec scopes.
+      - Emit BudgetDecision snapshots containing warnings, stop requests, and breach metadata without mutating caller data.
+      - Surface BudgetBreachError for hard budgets while allowing stop-on-breach actions to be consumed by the runner.
+  - id: runner_integration
+    summary: Retrofit FlowRunner skeleton to invoke adapters, enforce policies via BudgetManager, and emit trace events.
+    details:
+      - Drive adapters through estimate/execute hooks, charging budgets on commit and halting loops on stop requests.
+      - Emit budget_charge, budget_breach, and loop_stop events through a shared TraceEventEmitter with immutable payloads.
+      - Capture stop reasons for loop exits (budget stop, max iterations) and expose them via run results for inspection.
+modules:
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/__init__.py
+    role: Namespace package marker for task-specific modules.
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/budget_models.py
+    role: Budget value objects, normalization helpers, and BudgetMeter implementation.
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/budget_manager.py
+    role: Hierarchical BudgetManager coordinating scopes and breach semantics.
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/trace.py
+    role: TraceEventEmitter utility ensuring immutable structured payloads.
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/flow_runner.py
+    role: FlowRunner orchestration integrating adapters, budget manager, and trace emission.
+tests:
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py
+    focus: BudgetMeter edge cases (soft/hard breaches, unit normalization, immutable payloads).
+    coverage: ">=90%" of budget_models.py via branch-sensitive scenarios.
+    mocks:
+      - Use deterministic FakeClock to simulate time cost normalization.
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py
+    focus: Preflight/commit lifecycle across run/node/loop scopes, stop-request propagation, and exception semantics.
+    coverage: ">=90%" of budget_manager.py using parametrized scenarios.
+    mocks:
+      - Stub trace emitter to capture budget events for assertions.
+  - path: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner.py
+    focus: Loop stop-on-budget behaviour, trace emission ordering, and policy-safe adapter execution.
+    coverage: ">=85%" of flow_runner.py ensuring loop + run happy path and breach paths.
+    mocks:
+      - Fake adapters returning deterministic cost snapshots and outputs.
+run_order:
+  - Write unit tests for budget models.
+  - Implement budget_models.py until tests pass.
+  - Write tests for budget manager and implement budget_manager.py.
+  - Write flow runner tests followed by trace.py and flow_runner.py implementation.
+interfaces:
+  - BudgetMeter.charge(cost: CostSnapshot) -> BudgetChargeResult
+  - BudgetManager.preflight(scope_id, cost) -> BudgetDecision
+  - BudgetManager.commit(scope_id, cost, *, label, emit_trace) -> BudgetDecision
+  - TraceEventEmitter.emit(event, scope, payload) -> None
+  - FlowRunner.run(plan, *, adapters, budget_manager, trace_emitter) -> FlowResult
+tdd_coverage_targets:
+  budget_models.py: 0.9
+  budget_manager.py: 0.9
+  flow_runner.py: 0.85
+review_checklist:
+  - Budget normalization converts seconds to milliseconds with deterministic rounding.
+  - BudgetManager prevents spend leakage across scopes and returns immutable decision payloads.
+  - FlowRunner halts loops when breach_action=="stop" and raises on hard run-level breaches.
+  - Trace payloads use MappingProxyType to guarantee immutability in tests.
+  - Tests assert both trace content and stop reasons to guard regressions.
+outputs:
+  - plan: codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.yaml
+  - tests: codex/code/07b_budget_guards_and_runner_integration.yaml/tests/
+  - modules: codex/code/07b_budget_guards_and_runner_integration.yaml/
+  - docs_preview: codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+  - docs_review: codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+  - docs_postexecution: codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/budget_manager.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/budget_manager.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Mapping
+
+try:  # pragma: no cover - import flexibility for dynamic loading
+    from .budget_models import (
+        BudgetBreachError,
+        BudgetChargeResult,
+        BudgetMeter,
+        BudgetSpec,
+        CostSnapshot,
+    )
+except ImportError:  # pragma: no cover
+    from budget_models import (  # type: ignore[F401]
+        BudgetBreachError,
+        BudgetChargeResult,
+        BudgetMeter,
+        BudgetSpec,
+        CostSnapshot,
+    )
+
+TraceEmitter = Callable[[str, str, Mapping[str, object]], None]
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetDecision:
+    scope_id: str
+    charges: tuple[BudgetChargeResult, ...]
+    breaches: tuple[BudgetChargeResult, ...]
+    stop_requested: bool
+
+    @property
+    def breached(self) -> bool:
+        return bool(self.breaches)
+
+
+class BudgetManager:
+    def __init__(self, *, trace_emitter: TraceEmitter | None = None) -> None:
+        self._trace_emitter = trace_emitter
+        self._meters: dict[str, BudgetMeter] = {}
+        self._parents: dict[str, str | None] = {}
+
+    def register_scope(
+        self, scope_id: str, spec: BudgetSpec, *, parent: str | None = None
+    ) -> None:
+        if scope_id in self._meters:
+            raise ValueError(f"Scope '{scope_id}' already registered")
+        if parent is not None and parent not in self._meters:
+            raise ValueError(f"Parent scope '{parent}' must be registered before children")
+        self._meters[scope_id] = BudgetMeter(spec)
+        self._parents[scope_id] = parent
+
+    def preflight(
+        self, scope_id: str, cost: CostSnapshot, *, label: str = "preflight"
+    ) -> BudgetDecision:
+        self._ensure_scope(scope_id)
+        charges = [
+            self._meters[current].preview(cost, label=label)
+            for current in self._iter_chain(scope_id)
+        ]
+        return self._decision(scope_id, charges)
+
+    def commit(
+        self, scope_id: str, cost: CostSnapshot, *, label: str
+    ) -> BudgetDecision:
+        self._ensure_scope(scope_id)
+        charges: list[BudgetChargeResult] = []
+        errors: list[BudgetBreachError] = []
+        for current in self._iter_chain(scope_id):
+            result = self._meters[current].charge(cost, label=label)
+            charges.append(result)
+            self._emit_charge(result)
+            if result.breached:
+                action = (result.breach_action or "").lower()
+                if result.breach_kind is not None and result.breach_kind.value == "hard":
+                    errors.append(BudgetBreachError(result))
+                elif action == "error":
+                    errors.append(BudgetBreachError(result))
+        decision = self._decision(scope_id, charges)
+        if errors:
+            raise errors[0]
+        return decision
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_scope(self, scope_id: str) -> None:
+        if scope_id not in self._meters:
+            raise KeyError(f"Unknown budget scope '{scope_id}'")
+
+    def _iter_chain(self, scope_id: str) -> Iterable[str]:
+        current: str | None = scope_id
+        while current is not None:
+            yield current
+            current = self._parents.get(current)
+
+    def _decision(
+        self, scope_id: str, charges: Iterable[BudgetChargeResult]
+    ) -> BudgetDecision:
+        charge_tuple = tuple(charges)
+        breaches = tuple(result for result in charge_tuple if result.breached)
+        stop_requested = any(result.should_stop for result in charge_tuple)
+        return BudgetDecision(
+            scope_id=scope_id,
+            charges=charge_tuple,
+            breaches=breaches,
+            stop_requested=stop_requested,
+        )
+
+    def _emit_charge(self, charge: BudgetChargeResult) -> None:
+        if self._trace_emitter is None:
+            return
+        payload: dict[str, object] = {
+            "label": charge.label,
+            "cost": charge.cost.as_mapping(),
+            "remaining": charge.remaining,
+            "overages": charge.overages,
+            "breached": charge.breached,
+        }
+        self._trace_emitter("budget_charge", charge.scope, payload)
+        if charge.breached:
+            breach_payload = {
+                "label": charge.label,
+                "overages": charge.overages,
+                "remaining": charge.remaining,
+                "breach_action": charge.breach_action,
+            }
+            self._trace_emitter("budget_breach", charge.scope, breach_payload)

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/budget_models.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/budget_models.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Mapping, MutableMapping
+
+
+__all__ = [
+    "BudgetMode",
+    "BudgetSpec",
+    "CostSnapshot",
+    "BudgetChargeResult",
+    "BudgetMeter",
+    "BudgetBreachError",
+]
+
+
+class BudgetMode(str, Enum):
+    HARD = "hard"
+    SOFT = "soft"
+
+
+@dataclass(frozen=True, slots=True)
+class CostSnapshot:
+    usd: float
+    calls: int
+    tokens: int
+    time_ms: int
+
+    @classmethod
+    def zero(cls) -> "CostSnapshot":
+        return cls(usd=0.0, calls=0, tokens=0, time_ms=0)
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        usd: float | int = 0.0,
+        calls: int = 0,
+        tokens: int = 0,
+        time_ms: int | None = None,
+        time_seconds: float | int | None = None,
+    ) -> "CostSnapshot":
+        if time_ms is not None and time_seconds is not None:
+            raise ValueError("Provide either time_ms or time_seconds, not both")
+        if time_ms is None and time_seconds is not None:
+            time_ms = int(round(float(time_seconds) * 1000))
+        if time_ms is None:
+            time_ms = 0
+        return cls(
+            usd=float(usd),
+            calls=int(calls),
+            tokens=int(tokens),
+            time_ms=int(time_ms),
+        )
+
+    def add(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot(
+            usd=self.usd + other.usd,
+            calls=self.calls + other.calls,
+            tokens=self.tokens + other.tokens,
+            time_ms=self.time_ms + other.time_ms,
+        )
+
+    def as_mapping(self) -> Mapping[str, float | int]:
+        return MappingProxyType(
+            {
+                "usd": self.usd,
+                "calls": self.calls,
+                "tokens": self.tokens,
+                "time_ms": self.time_ms,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetSpec:
+    scope: str
+    mode: BudgetMode
+    limits: Mapping[str, float | int]
+    breach_action: str = "error"
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass hook
+        normalized: MutableMapping[str, float | int] = {}
+        for raw_key, raw_value in (self.limits or {}).items():
+            key, value = self._normalize_limit(raw_key, raw_value)
+            if value < 0:
+                value = 0
+            normalized[key] = value
+        object.__setattr__(self, "limits", MappingProxyType(dict(normalized)))
+        object.__setattr__(self, "breach_action", str(self.breach_action or "warn"))
+
+    @staticmethod
+    def _normalize_limit(key: str, value: float | int) -> tuple[str, float | int]:
+        key = key.lower()
+        mapping = {
+            "max_usd": "usd",
+            "usd": "usd",
+            "max_calls": "calls",
+            "calls": "calls",
+            "max_tokens": "tokens",
+            "tokens": "tokens",
+            "time_ms": "time_ms",
+            "time_limit_ms": "time_ms",
+            "time_limit_sec": "time_ms",
+            "time_seconds": "time_ms",
+        }
+        if key not in mapping:
+            raise ValueError(f"Unsupported budget limit key: {key}")
+        normalized_key = mapping[key]
+        if normalized_key == "usd":
+            normalized_value = float(value)
+        elif normalized_key in {"calls", "tokens"}:
+            normalized_value = int(value)
+        else:  # time_ms
+            if key in {"time_limit_sec", "time_seconds"}:
+                normalized_value = int(round(float(value) * 1000))
+            else:
+                normalized_value = int(value)
+        return normalized_key, normalized_value
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetChargeResult:
+    scope: str
+    label: str
+    cost: CostSnapshot
+    total: CostSnapshot
+    remaining: Mapping[str, float | int]
+    overages: Mapping[str, float | int]
+    breached: bool
+    breach_kind: BudgetMode | None
+    breach_action: str | None
+
+    @property
+    def should_stop(self) -> bool:
+        if not self.breached:
+            return False
+        if self.breach_kind is BudgetMode.HARD:
+            return True
+        if not self.breach_action:
+            return False
+        return self.breach_action.lower() in {"stop", "error"}
+
+
+class BudgetBreachError(RuntimeError):
+    def __init__(self, result: BudgetChargeResult):
+        message = (
+            f"Budget breach on {result.scope}: action={result.breach_action} "
+            f"remaining={dict(result.remaining)} overages={dict(result.overages)}"
+        )
+        super().__init__(message)
+        self.result = result
+
+
+class BudgetMeter:
+    def __init__(self, spec: BudgetSpec) -> None:
+        self.spec = spec
+        self._spend = CostSnapshot.zero()
+
+    def preview(self, cost: CostSnapshot, *, label: str = "preview") -> BudgetChargeResult:
+        return self._calculate(cost, label, mutate=False)
+
+    def charge(self, cost: CostSnapshot, *, label: str) -> BudgetChargeResult:
+        return self._calculate(cost, label, mutate=True)
+
+    def _calculate(self, cost: CostSnapshot, label: str, *, mutate: bool) -> BudgetChargeResult:
+        total = self._spend.add(cost)
+        if mutate:
+            self._spend = total
+
+        remaining: MutableMapping[str, float | int] = {}
+        overages: MutableMapping[str, float | int] = {}
+        breached = False
+        for key, limit in self.spec.limits.items():
+            spent_value = getattr(total, key)
+            remaining_value: float | int
+            overage_value: float | int
+            if limit == 0:
+                remaining_value = 0
+                overage_value = max(spent_value - limit, 0)
+            else:
+                remaining_value = max(limit - spent_value, 0)
+                overage_value = max(spent_value - limit, 0)
+            remaining[key] = remaining_value
+            overages[key] = overage_value
+            if overage_value > 0:
+                breached = True
+
+        return BudgetChargeResult(
+            scope=self.spec.scope,
+            label=label,
+            cost=cost,
+            total=total,
+            remaining=MappingProxyType(dict(remaining)),
+            overages=MappingProxyType(dict(overages)),
+            breached=breached,
+            breach_kind=self.spec.mode if breached else None,
+            breach_action=self.spec.breach_action if breached else None,
+        )

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/flow_runner.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/flow_runner.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping, MutableMapping, Protocol, Sequence
+
+try:  # pragma: no cover - allow standalone loading
+    from .budget_manager import BudgetDecision, BudgetManager
+    from .budget_models import BudgetBreachError, CostSnapshot
+    from .trace import TraceEventEmitter
+except ImportError:  # pragma: no cover
+    from budget_manager import BudgetDecision, BudgetManager  # type: ignore[F401]
+    from budget_models import BudgetBreachError, CostSnapshot  # type: ignore[F401]
+    from trace import TraceEventEmitter  # type: ignore[F401]
+
+
+class ToolAdapter(Protocol):
+    def estimate_cost(self) -> CostSnapshot:  # pragma: no cover - interface
+        ...
+
+    def execute(self) -> "ExecutionReport":  # pragma: no cover - interface
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionReport:
+    output: Mapping[str, object]
+    cost: CostSnapshot
+    metadata: Mapping[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class FlowNode:
+    id: str
+    kind: str
+    adapter_key: str
+    budget_scope: str | None = None
+
+    def scope_id(self) -> str:
+        return self.budget_scope or self.id
+
+
+@dataclass(frozen=True, slots=True)
+class LoopConfig:
+    id: str
+    nodes: Sequence[FlowNode]
+    max_iterations: int
+    budget_scope: str | None = None
+
+    def scope_id(self) -> str:
+        return self.budget_scope or self.id
+
+
+PlanNode = FlowNode | LoopConfig
+
+
+@dataclass(frozen=True, slots=True)
+class FlowPlan:
+    run_id: str
+    nodes: Sequence[PlanNode]
+
+
+@dataclass(frozen=True, slots=True)
+class LoopSummary:
+    iterations: int
+    stop_reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class FlowResult:
+    loop_summaries: Mapping[str, LoopSummary]
+
+
+@dataclass(slots=True)
+class _NodeOutcome:
+    executed: bool
+    decision: BudgetDecision | None = None
+    preflight: BudgetDecision | None = None
+
+
+class FlowRunner:
+    def __init__(
+        self,
+        *,
+        budget_manager: BudgetManager,
+        trace_emitter: TraceEventEmitter,
+    ) -> None:
+        self._budget_manager = budget_manager
+        self._trace_emitter = trace_emitter
+
+    def run(self, plan: FlowPlan, *, adapters: Mapping[str, ToolAdapter]) -> FlowResult:
+        loop_summaries: MutableMapping[str, LoopSummary] = {}
+        for node in plan.nodes:
+            if isinstance(node, LoopConfig):
+                summary = self._execute_loop(node, adapters)
+                loop_summaries[node.scope_id()] = summary
+            elif isinstance(node, FlowNode):
+                self._execute_node(node, adapters, iteration_label=node.id)
+            else:  # pragma: no cover - defensive guard
+                raise TypeError(f"Unsupported plan node: {type(node)!r}")
+        return FlowResult(loop_summaries=MappingProxyType(dict(loop_summaries)))
+
+    # ------------------------------------------------------------------
+    # Loop + node execution helpers
+    # ------------------------------------------------------------------
+    def _execute_loop(
+        self, loop: LoopConfig, adapters: Mapping[str, ToolAdapter]
+    ) -> LoopSummary:
+        iterations = 0
+        stop_reason: str | None = None
+        for index in range(loop.max_iterations):
+            executed_nodes = 0
+            for flow_node in loop.nodes:
+                label = f"{flow_node.id}#{index + 1}"
+                outcome = self._execute_node(flow_node, adapters, iteration_label=label)
+                if not outcome.executed:
+                    stop_reason = "budget_stop"
+                    break
+                executed_nodes += 1
+                if outcome.decision and outcome.decision.stop_requested:
+                    stop_reason = "budget_stop"
+                    break
+            if stop_reason is not None:
+                if executed_nodes:
+                    iterations += 1
+                break
+            iterations += 1
+        else:
+            stop_reason = "max_iterations"
+
+        if stop_reason is None:
+            stop_reason = "completed"
+
+        self._trace_emitter.emit(
+            "loop_stop",
+            loop.scope_id(),
+            {"reason": stop_reason, "iterations": iterations},
+        )
+        return LoopSummary(iterations=iterations, stop_reason=stop_reason)
+
+    def _execute_node(
+        self,
+        node: FlowNode,
+        adapters: Mapping[str, ToolAdapter],
+        *,
+        iteration_label: str,
+    ) -> _NodeOutcome:
+        adapter = adapters[node.adapter_key]
+        scope_id = node.scope_id()
+        estimate = adapter.estimate_cost()
+        preview = self._budget_manager.preflight(scope_id, estimate, label=f"{iteration_label}:preflight")
+        if preview.stop_requested:
+            critical = self._critical_breach(preview)
+            if critical is not None:
+                self._emit_preflight_traces(preview, iteration_label)
+                raise BudgetBreachError(critical)
+            return _NodeOutcome(executed=False, preflight=preview)
+        report = adapter.execute()
+        decision = self._budget_manager.commit(scope_id, report.cost, label=iteration_label)
+        return _NodeOutcome(executed=True, decision=decision)
+
+    def _critical_breach(self, decision: BudgetDecision) -> object | None:
+        for breach in decision.breaches:
+            action = (breach.breach_action or "").lower()
+            if breach.breach_kind is not None and getattr(breach.breach_kind, "value", str(breach.breach_kind)) == "hard":
+                return breach
+            if action == "error":
+                return breach
+        return None
+
+    def _emit_preflight_traces(self, decision: BudgetDecision, label: str) -> None:
+        for breach in decision.breaches:
+            payload = {
+                "label": f"{label}:preflight",
+                "remaining": breach.remaining,
+                "overages": breach.overages,
+                "breach_action": breach.breach_action,
+                "phase": "preflight",
+            }
+            self._trace_emitter.emit("budget_breach", breach.scope, payload)

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_manager.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[5]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str):
+    module_path = MODULE_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+budget_models = load_module("budget_models")
+BudgetSpec = budget_models.BudgetSpec
+BudgetMode = budget_models.BudgetMode
+BudgetBreachError = budget_models.BudgetBreachError
+CostSnapshot = budget_models.CostSnapshot
+
+budget_manager_mod = load_module("budget_manager")
+BudgetManager = budget_manager_mod.BudgetManager
+BudgetDecision = budget_manager_mod.BudgetDecision
+
+
+class DummyEmitter:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict[str, object]]] = []
+
+    def emit(self, event: str, scope: str, payload: dict[str, object]) -> None:
+        self.events.append((event, scope, payload))
+
+
+@pytest.fixture()
+def manager() -> tuple[BudgetManager, DummyEmitter]:
+    emitter = DummyEmitter()
+    mgr = BudgetManager(trace_emitter=emitter.emit)
+    return mgr, emitter
+
+
+def test_commit_updates_parent_and_child_scopes(manager: tuple[BudgetManager, DummyEmitter]) -> None:
+    mgr, emitter = manager
+
+    run_spec = BudgetSpec(scope="run", mode=BudgetMode.HARD, limits={"tokens": 150}, breach_action="error")
+    node_spec = BudgetSpec(scope="node:alpha", mode=BudgetMode.SOFT, limits={"tokens": 80}, breach_action="warn")
+
+    mgr.register_scope("run", run_spec)
+    mgr.register_scope("node:alpha", node_spec, parent="run")
+
+    decision = mgr.commit("node:alpha", CostSnapshot.from_values(tokens=60), label="node-alpha")
+    assert isinstance(decision, BudgetDecision)
+    assert len(decision.charges) == 2
+    child_charge = decision.charges[0]
+    run_charge = decision.charges[1]
+    assert dict(child_charge.remaining)["tokens"] == 20
+    assert dict(run_charge.remaining)["tokens"] == 90
+    assert not decision.stop_requested
+    assert len(emitter.events) == 2
+
+    with pytest.raises(BudgetBreachError):
+        mgr.commit("node:alpha", CostSnapshot.from_values(tokens=100), label="breach")
+
+
+def test_stop_request_propagates_from_loop_budget(manager: tuple[BudgetManager, DummyEmitter]) -> None:
+    mgr, _ = manager
+
+    run_spec = BudgetSpec(scope="run", mode=BudgetMode.HARD, limits={"calls": 10}, breach_action="error")
+    loop_spec = BudgetSpec(scope="loop:collect", mode=BudgetMode.SOFT, limits={"calls": 2}, breach_action="stop")
+    node_spec = BudgetSpec(scope="node:collect", mode=BudgetMode.SOFT, limits={"calls": 3}, breach_action="warn")
+
+    mgr.register_scope("run", run_spec)
+    mgr.register_scope("loop:collect", loop_spec, parent="run")
+    mgr.register_scope("node:collect", node_spec, parent="loop:collect")
+
+    first = mgr.commit("node:collect", CostSnapshot.from_values(calls=1), label="iter1")
+    assert not first.stop_requested
+
+    second = mgr.commit("node:collect", CostSnapshot.from_values(calls=2), label="iter2")
+    assert second.stop_requested
+    assert any(charge.breach_action == "stop" for charge in second.breaches)
+
+
+def test_preflight_does_not_mutate_scope_state(manager: tuple[BudgetManager, DummyEmitter]) -> None:
+    mgr, _ = manager
+
+    run_spec = BudgetSpec(scope="run", mode=BudgetMode.HARD, limits={"tokens": 50}, breach_action="error")
+    node_spec = BudgetSpec(scope="node:beta", mode=BudgetMode.SOFT, limits={"tokens": 30}, breach_action="warn")
+
+    mgr.register_scope("run", run_spec)
+    mgr.register_scope("node:beta", node_spec, parent="run")
+
+    preview = mgr.preflight("node:beta", CostSnapshot.from_values(tokens=80))
+    assert preview.stop_requested
+    assert any(charge.scope == "node:beta" for charge in preview.breaches)
+
+    decision = mgr.commit("node:beta", CostSnapshot.from_values(tokens=10), label="post-preview")
+    assert not decision.breached

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_budget_models.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[5]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str):
+    module_path = MODULE_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+budget_models = load_module("budget_models")
+BudgetSpec = budget_models.BudgetSpec
+BudgetMode = budget_models.BudgetMode
+BudgetMeter = budget_models.BudgetMeter
+CostSnapshot = budget_models.CostSnapshot
+
+
+def test_cost_snapshot_normalizes_seconds_to_milliseconds():
+    snapshot = CostSnapshot.from_values(time_seconds=1.25)
+    assert snapshot.time_ms == 1250
+    assert snapshot.calls == 0
+    assert snapshot.tokens == 0
+    assert snapshot.usd == 0.0
+
+
+def test_budget_meter_soft_budget_records_overage_without_stop():
+    spec = BudgetSpec(
+        scope="node:alpha",
+        mode=BudgetMode.SOFT,
+        limits={"tokens": 100},
+        breach_action="warn",
+    )
+    meter = BudgetMeter(spec)
+
+    first = meter.charge(CostSnapshot.from_values(tokens=80), label="first")
+    assert not first.breached
+    assert dict(first.remaining)["tokens"] == 20
+    assert dict(first.overages)["tokens"] == 0
+
+    second = meter.charge(CostSnapshot.from_values(tokens=30), label="second")
+    assert second.breached
+    assert second.breach_kind == BudgetMode.SOFT
+    assert not second.should_stop
+    assert dict(second.overages)["tokens"] == 10
+
+    with pytest.raises(TypeError):
+        second.remaining["tokens"] = 5  # type: ignore[index]
+
+
+def test_budget_meter_hard_budget_flags_stop():
+    spec = BudgetSpec(
+        scope="run",
+        mode=BudgetMode.HARD,
+        limits={"usd": 5.0},
+        breach_action="error",
+    )
+    meter = BudgetMeter(spec)
+
+    meter.charge(CostSnapshot.from_values(usd=3.5), label="setup")
+    result = meter.charge(CostSnapshot.from_values(usd=2.25), label="breach")
+
+    assert result.breached
+    assert result.breach_kind == BudgetMode.HARD
+    assert result.should_stop
+    assert pytest.approx(dict(result.overages)["usd"], rel=1e-6) == 0.75

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/tests/test_flow_runner.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[5]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str):
+    module_path = MODULE_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+budget_models = load_module("budget_models")
+BudgetSpec = budget_models.BudgetSpec
+BudgetMode = budget_models.BudgetMode
+BudgetBreachError = budget_models.BudgetBreachError
+CostSnapshot = budget_models.CostSnapshot
+
+budget_manager_mod = load_module("budget_manager")
+BudgetManager = budget_manager_mod.BudgetManager
+
+trace_mod = load_module("trace")
+TraceEventEmitter = trace_mod.TraceEventEmitter
+
+flow_runner_mod = load_module("flow_runner")
+FlowRunner = flow_runner_mod.FlowRunner
+FlowNode = flow_runner_mod.FlowNode
+LoopConfig = flow_runner_mod.LoopConfig
+FlowPlan = flow_runner_mod.FlowPlan
+ExecutionReport = flow_runner_mod.ExecutionReport
+
+
+class SequencedAdapter:
+    def __init__(self, costs: Iterable[CostSnapshot]) -> None:
+        self._costs = list(costs)
+        self._index = 0
+
+    def estimate_cost(self) -> CostSnapshot:
+        return self._costs[self._index]
+
+    def execute(self) -> ExecutionReport:
+        cost = self._costs[self._index]
+        self._index += 1
+        return ExecutionReport(output={"iteration": self._index}, cost=cost, metadata={})
+
+
+def build_runner(run_budget: BudgetSpec | None = None) -> tuple[FlowRunner, BudgetManager, TraceEventEmitter]:
+    emitter = TraceEventEmitter()
+    manager = BudgetManager(trace_emitter=emitter.emit)
+    runner = FlowRunner(budget_manager=manager, trace_emitter=emitter)
+    if run_budget is not None:
+        manager.register_scope("run", run_budget)
+    return runner, manager, emitter
+
+
+def test_flow_runner_stops_loop_on_budget_stop():
+    run_budget = BudgetSpec(scope="run", mode=BudgetMode.HARD, limits={"calls": 10}, breach_action="error")
+    loop_budget = BudgetSpec(scope="loop:collect", mode=BudgetMode.SOFT, limits={"calls": 2}, breach_action="stop")
+    node_budget = BudgetSpec(scope="node:collect", mode=BudgetMode.SOFT, limits={"calls": 5}, breach_action="warn")
+
+    runner, manager, emitter = build_runner(run_budget)
+    manager.register_scope("loop:collect", loop_budget, parent="run")
+    manager.register_scope("node:collect", node_budget, parent="loop:collect")
+
+    costs = [CostSnapshot.from_values(calls=1) for _ in range(5)]
+    adapters = {"node:collect": SequencedAdapter(costs)}
+
+    plan = FlowPlan(
+        run_id="run-123",
+        nodes=(
+            LoopConfig(
+                id="loop:collect",
+                nodes=(FlowNode(id="node:collect", kind="unit", adapter_key="node:collect"),),
+                max_iterations=5,
+                budget_scope="loop:collect",
+            ),
+        ),
+    )
+
+    result = runner.run(plan=plan, adapters=adapters)
+
+    summary = result.loop_summaries["loop:collect"]
+    assert summary.iterations == 2
+    assert summary.stop_reason == "budget_stop"
+
+    loop_events = [event for event in emitter.events if event.event == "budget_charge" and event.scope == "loop:collect"]
+    assert len(loop_events) == 2
+    with pytest.raises(TypeError):
+        loop_events[0].payload["remaining"]["calls"] = 99  # type: ignore[index]
+
+    stop_events = [event for event in emitter.events if event.event == "loop_stop"]
+    assert stop_events and stop_events[0].payload["reason"] == "budget_stop"
+
+
+def test_flow_runner_raises_on_hard_run_breach():
+    run_budget = BudgetSpec(scope="run", mode=BudgetMode.HARD, limits={"usd": 3.0}, breach_action="error")
+    node_budget = BudgetSpec(scope="node:expensive", mode=BudgetMode.HARD, limits={"usd": 2.0}, breach_action="error")
+
+    runner, manager, emitter = build_runner(run_budget)
+    manager.register_scope("node:expensive", node_budget, parent="run")
+
+    adapters = {
+        "node:expensive": SequencedAdapter([CostSnapshot.from_values(usd=4.5)])
+    }
+
+    plan = FlowPlan(
+        run_id="run-456",
+        nodes=(FlowNode(id="node:expensive", kind="unit", adapter_key="node:expensive"),),
+    )
+
+    with pytest.raises(BudgetBreachError):
+        runner.run(plan=plan, adapters=adapters)
+
+    assert any(event.event == "budget_breach" and event.scope == "run" for event in emitter.events)
+
+
+def test_preflight_blocks_iteration_before_execute():
+    run_budget = BudgetSpec(scope="run", mode=BudgetMode.HARD, limits={"tokens": 100}, breach_action="error")
+    loop_budget = BudgetSpec(scope="loop:writer", mode=BudgetMode.SOFT, limits={"tokens": 3}, breach_action="stop")
+    node_budget = BudgetSpec(scope="node:writer", mode=BudgetMode.SOFT, limits={"tokens": 5}, breach_action="warn")
+
+    runner, manager, emitter = build_runner(run_budget)
+    manager.register_scope("loop:writer", loop_budget, parent="run")
+    manager.register_scope("node:writer", node_budget, parent="loop:writer")
+
+    adapters = {"node:writer": SequencedAdapter([CostSnapshot.from_values(tokens=1) for _ in range(4)])}
+
+    plan = FlowPlan(
+        run_id="run-789",
+        nodes=(
+            LoopConfig(
+                id="loop:writer",
+                nodes=(FlowNode(id="node:writer", kind="unit", adapter_key="node:writer"),),
+                max_iterations=10,
+                budget_scope="loop:writer",
+            ),
+        ),
+    )
+
+    result = runner.run(plan=plan, adapters=adapters)
+
+    summary = result.loop_summaries["loop:writer"]
+    assert summary.iterations == 3
+    assert summary.stop_reason == "budget_stop"
+
+    loop_charges = [event for event in emitter.events if event.event == "budget_charge" and event.scope == "loop:writer"]
+    assert len(loop_charges) == 3

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/trace.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/trace.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Callable, Mapping, MutableMapping, Sequence
+
+
+__all__ = ["TraceEvent", "TraceEventEmitter"]
+
+
+@dataclass(frozen=True, slots=True)
+class TraceEvent:
+    event: str
+    scope: str
+    payload: Mapping[str, object]
+
+
+class TraceEventEmitter:
+    def __init__(self, *, sink: Callable[[TraceEvent], None] | None = None) -> None:
+        self._sink = sink
+        self._events: list[TraceEvent] = []
+
+    def emit(self, event: str, scope: str, payload: Mapping[str, object] | MappingProxyType) -> None:
+        frozen_payload = _freeze_payload(payload)
+        record = TraceEvent(event=event, scope=scope, payload=frozen_payload)
+        self._events.append(record)
+        if self._sink is not None:
+            self._sink(record)
+
+    @property
+    def events(self) -> Sequence[TraceEvent]:
+        return tuple(self._events)
+
+
+def _freeze_payload(data: Mapping[str, object] | MappingProxyType) -> Mapping[str, object]:
+    frozen: MutableMapping[str, object] = {}
+    for key, value in data.items():
+        frozen[key] = _freeze_value(value)
+    return MappingProxyType(dict(frozen))
+
+
+def _freeze_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        return _freeze_payload(value)
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return tuple(_freeze_value(item) for item in value)
+    return value


### PR DESCRIPTION
## Summary
- add immutable budget models and metering utilities for scope spend tracking
- introduce a hierarchical BudgetManager with preflight/commit lifecycle and trace emission
- extend the FlowRunner to enforce budgets, stop loops on breaches, and emit immutable trace events alongside unit coverage

## Testing
- pytest codex/code/07b_budget_guards_and_runner_integration.yaml/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e895292a74832c97ce572dc258343c