### PR TITLE
Implement Phase 3 budget guards and runner integration

### DIFF
--- a/codex/DOCUMENTATION/P3/work-20250505-gpt5codex.yaml
+++ b/codex/DOCUMENTATION/P3/work-20250505-gpt5codex.yaml
@@ -1,0 +1,54 @@
+component: budget_guard_runner_phase3
+purpose: |
+  Provide canonical budget data models, a scope-aware BudgetManager, and an adapter-backed FlowRunner that integrates
+  budget enforcement with policy checks while emitting immutable trace events.
+cli_usage:
+  description: Execute targeted validation for budget guards.
+  command: pytest codex/code/work/tests -q
+public_interfaces:
+  - name: codex.code.work.dsl.budget_models.CostSnapshot
+    description: Normalised cost record supporting additive arithmetic and payload serialisation.
+  - name: codex.code.work.dsl.budget_models.BudgetSpec
+    description: Declarative budget definition including scope, limits, and breach semantics.
+  - name: codex.code.work.dsl.budget_models.BudgetDecision
+    description: Aggregates outcomes for a scope and identifies blocking breaches.
+  - name: codex.code.work.dsl.budget_manager.BudgetManager
+    description: Coordinates scope lifecycle, preview/commit flows, and breach telemetry.
+  - name: codex.code.work.dsl.flow_runner.FlowRunner
+    description: Executes flow nodes via adapters with integrated policy and budget enforcement.
+extension_hooks:
+  - hook: BudgetManager.record_breach
+    extension: Attach alternative emitters or sinks before raising stop errors.
+  - hook: TraceEventEmitter.attach_sink
+    extension: Forward immutable trace events to structured logging systems.
+configurable_options:
+  - name: BudgetSpec.mode
+    values: [hard, soft]
+    default: hard
+  - name: BudgetSpec.breach_action
+    values: [stop, warn]
+    default: stop
+automation_triggers:
+  - trigger: PolicyStack.enforce
+    outcome: Ensures policy validation precedes adapter execution.
+error_contracts:
+  - name: BudgetBreachError
+    raised_when: Hard-stop or stop-configured budgets breach during preview/commit.
+    payload: scope metadata and breached BudgetChargeOutcome.
+  - name: BudgetError
+    raised_when: Inconsistent manager state (e.g., missing blocking outcome).
+serialization:
+  trace_payloads: Immutable mapping proxies containing cost, totals, remaining, and overage metrics.
+  cost_snapshot: Dict with time_ms (float) and tokens (int).
+lifecycle:
+  - enter_scope -> preview_charge -> record_breach (optional) -> commit_charge -> exit_scope
+  - FlowRunner orchestrates run scope, per-node scopes, and adapter execution results.
+typing:
+  language: Python 3.12
+  typing: dataclasses with type annotations; Protocol for ToolAdapter.
+security:
+  - Ensure adapters are trusted; FlowRunner does not sandbox execution.
+  - Trace payloads redact nothing by default—route through trusted sinks only.
+performance:
+  - Cost computations operate on simple floats/ints; negligible overhead for preview/commit loops.
+  - Trace emission is synchronous; attach asynchronous sink if high volume expected.

--- a/codex/TESTS/P3/work-20250505-gpt5codex.yaml
+++ b/codex/TESTS/P3/work-20250505-gpt5codex.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_loop_scope_budget_stop
+      rationale: Cover loop scope entry/exit and ensure budget stop halts loop iterations with correct trace ordering.
+      source_module: codex/code/work/dsl/flow_runner.py
+      priority: high
+    - name: test_policy_and_budget_violation_coexistence
+      rationale: Validate FlowRunner behaviour when a policy denial and budget breach occur on the same node.
+      source_module: codex/code/work/dsl/flow_runner.py
+      priority: medium
+    - name: test_trace_payload_schema_validation
+      rationale: Ensure emitted trace payloads conform to DSL schema via jsonschema validation helper.
+      source_module: codex/code/work/dsl/trace.py
+      priority: medium

--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -1,0 +1,1 @@
+"""Codex automation helper package."""

--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.md
@@ -1,0 +1,14 @@
+# Phase 3 Post-Execution – Budget guards and runner integration
+
+## Test & Coverage Summary
+- `pytest codex/code/work/tests -q`
+  - All 12 assertions passed across model, manager, and runner suites.
+
+## Notable Outcomes
+- History ledger in `BudgetManager` enables inspection after scope exit, satisfying integration tests.
+- FlowRunner raises `BudgetBreachError` for node hard stops while leaving run scope history available for diagnostics.
+- Trace emission centralised through `TraceEventEmitter` confirmed immutable payloads during tests.
+
+## Follow-ups
+- Consider schema validation of emitted payloads against DSL trace schema for additional safety.
+- Extend integration tests to cover loop scopes and simultaneous policy + budget breaches.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.md
@@ -1,0 +1,12 @@
+# Phase 3 Preview – Budget guards and runner integration
+
+## Overview
+- Normalised cost math through `CostSnapshot` with seconds-to-milliseconds conversion and immutable helpers.
+- Structured budget models (`BudgetSpec`, `BudgetChargeOutcome`, `BudgetDecision`) driving deterministic trace payloads.
+- Scope-aware `BudgetManager` orchestrating preview/commit flows with breach telemetry and history snapshots.
+- Adapter-backed `FlowRunner` enforcing policies, applying budgets per scope, and emitting run/node lifecycle traces.
+
+## Planned Validation
+- Unit tests for model math, breach stop/warn semantics, and immutable trace payloads.
+- Manager tests covering preview/commit, hard-stop exceptions, warn-and-commit behaviour, and scope lifecycle guards.
+- Runner integration tests verifying adapter orchestration, policy enforcement, hard-stop interruption, and soft-run warnings.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.md
@@ -1,0 +1,13 @@
+# Phase 3 Review Notes – Budget guards and runner integration
+
+## Checklist
+- [x] Cost normalisation handles seconds → milliseconds and preserves tokens.
+- [x] BudgetManager distinguishes warn vs stop and logs breaches before raising.
+- [x] FlowRunner enforces PolicyStack prior to adapter execution and releases scopes on errors.
+- [x] Trace payloads flow through `TraceEventEmitter` and remain immutable mapping proxies.
+- [x] Tests cover hard stop, soft warn, scope exit validation, and integration pathways.
+
+## Reviewer Guidance
+- Verify history snapshots allow inspection after scope exit.
+- Confirm FlowRunner surfaces `BudgetBreachError` with node scope metadata for hard stops.
+- Ensure adapters without specs still execute (decisions with zero outcomes) without errors.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.yaml
@@ -1,0 +1,67 @@
+summary: Reinstate adapter-backed FlowRunner with BudgetManager integration and immutable traces
+justification: |
+  Phase 2 synthesis selected immutable budget models, the BudgetManager orchestration, and adapter-driven FlowRunner execution.
+  This plan codifies those choices into a focused implementation that maximises reuse, restores policy enforcement, and
+  validates stop/warn semantics across run/node/loop scopes with trace schema alignment.
+steps:
+  - name: budget_models
+    description: Consolidate typed budget DTOs with normalization helpers and structured charge outcomes.
+  - name: trace_emitter
+    description: Provide immutable trace emitter shared by budget and policy integrations.
+  - name: budget_manager
+    description: Implement scope-aware BudgetManager orchestrating preflight/commit across scopes with trace hooks.
+  - name: flow_runner
+    description: Wire FlowRunner to adapters, BudgetManager, and PolicyStack enforcing stop semantics and trace emission.
+modules:
+  - path: codex/code/work/dsl/budget_models.py
+    role: Canonical budget value objects and helpers adopted across manager and runner.
+  - path: codex/code/work/dsl/trace.py
+    role: Shared TraceEventEmitter producing immutable payloads for policy and budget traces.
+  - path: codex/code/work/dsl/budget_manager.py
+    role: Scope-aware orchestration layer coordinating budgets, traces, and breach outcomes.
+  - path: codex/code/work/dsl/flow_runner.py
+    role: Adapter-backed runner enforcing policies and budgets with deterministic traces.
+  - path: codex/code/work/tests/__init__.py
+    role: Test package initialiser.
+  - path: codex/code/work/__init__.py
+    role: Package initialiser for module discovery.
+tests:
+  - path: codex/code/work/tests/test_budget_models.py
+    coverage: cost normalization, charge outcome remaining/overage math, immutability guards.
+    mocks: none (pure data models).
+  - path: codex/code/work/tests/test_budget_manager.py
+    coverage: preflight vs commit, soft/hard breach actions, trace emission.
+    mocks: FakeTraceEmitter for deterministic capture.
+  - path: codex/code/work/tests/test_flow_runner_budget_integration.py
+    coverage: FlowRunner adapter orchestration, policy enforcement, loop stop vs warn semantics, trace ordering.
+    mocks: Fake adapters, in-memory policy stack fixtures, FakeTraceEmitter.
+run_order:
+  - pytest codex/code/work/tests/test_budget_models.py
+  - pytest codex/code/work/tests/test_budget_manager.py
+  - pytest codex/code/work/tests/test_flow_runner_budget_integration.py
+interfaces:
+  budget_models: [CostSnapshot, BudgetSpec, BudgetCharge, BudgetChargeOutcome, BudgetDecision]
+  budget_manager: [BudgetManager.enter_scope, BudgetManager.exit_scope, BudgetManager.preview_charge, BudgetManager.commit_charge]
+  flow_runner: [FlowRunner.run, FlowRunner._execute_node]
+  trace: [TraceEventEmitter.emit, TraceEventEmitter.attach_sink]
+tdd_coverage_targets:
+  codex/code/work/dsl/budget_models.py: 95
+  codex/code/work/dsl/budget_manager.py: 90
+  codex/code/work/dsl/flow_runner.py: 85
+review_checklist:
+  - Ensure CostSnapshot normalizes seconds to milliseconds and preserves integer tokens.
+  - Confirm BudgetManager differentiates warn vs stop actions and records breaches in traces.
+  - Validate FlowRunner enforces PolicyStack decisions before adapter execution.
+  - Verify trace payloads use mapping proxies (immutable) and maintain schema-aligned fields.
+  - Check tests cover both happy path and breach scenarios with deterministic adapters.
+outputs:
+  plan: codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.yaml
+  tests: codex/code/work/tests
+  implementation: codex/code/work/dsl
+  documentation:
+    preview: codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.md
+    review: codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.md
+    postexecution: codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250505-gpt5codex.md
+    metadata: codex/DOCUMENTATION/P3/work-20250505-gpt5codex.yaml
+  missing_tests: codex/TESTS/P3/work-20250505-gpt5codex.yaml
+  optional_runner: codex/code/07b_budget_guards_and_runner_integration.yaml/phase3_runner.py

--- a/codex/code/work/__init__.py
+++ b/codex/code/work/__init__.py
@@ -1,0 +1,1 @@
+"""Work branch package for Phase 3 implementations."""

--- a/codex/code/work/dsl/__init__.py
+++ b/codex/code/work/dsl/__init__.py
@@ -1,0 +1,5 @@
+"""DSL helpers for Phase 3 work branch."""
+
+from . import budget_models
+
+__all__ = ["budget_models"]

--- a/codex/code/work/dsl/budget_manager.py
+++ b/codex/code/work/dsl/budget_manager.py
@@ -1,0 +1,139 @@
+"""Scope-aware budget manager coordinating previews, commits, and traces."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from . import budget_models as bm
+from .trace import TraceEventEmitter
+
+__all__ = ["BudgetManager", "BudgetBreachError", "BudgetError"]
+
+
+class BudgetError(RuntimeError):
+    """Base error for budget management."""
+
+
+class BudgetBreachError(BudgetError):
+    """Raised when a budget breach requires execution to stop."""
+
+    def __init__(self, scope: bm.ScopeKey, outcome: bm.BudgetChargeOutcome) -> None:
+        super().__init__(
+            f"Budget '{outcome.spec.name}' breached at {scope.scope_type}:{scope.scope_id}"
+        )
+        self.scope = scope
+        self.outcome = outcome
+
+
+@dataclass(slots=True)
+class _ScopeState:
+    scope: bm.ScopeKey
+    spent: dict[str, bm.CostSnapshot]
+
+
+class BudgetManager:
+    """Coordinate budget previews and commits across scopes."""
+
+    def __init__(
+        self,
+        *,
+        specs: Iterable[bm.BudgetSpec],
+        trace: TraceEventEmitter | None = None,
+    ) -> None:
+        self._trace = trace or TraceEventEmitter()
+        self._specs_by_scope: dict[str, list[bm.BudgetSpec]] = defaultdict(list)
+        for spec in specs:
+            self._specs_by_scope[spec.scope_type].append(spec)
+        self._scopes: dict[bm.ScopeKey, _ScopeState] = {}
+        self._history: dict[bm.ScopeKey, _ScopeState] = {}
+
+    # ------------------------------------------------------------------
+    # Scope management
+    # ------------------------------------------------------------------
+    def enter_scope(self, scope: bm.ScopeKey) -> None:
+        if scope in self._scopes:
+            raise KeyError(f"scope already active: {scope}")
+        self._history.pop(scope, None)
+        specs = self._specs_by_scope.get(scope.scope_type, [])
+        spent = {spec.name: bm.CostSnapshot.zero() for spec in specs}
+        self._scopes[scope] = _ScopeState(scope=scope, spent=spent)
+
+    def exit_scope(self, scope: bm.ScopeKey) -> None:
+        if scope not in self._scopes:
+            raise KeyError(f"scope not active: {scope}")
+        state = self._scopes.pop(scope)
+        self._history[scope] = state
+
+    # ------------------------------------------------------------------
+    # Charging
+    # ------------------------------------------------------------------
+    def preview_charge(
+        self,
+        scope: bm.ScopeKey,
+        cost: bm.CostSnapshot,
+    ) -> bm.BudgetDecision:
+        state = self._scopes.get(scope)
+        if state is None:
+            raise KeyError(f"scope not active: {scope}")
+        specs = self._specs_by_scope.get(scope.scope_type, [])
+        outcomes: list[bm.BudgetChargeOutcome] = []
+        for spec in specs:
+            prior = state.spent[spec.name]
+            outcome = bm.BudgetChargeOutcome.compute(spec=spec, prior=prior, cost=cost)
+            outcomes.append(outcome)
+        decision = bm.BudgetDecision.make(scope=scope, cost=cost, outcomes=outcomes)
+        return decision
+
+    def commit_charge(self, decision: bm.BudgetDecision) -> None:
+        state = self._scopes.get(decision.scope)
+        if state is None:
+            raise KeyError(f"scope not active: {decision.scope}")
+        if decision.should_stop:
+            blocking = decision.blocking
+            if blocking is None:  # pragma: no cover - defensive guard
+                raise BudgetError("blocking outcome missing for stop decision")
+            raise BudgetBreachError(decision.scope, blocking)
+        for outcome in decision.outcomes:
+            state.spent[outcome.spec.name] = outcome.charge.new_total
+            self._trace.emit(
+                "budget_charge",
+                scope_type=decision.scope.scope_type,
+                scope_id=decision.scope.scope_id,
+                payload=outcome.to_trace_payload(
+                    scope_type=decision.scope.scope_type,
+                    scope_id=decision.scope.scope_id,
+                ),
+            )
+
+    def record_breach(self, decision: bm.BudgetDecision) -> None:
+        state = self._scopes.get(decision.scope)
+        if state is None:
+            raise KeyError(f"scope not active: {decision.scope}")
+        for outcome in decision.outcomes:
+            if outcome.breached:
+                self._trace.emit(
+                    "budget_breach",
+                    scope_type=decision.scope.scope_type,
+                    scope_id=decision.scope.scope_id,
+                    payload=outcome.to_trace_payload(
+                        scope_type=decision.scope.scope_type,
+                        scope_id=decision.scope.scope_id,
+                    ),
+                )
+
+    # ------------------------------------------------------------------
+    # Inspection helpers
+    # ------------------------------------------------------------------
+    def spent(self, scope: bm.ScopeKey, spec_name: str) -> bm.CostSnapshot:
+        state = self._scopes.get(scope)
+        if state is None:
+            state = self._history.get(scope)
+            if state is None:
+                raise KeyError(f"scope not active: {scope}")
+        return state.spent[spec_name]
+
+    @property
+    def trace(self) -> TraceEventEmitter:
+        return self._trace

--- a/codex/code/work/dsl/budget_models.py
+++ b/codex/code/work/dsl/budget_models.py
@@ -1,0 +1,212 @@
+"""Canonical budget models reused by manager and FlowRunner."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .trace import TraceEventEmitter
+
+__all__ = [
+    "ScopeKey",
+    "CostSnapshot",
+    "BudgetSpec",
+    "BudgetCharge",
+    "BudgetChargeOutcome",
+    "BudgetDecision",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ScopeKey:
+    """Identifies a budget scope (run/node/loop/etc.)."""
+
+    scope_type: str
+    scope_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class CostSnapshot:
+    """Normalized cost snapshot in milliseconds and tokens."""
+
+    time_ms: float = 0.0
+    tokens: int = 0
+
+    def __add__(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot(
+            time_ms=self.time_ms + other.time_ms,
+            tokens=self.tokens + other.tokens,
+        )
+
+    def __sub__(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot(
+            time_ms=max(0.0, self.time_ms - other.time_ms),
+            tokens=max(0, self.tokens - other.tokens),
+        )
+
+    @classmethod
+    def zero(cls) -> "CostSnapshot":
+        return cls()
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any] | None) -> "CostSnapshot":
+        if raw is None:
+            return cls.zero()
+        time_ms = float(raw.get("time_ms", 0.0))
+        if "time_s" in raw:
+            time_ms += float(raw["time_s"]) * 1000.0
+        tokens = int(raw.get("tokens", 0))
+        return cls(time_ms=time_ms, tokens=tokens)
+
+    def has_positive(self) -> bool:
+        return self.time_ms > 0.0 or self.tokens > 0
+
+    def to_payload(self) -> dict[str, float | int]:
+        return {"time_ms": float(self.time_ms), "tokens": int(self.tokens)}
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetSpec:
+    """Declarative definition of a budget."""
+
+    name: str
+    scope_type: str
+    limit: CostSnapshot
+    mode: str = "hard"  # "hard" or "soft"
+    breach_action: str = "stop"  # "stop" or "warn"
+
+    def __post_init__(self) -> None:  # pragma: no cover - validation
+        mode = self.mode.lower()
+        action = self.breach_action.lower()
+        if mode not in {"hard", "soft"}:
+            raise ValueError("mode must be 'hard' or 'soft'")
+        if action not in {"stop", "warn"}:
+            raise ValueError("breach_action must be 'stop' or 'warn'")
+        object.__setattr__(self, "mode", mode)
+        object.__setattr__(self, "breach_action", action)
+
+    def should_stop(self, breached: bool) -> bool:
+        if not breached:
+            return False
+        if self.mode == "hard":
+            return True
+        return self.breach_action == "stop"
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetCharge:
+    """Computed charge against a spec."""
+
+    spec: BudgetSpec
+    cost: CostSnapshot
+    prior: CostSnapshot
+    new_total: CostSnapshot
+    remaining: CostSnapshot
+    overage: CostSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetChargeOutcome:
+    """Outcome of applying a cost to a budget spec."""
+
+    spec: BudgetSpec
+    charge: BudgetCharge
+    breached: bool
+
+    @classmethod
+    def compute(
+        cls,
+        *,
+        spec: BudgetSpec,
+        prior: CostSnapshot,
+        cost: CostSnapshot,
+    ) -> "BudgetChargeOutcome":
+        new_total = prior + cost
+        remaining_time = spec.limit.time_ms - new_total.time_ms
+        remaining_tokens = spec.limit.tokens - new_total.tokens
+        remaining = CostSnapshot(time_ms=remaining_time, tokens=remaining_tokens)
+        overage = CostSnapshot(
+            time_ms=max(0.0, -remaining_time),
+            tokens=max(0, -remaining_tokens),
+        )
+        breached = overage.has_positive()
+        charge = BudgetCharge(
+            spec=spec,
+            cost=cost,
+            prior=prior,
+            new_total=new_total,
+            remaining=remaining,
+            overage=overage,
+        )
+        return cls(spec=spec, charge=charge, breached=breached)
+
+    @property
+    def should_stop(self) -> bool:
+        return self.spec.should_stop(self.breached)
+
+    def to_trace_payload(self, *, scope_type: str, scope_id: str) -> Mapping[str, Any]:
+        from types import MappingProxyType
+
+        payload = {
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "spec_name": self.spec.name,
+            "mode": self.spec.mode,
+            "breach_action": self.spec.breach_action,
+            "breached": self.breached,
+            "should_stop": self.should_stop,
+            "cost": self.charge.cost.to_payload(),
+            "prior": self.charge.prior.to_payload(),
+            "new_total": self.charge.new_total.to_payload(),
+            "remaining": self.charge.remaining.to_payload(),
+            "overage": self.charge.overage.to_payload(),
+        }
+        return MappingProxyType(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetDecision:
+    """Aggregate of multiple budget outcomes for a scope."""
+
+    scope: ScopeKey
+    cost: CostSnapshot
+    outcomes: tuple[BudgetChargeOutcome, ...]
+    blocking: BudgetChargeOutcome | None
+
+    @classmethod
+    def make(
+        cls,
+        *,
+        scope: ScopeKey,
+        cost: CostSnapshot,
+        outcomes: Iterable[BudgetChargeOutcome],
+    ) -> "BudgetDecision":
+        materialized = tuple(outcomes)
+        blocking = next((out for out in materialized if out.should_stop), None)
+        return cls(scope=scope, cost=cost, outcomes=materialized, blocking=blocking)
+
+    @property
+    def breached(self) -> bool:
+        return any(outcome.breached for outcome in self.outcomes)
+
+    @property
+    def should_stop(self) -> bool:
+        return self.blocking is not None
+
+    def to_trace_records(
+        self,
+        *,
+        emitter: TraceEventEmitter,
+        event: str,
+    ) -> None:
+        for outcome in self.outcomes:
+            emitter.emit(
+                event,
+                scope_type=self.scope.scope_type,
+                scope_id=self.scope.scope_id,
+                payload=outcome.to_trace_payload(
+                    scope_type=self.scope.scope_type,
+                    scope_id=self.scope.scope_id,
+                ),
+            )

--- a/codex/code/work/dsl/flow_runner.py
+++ b/codex/code/work/dsl/flow_runner.py
@@ -1,0 +1,132 @@
+"""Adapter-backed FlowRunner integrating budgets and policies."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from pkgs.dsl.policy import PolicyStack, PolicyViolationError
+
+from . import budget_models as bm
+from .budget_manager import BudgetBreachError, BudgetError, BudgetManager
+from .trace import TraceEventEmitter
+
+__all__ = ["ToolAdapter", "NodeExecution", "FlowRunner"]
+
+
+@runtime_checkable
+class ToolAdapter(Protocol):
+    """Protocol implemented by tool adapters."""
+
+    def estimate_cost(self, node: Mapping[str, object]) -> Mapping[str, object]:
+        ...
+
+    def execute(self, node: Mapping[str, object]) -> object:
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class NodeExecution:
+    """Immutable record of node execution."""
+
+    node_id: str
+    tool: str
+    result: object
+
+
+class FlowRunner:
+    """Execute flow nodes with policy enforcement and budget guards."""
+
+    def __init__(
+        self,
+        *,
+        adapters: Mapping[str, ToolAdapter],
+        budget_manager: BudgetManager,
+        policy_stack: PolicyStack,
+        trace: TraceEventEmitter | None = None,
+    ) -> None:
+        self._adapters = dict(adapters)
+        self._budgets = budget_manager
+        self._policies = policy_stack
+        self._trace = trace or budget_manager.trace
+
+    def run(
+        self,
+        *,
+        flow_id: str,
+        run_id: str,
+        nodes: Iterable[Mapping[str, object]],
+    ) -> list[NodeExecution]:
+        run_scope = bm.ScopeKey(scope_type="run", scope_id=run_id)
+        self._budgets.enter_scope(run_scope)
+        self._trace.emit(
+            "run_start",
+            scope_type="run",
+            scope_id=run_id,
+            payload={"flow_id": flow_id},
+        )
+        executions: list[NodeExecution] = []
+        try:
+            for raw_node in nodes:
+                node_id = str(raw_node["id"])
+                tool = str(raw_node["tool"])
+                adapter = self._adapters.get(tool)
+                if adapter is None:
+                    raise KeyError(f"unknown adapter for tool '{tool}'")
+                node_scope = bm.ScopeKey(scope_type="node", scope_id=node_id)
+                self._budgets.enter_scope(node_scope)
+                self._trace.emit(
+                    "node_start",
+                    scope_type="node",
+                    scope_id=node_id,
+                    payload={"tool": tool},
+                )
+                try:
+                    self._policies.enforce(tool)
+                    cost_snapshot = bm.CostSnapshot.from_raw(adapter.estimate_cost(raw_node))
+                    self._apply_budget(run_scope, cost_snapshot)
+                    self._apply_budget(node_scope, cost_snapshot)
+                    result = adapter.execute(raw_node)
+                    executions.append(
+                        NodeExecution(node_id=node_id, tool=tool, result=result)
+                    )
+                    self._trace.emit(
+                        "node_complete",
+                        scope_type="node",
+                        scope_id=node_id,
+                        payload={"tool": tool},
+                    )
+                except PolicyViolationError as exc:
+                    self._trace.emit(
+                        "policy_violation",
+                        scope_type="node",
+                        scope_id=node_id,
+                        payload={"tool": tool, "error": str(exc)},
+                    )
+                    raise
+                finally:
+                    self._budgets.exit_scope(node_scope)
+            self._trace.emit(
+                "run_complete",
+                scope_type="run",
+                scope_id=run_id,
+                payload={"flow_id": flow_id},
+            )
+            return executions
+        finally:
+            self._budgets.exit_scope(run_scope)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _apply_budget(self, scope: bm.ScopeKey, cost: bm.CostSnapshot) -> None:
+        decision = self._budgets.preview_charge(scope, cost)
+        if decision.breached:
+            self._budgets.record_breach(decision)
+        if decision.should_stop:
+            blocking = decision.blocking
+            if blocking is None:  # pragma: no cover - defensive guard
+                raise BudgetError("blocking outcome missing for stop decision")
+            raise BudgetBreachError(scope, blocking)
+        self._budgets.commit_charge(decision)

--- a/codex/code/work/dsl/trace.py
+++ b/codex/code/work/dsl/trace.py
@@ -1,0 +1,61 @@
+"""Shared trace event emitter for budget and policy integrations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+
+__all__ = ["TraceEvent", "TraceEventEmitter"]
+
+
+@dataclass(frozen=True, slots=True)
+class TraceEvent:
+    """Immutable trace record."""
+
+    event: str
+    scope_type: str
+    scope_id: str
+    payload: Mapping[str, Any]
+
+
+class TraceEventEmitter:
+    """Emit immutable trace events with optional sink forwarding."""
+
+    def __init__(self) -> None:
+        self._events: list[TraceEvent] = []
+        self._sink: Callable[[TraceEvent], None] | None = None
+
+    def attach_sink(self, sink: Callable[[TraceEvent], None] | None) -> None:
+        """Attach or clear an external sink that receives emitted events."""
+
+        self._sink = sink
+
+    def emit(
+        self,
+        event: str,
+        *,
+        scope_type: str,
+        scope_id: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> TraceEvent:
+        data = dict(payload or {})
+        record = TraceEvent(
+            event=event,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            payload=MappingProxyType(data),
+        )
+        self._events.append(record)
+        if self._sink is not None:
+            self._sink(record)
+        return record
+
+    @property
+    def events(self) -> tuple[TraceEvent, ...]:
+        return tuple(self._events)
+
+    def clear(self) -> None:
+        self._events.clear()

--- a/codex/code/work/tests/__init__.py
+++ b/codex/code/work/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for Phase 3 work branch."""

--- a/codex/code/work/tests/conftest.py
+++ b/codex/code/work/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/codex/code/work/tests/test_budget_manager.py
+++ b/codex/code/work/tests/test_budget_manager.py
@@ -1,0 +1,96 @@
+import pytest
+
+from codex.code.work.dsl import budget_models as bm
+from codex.code.work.dsl.budget_manager import BudgetManager, BudgetBreachError
+from codex.code.work.dsl.trace import TraceEventEmitter
+
+
+@pytest.fixture()
+def trace_emitter() -> TraceEventEmitter:
+    return TraceEventEmitter()
+
+
+def make_manager(emitter: TraceEventEmitter) -> BudgetManager:
+    specs = [
+        bm.BudgetSpec(
+            name="run-hard",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 100}),
+            mode="hard",
+            breach_action="stop",
+        ),
+        bm.BudgetSpec(
+            name="run-soft",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 150}),
+            mode="soft",
+            breach_action="warn",
+        ),
+    ]
+    return BudgetManager(specs=specs, trace=emitter)
+
+
+class TestBudgetManager:
+    def test_preview_and_commit_updates_spend(self, trace_emitter: TraceEventEmitter) -> None:
+        manager = make_manager(trace_emitter)
+        scope = bm.ScopeKey(scope_type="run", scope_id="run-1")
+        manager.enter_scope(scope)
+        decision = manager.preview_charge(scope, bm.CostSnapshot.from_raw({"time_ms": 40}))
+        assert decision.breached is False
+        manager.commit_charge(decision)
+        assert manager.spent(scope, "run-hard").time_ms == pytest.approx(40.0)
+        assert manager.spent(scope, "run-soft").time_ms == pytest.approx(40.0)
+        events = trace_emitter.events
+        assert events[-1].event == "budget_charge"
+        assert events[-1].payload["spec_name"] == "run-soft"
+
+    def test_hard_breach_raises_and_emits(self, trace_emitter: TraceEventEmitter) -> None:
+        manager = make_manager(trace_emitter)
+        scope = bm.ScopeKey(scope_type="run", scope_id="run-99")
+        manager.enter_scope(scope)
+        manager.commit_charge(
+            manager.preview_charge(scope, bm.CostSnapshot.from_raw({"time_ms": 90}))
+        )
+        decision = manager.preview_charge(scope, bm.CostSnapshot.from_raw({"time_ms": 20}))
+        assert decision.should_stop is True
+        manager.record_breach(decision)
+        with pytest.raises(BudgetBreachError):
+            manager.commit_charge(decision)
+        events = trace_emitter.events
+        assert any(evt.event == "budget_breach" and evt.payload["spec_name"] == "run-hard" for evt in events)
+
+    def test_soft_breach_warns_but_commits(self, trace_emitter: TraceEventEmitter) -> None:
+        manager = BudgetManager(
+            specs=[
+                bm.BudgetSpec(
+                    name="run-soft",
+                    scope_type="run",
+                    limit=bm.CostSnapshot.from_raw({"time_ms": 150}),
+                    mode="soft",
+                    breach_action="warn",
+                )
+            ],
+            trace=trace_emitter,
+        )
+        scope = bm.ScopeKey(scope_type="run", scope_id="run-2")
+        manager.enter_scope(scope)
+        manager.commit_charge(
+            manager.preview_charge(scope, bm.CostSnapshot.from_raw({"time_ms": 150}))
+        )
+        decision = manager.preview_charge(scope, bm.CostSnapshot.from_raw({"time_ms": 10}))
+        assert decision.breached is True
+        assert decision.should_stop is False
+        manager.record_breach(decision)
+        manager.commit_charge(decision)
+        assert manager.spent(scope, "run-soft").time_ms == pytest.approx(160.0)
+        events = [evt.event for evt in trace_emitter.events]
+        assert "budget_breach" in events
+        assert events.count("budget_charge") >= 2
+
+    def test_exit_scope_validates(self, trace_emitter: TraceEventEmitter) -> None:
+        manager = make_manager(trace_emitter)
+        scope = bm.ScopeKey(scope_type="run", scope_id="run-3")
+        manager.enter_scope(scope)
+        manager.exit_scope(scope)
+        with pytest.raises(KeyError):
+            manager.exit_scope(scope)

--- a/codex/code/work/tests/test_budget_models.py
+++ b/codex/code/work/tests/test_budget_models.py
@@ -1,0 +1,96 @@
+import pytest
+
+from codex.code.work.dsl import budget_models as bm
+
+
+class TestCostSnapshot:
+    def test_from_raw_normalizes_seconds_and_tokens(self) -> None:
+        snapshot = bm.CostSnapshot.from_raw({"time_s": 0.5, "tokens": 42})
+        assert snapshot.time_ms == pytest.approx(500.0)
+        assert snapshot.tokens == 42
+
+    def test_addition_is_immutable(self) -> None:
+        base = bm.CostSnapshot.from_raw({"time_ms": 100})
+        inc = bm.CostSnapshot.from_raw({"time_ms": 50, "tokens": 10})
+        total = base + inc
+        assert total.time_ms == pytest.approx(150.0)
+        assert total.tokens == 10
+        # Ensure operands unchanged
+        assert base.time_ms == pytest.approx(100.0)
+        assert base.tokens == 0
+        assert inc.tokens == 10
+
+    def test_subtraction_and_floor_zero(self) -> None:
+        lhs = bm.CostSnapshot.from_raw({"time_ms": 120, "tokens": 30})
+        rhs = bm.CostSnapshot.from_raw({"time_ms": 200, "tokens": 35})
+        diff = lhs - rhs
+        assert diff.time_ms == 0.0
+        assert diff.tokens == 0
+
+
+class TestBudgetChargeOutcome:
+    def test_overage_and_remaining(self) -> None:
+        spec = bm.BudgetSpec(
+            name="node",
+            scope_type="node",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 120}),
+            mode="soft",
+            breach_action="warn",
+        )
+        prior = bm.CostSnapshot.from_raw({"time_ms": 100})
+        cost = bm.CostSnapshot.from_raw({"time_ms": 60})
+        outcome = bm.BudgetChargeOutcome.compute(spec=spec, prior=prior, cost=cost)
+        assert outcome.charge.remaining.time_ms == pytest.approx(-40.0)
+        assert outcome.charge.overage.time_ms == pytest.approx(40.0)
+        assert outcome.breached is True
+        assert outcome.should_stop is False
+        payload = outcome.to_trace_payload(scope_type="node", scope_id="node-1")
+        assert payload["spec_name"] == "node"
+        with pytest.raises(TypeError):
+            payload["spec_name"] = "mutate"  # type: ignore[index]
+
+    def test_hard_stop_detection(self) -> None:
+        spec = bm.BudgetSpec(
+            name="run",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 200}),
+            mode="hard",
+            breach_action="stop",
+        )
+        outcome = bm.BudgetChargeOutcome.compute(
+            spec=spec,
+            prior=bm.CostSnapshot.zero(),
+            cost=bm.CostSnapshot.from_raw({"time_ms": 250}),
+        )
+        assert outcome.breached is True
+        assert outcome.should_stop is True
+
+
+class TestBudgetDecision:
+    def test_decision_identifies_blocking_outcome(self) -> None:
+        spec_soft = bm.BudgetSpec(
+            name="soft",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 100}),
+            mode="soft",
+            breach_action="warn",
+        )
+        spec_hard = bm.BudgetSpec(
+            name="hard",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 80}),
+            mode="hard",
+            breach_action="stop",
+        )
+        prior = bm.CostSnapshot.from_raw({"time_ms": 60})
+        cost = bm.CostSnapshot.from_raw({"time_ms": 30})
+        soft_outcome = bm.BudgetChargeOutcome.compute(spec=spec_soft, prior=prior, cost=cost)
+        hard_outcome = bm.BudgetChargeOutcome.compute(spec=spec_hard, prior=prior, cost=cost)
+        decision = bm.BudgetDecision.make(
+            scope=bm.ScopeKey(scope_type="run", scope_id="run-1"),
+            cost=cost,
+            outcomes=[soft_outcome, hard_outcome],
+        )
+        assert decision.breached is True
+        assert decision.should_stop is True
+        assert decision.blocking is hard_outcome

--- a/codex/code/work/tests/test_flow_runner_budget_integration.py
+++ b/codex/code/work/tests/test_flow_runner_budget_integration.py
@@ -1,0 +1,133 @@
+import pytest
+
+from codex.code.work.dsl import budget_models as bm
+from codex.code.work.dsl.budget_manager import BudgetBreachError, BudgetManager
+from codex.code.work.dsl.flow_runner import FlowRunner, ToolAdapter
+from codex.code.work.dsl.trace import TraceEventEmitter
+from pkgs.dsl.policy import PolicyStack
+
+
+class FakeAdapter(ToolAdapter):
+    def __init__(self, cost_by_node: dict[str, dict[str, float]], results: dict[str, object]) -> None:
+        self._cost_by_node = cost_by_node
+        self._results = results
+        self.executed: list[str] = []
+
+    def estimate_cost(self, node: dict[str, object]) -> dict[str, float]:  # type: ignore[override]
+        return self._cost_by_node[node["id"]]
+
+    def execute(self, node: dict[str, object]) -> object:  # type: ignore[override]
+        self.executed.append(node["id"])
+        return self._results[node["id"]]
+
+
+@pytest.fixture()
+def trace_emitter() -> TraceEventEmitter:
+    return TraceEventEmitter()
+
+
+@pytest.fixture()
+def policy_stack(trace_emitter: TraceEventEmitter) -> PolicyStack:
+    tools = {"echo": {"tags": []}}
+    return PolicyStack(tools=tools, trace=None, event_sink=None)
+
+
+@pytest.fixture()
+def budget_manager(trace_emitter: TraceEventEmitter) -> BudgetManager:
+    specs = [
+        bm.BudgetSpec(
+            name="run-soft",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 100}),
+            mode="soft",
+            breach_action="warn",
+        ),
+        bm.BudgetSpec(
+            name="node-hard",
+            scope_type="node",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 50}),
+            mode="hard",
+            breach_action="stop",
+        ),
+    ]
+    return BudgetManager(specs=specs, trace=trace_emitter)
+
+
+@pytest.fixture()
+def flow_runner(budget_manager: BudgetManager, policy_stack: PolicyStack, trace_emitter: TraceEventEmitter) -> FlowRunner:
+    adapters = {"echo": FakeAdapter(cost_by_node={}, results={})}
+    return FlowRunner(
+        adapters=adapters,
+        budget_manager=budget_manager,
+        policy_stack=policy_stack,
+        trace=trace_emitter,
+    )
+
+
+def test_hard_node_breach_stops_execution(
+    budget_manager: BudgetManager,
+    policy_stack: PolicyStack,
+    trace_emitter: TraceEventEmitter,
+) -> None:
+    adapter = FakeAdapter(
+        cost_by_node={
+            "n1": {"time_ms": 40},
+            "n2": {"time_ms": 60},
+        },
+        results={"n1": "ok", "n2": "fail"},
+    )
+    runner = FlowRunner(
+        adapters={"echo": adapter},
+        budget_manager=budget_manager,
+        policy_stack=policy_stack,
+        trace=trace_emitter,
+    )
+    nodes = [
+        {"id": "n1", "tool": "echo", "params": {}},
+        {"id": "n2", "tool": "echo", "params": {}},
+    ]
+    with pytest.raises(BudgetBreachError) as excinfo:
+        runner.run(flow_id="flow-1", run_id="run-1", nodes=nodes)
+    assert excinfo.value.scope.scope_type == "node"
+    assert adapter.executed == ["n1"]
+    events = trace_emitter.events
+    assert any(evt.event == "budget_breach" and evt.scope_type == "node" for evt in events)
+
+
+def test_soft_run_breach_warns_but_allows_completion(
+    trace_emitter: TraceEventEmitter,
+) -> None:
+    specs = [
+        bm.BudgetSpec(
+            name="run-soft",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 100}),
+            mode="soft",
+            breach_action="warn",
+        )
+    ]
+    manager = BudgetManager(specs=specs, trace=trace_emitter)
+    policy = PolicyStack(tools={"echo": {"tags": []}}, trace=None, event_sink=None)
+    adapter = FakeAdapter(
+        cost_by_node={
+            "n1": {"time_ms": 60},
+            "n2": {"time_ms": 60},
+        },
+        results={"n1": "ok", "n2": "ok"},
+    )
+    runner = FlowRunner(
+        adapters={"echo": adapter},
+        budget_manager=manager,
+        policy_stack=policy,
+        trace=trace_emitter,
+    )
+    nodes = [
+        {"id": "n1", "tool": "echo", "params": {}},
+        {"id": "n2", "tool": "echo", "params": {}},
+    ]
+    results = runner.run(flow_id="flow-2", run_id="run-2", nodes=nodes)
+    assert [record.node_id for record in results] == ["n1", "n2"]
+    assert manager.spent(bm.ScopeKey("run", "run-2"), "run-soft").time_ms == pytest.approx(120.0)
+    events = [evt.event for evt in trace_emitter.events]
+    assert "budget_breach" in events
+    assert events.count("budget_charge") == 2


### PR DESCRIPTION
## Summary
- add canonical budget models with normalized cost math and aggregated decisions
- introduce scope-aware BudgetManager emitting immutable budget traces and preserving history snapshots
- wire an adapter-backed FlowRunner through policies and budgets with lifecycle trace events and tests

## Testing
- pytest codex/code/work/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8a9dc8530832c914a518a356b62ed