### PR TITLE
Implement budget manager and FlowRunner integration with tracing

### DIFF
--- a/codex/DOCUMENTATION/P3/work-20250504-gpt5codex.yaml
+++ b/codex/DOCUMENTATION/P3/work-20250504-gpt5codex.yaml
@@ -1,0 +1,86 @@
+documentation:
+  task_id: 07b_budget_guards_and_runner_integration
+  branch: work
+  phase: P3
+  components:
+    - name: pkgs.dsl.budget
+      purpose: Unified budget specification, scope identification, and manager orchestration for FlowRunner.
+      public_interfaces:
+        classes:
+          - BudgetSpec.from_mapping(limit, mode, breach_action)
+          - BudgetScope.run|loop|node|spec(identifier)
+          - BudgetManager.preview(cost, scopes)
+          - BudgetManager.commit(cost, scopes)
+      extension_hooks:
+        - Additional scope kinds can be added by extending BudgetScope factory helpers.
+        - Downstream runners can wrap BudgetManager to introduce custom breach actions.
+      lifecycle:
+        creation: FlowRunner builds a manager per run and registers scopes discovered in the flow spec.
+        usage: preview before adapter execution; commit with actual spend after execution.
+      error_contracts:
+        - Registering duplicate scopes raises ValueError.
+        - Invalid limit or cost mappings raise ValueError with descriptive messages.
+      typing_notes:
+        - All payloads exposed via BudgetCharge and BudgetOutcome use MappingProxyType to prevent mutation.
+      performance_notes:
+        - Normalisation folds `_seconds` metrics into milliseconds; caching of totals keeps per-charge overhead small.
+    - name: pkgs.dsl.trace
+      purpose: Shared trace emitter for budget and policy events with immutable payloads.
+      public_interfaces:
+        classes:
+          - TraceEventEmitter.emit(event, scope, payload)
+          - TraceEventEmitter.budget_charge(charge, loop_iteration, run_id)
+          - TraceEventEmitter.budget_breach(charge, loop_iteration, run_id, stop_reason)
+          - TraceEventEmitter.policy_resolved(node_id, resolution, run_id, iteration)
+      extension_hooks:
+        - `extend()` helper allows streaming pre-existing events into the emitter.
+      lifecycle:
+        creation: Injected into FlowRunner; reset per run.
+        usage: FlowRunner records policy decisions and budget state transitions.
+      error_contracts:
+        - None beyond standard Python type errors; payloads are assumed serialisable.
+      typing_notes:
+        - Events expose MappingProxyType payloads; callers must copy to mutate.
+      performance_notes:
+        - Payload creation copies small dicts; emitter keeps in-memory list suitable for deterministic tests.
+    - name: pkgs.dsl.runner
+      purpose: Adapter-driven FlowRunner enforcing policies and budgets while emitting traces.
+      public_interfaces:
+        classes:
+          - ToolAdapter(estimate_cost, execute)
+          - FlowRunner.run(spec, vars)
+          - RunResult(status, outputs, warnings, stop_reason, trace_events)
+      extension_hooks:
+        - Custom adapters implement ToolAdapter to integrate new tools.
+        - `enforce_budgets=False` toggles preview halting for diagnostic runs.
+      lifecycle:
+        creation: Instantiate with adapter registry, policy tool registry, and optional trace emitter.
+        usage: `run()` performs sequential execution, handling loops and scope registration per spec.
+      error_contracts:
+        - Missing adapters raise ValueError; policy violations raise PolicyViolationError captured as run errors.
+        - Hard budget breaches raise `_RunHalted` internally, surfaced as halted RunResult with reason metadata.
+      typing_notes:
+        - Outputs and warnings returned as mapping proxies containing tuples of iteration outputs.
+      security_notes:
+        - No network or file IO performed; adapters remain responsible for sandboxing external calls.
+      performance_notes:
+        - Designed for deterministic single-thread execution; loop guard prevents infinite iteration when no stop signals exist.
+  cli:
+    usage:
+      - No direct CLI; FlowRunner intended for programmatic orchestration.
+  automation:
+    triggers:
+      - Tests located in `codex/code/work/tests` validate budget math and runner integration; include in CI matrix.
+  serialization:
+    traces:
+      format: JSONL-friendly dictionaries produced by TraceEventEmitter.
+      retention: Caller-defined; emitter keeps data in-memory until persisted by host application.
+  error_contracts:
+    - Hard budget stop reason payload follows `{scope, id, reason}` mapping.
+  typing_and_security:
+    typing: Runtime relies on Python 3.12 typing; protocols satisfied by abstract base class `ToolAdapter`.
+    security: No external IO; safe for offline execution.
+  performance:
+    considerations:
+      - Budget normalisation performs O(n) merge per charge; intended for small metric sets.
+      - Loop execution halts via budgets or optional `max_iterations` guard.

--- a/codex/TESTS/P3/work-20250504-gpt5codex.yaml
+++ b/codex/TESTS/P3/work-20250504-gpt5codex.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_flow_runner_policy_violation_stops_execution
+      rationale: Ensure FlowRunner surfaces PolicyViolationError as halted run and emits policy_violation trace.
+      source_module: pkgs/dsl/runner.py
+      priority: high
+    - name: test_budget_manager_spec_scope_registration
+      rationale: Validate spec-level (node.spec.budget) registration and charging semantics.
+      source_module: pkgs/dsl/budget.py
+      priority: medium
+    - name: test_trace_emitter_serialization_stability
+      rationale: Guard against accidental mutation of emitted payloads when serialized to JSON.
+      source_module: pkgs/dsl/trace.py
+      priority: low

--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.md
@@ -1,0 +1,11 @@
+# Phase 3 Post-Execution — Budget Guards and Runner Integration
+
+## Test Run
+- `pytest codex/code/work/tests -q`
+
+All tests passed. BudgetManager and FlowRunner integration verified for hard stop, soft warning, and trace emission paths.
+
+## Coverage + Observations
+- BudgetManager preview/commit exercised through unit tests, including immutability assertions.
+- FlowRunner exercised through loop budget halt scenario; future suites should add policy violation coverage and spec-level budgets.
+- Trace emitter validated for policy and budget events; consider schema-level validation in later phases.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.md
@@ -1,0 +1,15 @@
+# Phase 3 Preview — Budget Guards and Runner Integration
+
+## Intent
+- Stabilise unified budget models (`BudgetSpec`, `BudgetScope`, `BudgetManager`) with preview/commit lifecycle.
+- Introduce shared `TraceEventEmitter` for immutable budget and policy traces.
+- Retrofit FlowRunner to orchestrate adapters, policies, and budgets with loop stop semantics.
+
+## Design Highlights
+- Budget APIs favour mapping proxies to avoid trace mutation.
+- Trace emitter bridges budget charges/breaches and policy resolutions with run/loop metadata.
+- FlowRunner keeps sequential adapter execution but enforces scopes (run, loop, node, spec) via `BudgetManager` outcomes.
+
+## Test Plan
+- `test_budget_manager.py`: preview vs commit, soft/hard breach handling, immutability checks.
+- `test_flow_runner_budget_integration.py`: loop halt on budget breach, warnings for soft node budgets, trace fidelity.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.md
@@ -1,0 +1,12 @@
+# Phase 3 Review Notes — Budget Guards and Runner Integration
+
+## Checklist
+- [x] BudgetManager preview/commit keeps state immutable until commit; duplicate scope registration guarded.
+- [x] TraceEventEmitter emits `budget_charge`, `budget_breach`, and `policy_resolved` with mapping proxies and loop metadata.
+- [x] FlowRunner clears scope caches per run, registers run/node/loop/spec budgets, and halts on hard breaches.
+- [x] Soft node budgets accumulate warnings without halting execution.
+- [x] Tests cover hard + soft scenarios and trace payload validation.
+
+## Review Comments
+- Consider deduplicating breach events for charges emitted during commit if preview already warned; current behaviour is acceptable but may double log warnings.
+- Future enhancement: surface policy stack push/pop traces through the shared emitter for parity with budget events.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.yaml
@@ -1,0 +1,94 @@
+summary: Canonicalise budget enforcement primitives and integrate them into FlowRunner with schema-aligned tracing.
+justification: |
+  Earlier phases converged on immutable budget models (zwi2ny branch), structured charge diagnostics (pbdel9),
+  and a reusable BudgetManager (test-first branches) while preserving the adapter-driven FlowRunner baseline.
+  Phase 3 must merge these threads: expose a normalised BudgetManager API, surface trace emissions via a shared
+  emitter, and retrofit FlowRunner to charge run/node/loop/spec budgets without regressing policy enforcement.
+steps:
+  - id: budget_models
+    description: Define immutable budget value objects, meters, and manager orchestration with preview/commit lifecycle.
+    inputs: [codex/specs/flow_runner_spec.yaml, codex/specs/flow_runner_spec_ext.yaml]
+    outputs: [pkgs/dsl/budget.py]
+  - id: trace_emitter
+    description: Provide a TraceEventEmitter that wraps mapping proxies and produces budget/policy events.
+    inputs: [codex/specs/flow_runner_spec_ext.yaml]
+    outputs: [pkgs/dsl/trace.py]
+  - id: runner_integration
+    description: Update FlowRunner to use adapters, PolicyStack, and BudgetManager while emitting structured traces and handling loop stops.
+    inputs: [pkgs/dsl/policy.py, pkgs/dsl/models.py]
+    outputs: [pkgs/dsl/runner.py]
+modules:
+  - path: pkgs/dsl/budget.py
+    role: Unified budget specifications, meters, and manager orchestration.
+    owner: dsl-runtime
+  - path: pkgs/dsl/trace.py
+    role: Trace event abstraction shared by policy and budget emitters.
+    owner: dsl-runtime
+  - path: pkgs/dsl/runner.py
+    role: FlowRunner implementation with budget and policy integration.
+    owner: dsl-runner
+tests:
+  - name: unit_budget_manager
+    path: codex/code/work/tests/test_budget_manager.py
+    covers: [pkgs/dsl/budget.py]
+    focus: preview/commit semantics, hard vs soft breaches, immutable payloads.
+    mocks: none (pure value objects)
+  - name: unit_flow_runner_budgets
+    path: codex/code/work/tests/test_flow_runner_budget_integration.py
+    covers: [pkgs/dsl/runner.py, pkgs/dsl/trace.py]
+    focus: run/node/loop budget enforcement, trace emission, policy integration signals.
+    mocks: fake tool adapters, in-memory trace emitter
+run_order:
+  - write unit_budget_manager tests
+  - write unit_flow_runner_budgets tests
+  - implement pkgs/dsl/budget.py
+  - implement pkgs/dsl/trace.py
+  - implement pkgs/dsl/runner.py
+  - run pytest codex/code/work/tests -q
+interfaces:
+  BudgetSpec:
+    methods:
+      - from_mapping(mapping: Mapping[str, object], *, name: str | None = None) -> BudgetSpec
+    notes: Normalises mode/breach_action enums and freezes limit mappings.
+  BudgetManager:
+    methods:
+      - register(scope: BudgetScope, spec: BudgetSpec) -> None
+      - preview(cost: Mapping[str, float], scopes: Sequence[BudgetScope]) -> BudgetOutcome
+      - commit(cost: Mapping[str, float], scopes: Sequence[BudgetScope]) -> BudgetOutcome
+    notes: Preview never mutates; commit returns immutable BudgetCharge payloads and stop/warn aggregation.
+  TraceEventEmitter:
+    methods:
+      - emit(event: str, scope: str, payload: Mapping[str, object]) -> None
+      - budget_charge(charge: BudgetCharge, *, loop_iteration: int | None, run_id: str) -> None
+      - budget_breach(charge: BudgetCharge, *, loop_iteration: int | None, run_id: str, stop_reason: str) -> None
+      - policy_resolved(node_id: str, resolution: PolicyResolution, run_id: str, iteration: int | None) -> None
+    notes: Wraps payloads in mapping proxies for schema-aligned immutability.
+  FlowRunner:
+    methods:
+      - run(spec: Mapping[str, object], vars: Mapping[str, object]) -> RunResult
+    notes: Executes adapters sequentially, charges relevant budgets, integrates policy stack, records traces, and halts on stop outcomes.
+tdd_coverage_targets:
+  pkgs/dsl/budget.py: 0.9
+  pkgs/dsl/runner.py: 0.85
+  pkgs/dsl/trace.py: 0.85
+review_checklist:
+  - Verify BudgetManager preview/commit lifecycle does not mutate state prematurely.
+  - Ensure FlowRunner stops on hard breaches and records warnings for soft breaches.
+  - Confirm trace payloads use MappingProxyType and include run_id, node_id, and loop_iteration where relevant.
+  - Validate policy_resolved events are emitted once per node execution.
+  - Check tests exercise run/node/loop/spec budget combinations.
+outputs:
+  plan: codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.yaml
+  tests:
+    - codex/code/work/tests/test_budget_manager.py
+    - codex/code/work/tests/test_flow_runner_budget_integration.py
+  modules:
+    - pkgs/dsl/budget.py
+    - pkgs/dsl/trace.py
+    - pkgs/dsl/runner.py
+  docs:
+    - codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.md
+    - codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.md
+    - codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250504-gpt5codex.md
+    - codex/DOCUMENTATION/P3/work-20250504-gpt5codex.yaml
+  missing_tests: codex/TESTS/P3/work-20250504-gpt5codex.yaml

--- a/codex/code/work/tests/conftest.py
+++ b/codex/code/work/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration ensuring local packages are importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/codex/code/work/tests/test_budget_manager.py
+++ b/codex/code/work/tests/test_budget_manager.py
@@ -1,0 +1,98 @@
+"""Unit tests for the canonical BudgetManager orchestration layer."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from pkgs.dsl.budget import BudgetManager, BudgetScope, BudgetSpec
+
+
+@pytest.fixture()
+def run_budget_manager() -> tuple[BudgetManager, BudgetScope]:
+    manager = BudgetManager()
+    run_scope = BudgetScope.run("run")
+    run_spec = BudgetSpec.from_mapping(
+        {
+            "name": "run",
+            "limit": {"calls": 5},
+            "mode": "hard",
+            "breach_action": "stop",
+        }
+    )
+    manager.register(run_scope, run_spec)
+    return manager, run_scope
+
+
+def test_preview_and_commit_hard_budget_stop(run_budget_manager: tuple[BudgetManager, BudgetScope]) -> None:
+    manager, run_scope = run_budget_manager
+
+    initial_commit = manager.commit({"calls": 3}, [run_scope])
+    first_charge = initial_commit.charges[0]
+    assert first_charge.remaining["calls"] == 2
+    assert not initial_commit.should_stop
+
+    stop_preview = manager.preview({"calls": 3}, [run_scope])
+    charge = stop_preview.charges[0]
+    assert stop_preview.should_stop
+    assert charge.overages["calls"] == 1
+    assert charge.remaining["calls"] == 0
+    assert isinstance(charge.remaining, MappingProxyType)
+    assert isinstance(charge.overages, MappingProxyType)
+
+    confirm_no_mutation = manager.preview({"calls": 1}, [run_scope])
+    assert not confirm_no_mutation.should_stop
+    assert confirm_no_mutation.charges[0].remaining["calls"] == 1
+
+    post_commit = manager.commit({"calls": 1}, [run_scope])
+    assert post_commit.charges[0].remaining["calls"] == 1
+
+
+def test_soft_budget_warn_allows_commit() -> None:
+    manager = BudgetManager()
+    node_scope = BudgetScope.node("node-1")
+    spec = BudgetSpec.from_mapping(
+        {
+            "name": "node-1",
+            "limit": {"calls": 2},
+            "mode": "soft",
+            "breach_action": "warn",
+        }
+    )
+    manager.register(node_scope, spec)
+
+    first = manager.commit({"calls": 2}, [node_scope])
+    assert not first.should_stop
+    assert first.warnings == ()
+
+    preview = manager.preview({"calls": 1}, [node_scope])
+    assert not preview.should_stop
+    assert preview.warnings == (preview.charges[0],)
+
+    commit = manager.commit({"calls": 1}, [node_scope])
+    assert commit.charges[0].overages["calls"] == 1
+
+
+def test_preview_does_not_mutate_spent() -> None:
+    manager = BudgetManager()
+    scope = BudgetScope.loop("loop-1")
+    spec = BudgetSpec.from_mapping(
+        {
+            "name": "loop-1",
+            "limit": {"tokens": 100},
+            "mode": "hard",
+            "breach_action": "stop",
+        }
+    )
+    manager.register(scope, spec)
+
+    preview = manager.preview({"tokens": 120}, [scope])
+    assert preview.should_stop
+
+    safe_commit = manager.commit({"tokens": 20}, [scope])
+    assert not safe_commit.should_stop
+    assert safe_commit.charges[0].remaining["tokens"] == 80
+
+    second_preview = manager.preview({"tokens": 90}, [scope])
+    assert second_preview.should_stop

--- a/codex/code/work/tests/test_flow_runner_budget_integration.py
+++ b/codex/code/work/tests/test_flow_runner_budget_integration.py
@@ -1,0 +1,112 @@
+"""Integration-style tests for FlowRunner budget enforcement and tracing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import pytest
+
+from pkgs.dsl.runner import FlowRunner, RunResult, ToolAdapter
+from pkgs.dsl.trace import TraceEventEmitter
+
+
+@dataclass
+class RecordingAdapter(ToolAdapter):
+    """Simple adapter that increments a counter and records executions."""
+
+    cost_per_call: Mapping[str, float]
+    payload_template: Mapping[str, Any]
+    calls: int = 0
+
+    def estimate_cost(self, node_spec: Mapping[str, Any], context: Mapping[str, Any]) -> Mapping[str, float]:
+        return dict(self.cost_per_call)
+
+    def execute(self, node_spec: Mapping[str, Any], context: Mapping[str, Any]) -> tuple[Mapping[str, Any], Mapping[str, float]]:
+        self.calls += 1
+        outputs = {"value": self.calls, **self.payload_template}
+        return outputs, dict(self.cost_per_call)
+
+
+@pytest.fixture()
+def flow_spec() -> Mapping[str, Any]:
+    return {
+        "id": "demo",
+        "run": {
+            "budget": {
+                "name": "run",
+                "limit": {"calls": 10},
+                "mode": "hard",
+                "breach_action": "stop",
+            }
+        },
+        "graph": [
+            {
+                "id": "loop",
+                "kind": "loop",
+                "stop": {
+                    "budget": {
+                        "name": "loop",
+                        "limit": {"calls": 2},
+                        "mode": "hard",
+                        "breach_action": "stop",
+                    }
+                },
+                "target": [
+                    {
+                        "id": "task",
+                        "kind": "unit",
+                        "budget": {
+                            "name": "task",
+                            "limit": {"calls": 1},
+                            "mode": "soft",
+                            "breach_action": "warn",
+                        },
+                        "spec": {
+                            "tool_ref": "adder",
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_flow_runner_emits_traces_and_stops_on_loop_budget(flow_spec: Mapping[str, Any]) -> None:
+    adapter = RecordingAdapter(cost_per_call={"calls": 1}, payload_template={})
+    emitter = TraceEventEmitter()
+    runner = FlowRunner(
+        tool_adapters={"adder": adapter},
+        tool_registry={"adder": {"tags": []}},
+        trace_emitter=emitter,
+        run_id_factory=lambda: "run-1",
+    )
+
+    result = runner.run(flow_spec, vars={})
+    assert isinstance(result, RunResult)
+    assert result.status == "halted"
+    assert result.stop_reason == {"scope": "loop", "id": "loop", "reason": "budget_stop"}
+    assert result.outputs["task"] == ({"value": 1}, {"value": 2})
+    assert any(warning["scope"] == "node" and warning["id"] == "task" for warning in result.warnings)
+
+    breach_events = [event for event in emitter.events if event.event == "budget_breach"]
+    assert breach_events, "loop breach should be traced"
+    loop_breach = next(
+        event for event in breach_events if event.data["scope_kind"] == "loop"
+    )
+    assert isinstance(loop_breach.data, MappingProxyType)
+    assert loop_breach.data["scope_kind"] == "loop"
+    assert loop_breach.data["loop_iteration"] == 3
+    assert loop_breach.data["run_id"] == "run-1"
+
+    policy_events = [event for event in emitter.events if event.event == "policy_resolved"]
+    assert policy_events, "Policy resolution must be traced"
+    policy_payload = policy_events[0].data
+    assert isinstance(policy_payload, MappingProxyType)
+    assert policy_payload["allowed"] == ("adder",)
+    assert policy_payload["node_id"] == "task"
+
+    charge_events = [event for event in emitter.events if event.event == "budget_charge"]
+    assert len(charge_events) >= 4  # run + loop + node budgets charged multiple times
+    assert all("remaining" in event.data for event in charge_events)

--- a/pkgs/__init__.py
+++ b/pkgs/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for RAGX runtime components."""

--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -1,5 +1,13 @@
 """DSL package exports for policy engine components."""
 
+from .budget import (  # noqa: F401
+    BudgetCharge,
+    BudgetManager,
+    BudgetMode,
+    BudgetOutcome,
+    BudgetScope,
+    BudgetSpec,
+)
 from .models import (  # noqa: F401
     PolicyDecision,
     PolicyDenial,
@@ -14,8 +22,16 @@ from .policy import (  # noqa: F401
     PolicyTraceRecorder,
     PolicyViolationError,
 )
+from .runner import FlowRunner, RunResult, ToolAdapter  # noqa: F401
+from .trace import TraceEvent, TraceEventEmitter  # noqa: F401
 
 __all__ = [
+    "BudgetCharge",
+    "BudgetManager",
+    "BudgetMode",
+    "BudgetOutcome",
+    "BudgetScope",
+    "BudgetSpec",
     "PolicyDecision",
     "PolicyDenial",
     "PolicyResolution",
@@ -26,4 +42,9 @@ __all__ = [
     "PolicyTraceRecorder",
     "PolicyViolationError",
     "ToolDescriptor",
+    "FlowRunner",
+    "RunResult",
+    "ToolAdapter",
+    "TraceEvent",
+    "TraceEventEmitter",
 ]

--- a/pkgs/dsl/budget.py
+++ b/pkgs/dsl/budget.py
@@ -1,0 +1,239 @@
+"""Budget enforcement primitives for the FlowRunner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping, Sequence
+
+from .models import mapping_proxy
+
+__all__ = [
+    "BudgetMode",
+    "BudgetSpec",
+    "BudgetScope",
+    "BudgetCharge",
+    "BudgetOutcome",
+    "BudgetManager",
+]
+
+
+class BudgetMode(str, Enum):
+    """Supported budget enforcement modes."""
+
+    HARD = "hard"
+    SOFT = "soft"
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetSpec:
+    """Immutable specification describing a single budget scope."""
+
+    name: str
+    limit: Mapping[str, float]
+    mode: BudgetMode
+    breach_action: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass post init
+        object.__setattr__(self, "limit", mapping_proxy(self.limit))
+        object.__setattr__(self, "breach_action", self.breach_action.lower())
+
+    @staticmethod
+    def from_mapping(mapping: Mapping[str, object], *, name: str | None = None) -> BudgetSpec:
+        """Normalise a mapping describing a budget specification."""
+
+        provided_name = name or str(mapping.get("name") or "")
+        raw_limit = mapping.get("limit")
+        if not isinstance(raw_limit, Mapping) or not raw_limit:
+            raise ValueError("budget limit must be a non-empty mapping")
+        limit: dict[str, float] = {}
+        for metric, value in raw_limit.items():
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+                raise ValueError(f"invalid numeric value for metric {metric!r}") from exc
+            if numeric < 0:
+                raise ValueError("budget limits must be non-negative")
+            limit[str(metric)] = numeric
+
+        mode_value = str(mapping.get("mode", BudgetMode.HARD.value)).lower()
+        try:
+            mode = BudgetMode(mode_value)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"unsupported budget mode: {mode_value}") from exc
+
+        breach_action = str(mapping.get("breach_action", "stop")).lower()
+        if breach_action not in {"stop", "warn"}:
+            raise ValueError(f"unsupported breach action: {breach_action}")
+
+        return BudgetSpec(
+            name=provided_name,
+            limit=limit,
+            mode=mode,
+            breach_action=breach_action,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetScope:
+    """Identify a budget scope tracked by the manager."""
+
+    kind: str
+    identifier: str
+
+    @classmethod
+    def run(cls, identifier: str) -> BudgetScope:
+        return cls("run", identifier)
+
+    @classmethod
+    def loop(cls, identifier: str) -> BudgetScope:
+        return cls("loop", identifier)
+
+    @classmethod
+    def node(cls, identifier: str) -> BudgetScope:
+        return cls("node", identifier)
+
+    @classmethod
+    def spec(cls, identifier: str) -> BudgetScope:
+        return cls("spec", identifier)
+
+    def __str__(self) -> str:  # pragma: no cover - debug helper
+        return f"{self.kind}:{self.identifier}"
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetCharge:
+    """Result of charging a budget scope."""
+
+    scope: BudgetScope
+    spec: BudgetSpec
+    cost: Mapping[str, float]
+    remaining: Mapping[str, float]
+    overages: Mapping[str, float]
+    breached: bool
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass post init
+        object.__setattr__(self, "cost", mapping_proxy(self.cost))
+        object.__setattr__(self, "remaining", mapping_proxy(self.remaining))
+        object.__setattr__(self, "overages", mapping_proxy(self.overages))
+
+    @property
+    def action(self) -> str:
+        """Return the breach action associated with the budget specification."""
+
+        return self.spec.breach_action
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetOutcome:
+    """Aggregate preview/commit outcome across multiple scopes."""
+
+    charges: tuple[BudgetCharge, ...]
+    warnings: tuple[BudgetCharge, ...]
+    should_stop: bool
+
+    @staticmethod
+    def from_charges(charges: Sequence[BudgetCharge]) -> BudgetOutcome:
+        warning_charges = tuple(
+            charge for charge in charges if charge.breached and charge.action == "warn"
+        )
+        should_stop = any(
+            charge.breached and charge.action == "stop" for charge in charges
+        )
+        return BudgetOutcome(
+            charges=tuple(charges),
+            warnings=warning_charges,
+            should_stop=should_stop,
+        )
+
+
+class _BudgetMeter:
+    """Track spend for a particular scope."""
+
+    def __init__(self, spec: BudgetSpec) -> None:
+        self.spec = spec
+        self._spent: dict[str, float] = {}
+
+    def evaluate(
+        self, cost: Mapping[str, float], scope: BudgetScope, *, mutate: bool
+    ) -> BudgetCharge:
+        totals = self._spent.copy()
+        for metric, value in cost.items():
+            totals[metric] = totals.get(metric, 0.0) + value
+
+        remaining: dict[str, float] = {}
+        overages: dict[str, float] = {}
+        breached = False
+        for metric, limit in self.spec.limit.items():
+            current = totals.get(metric, 0.0)
+            remaining_value = max(limit - current, 0.0)
+            remaining[metric] = remaining_value
+            overage_value = max(current - limit, 0.0)
+            if overage_value > 0:
+                breached = True
+                overages[metric] = overage_value
+
+        if mutate:
+            self._spent = totals
+
+        return BudgetCharge(
+            scope=scope,
+            spec=self.spec,
+            cost=dict(cost),
+            remaining=remaining,
+            overages=overages,
+            breached=breached,
+        )
+
+
+class BudgetManager:
+    """Coordinate budget meters across run/node/loop/spec scopes."""
+
+    def __init__(self) -> None:
+        self._meters: dict[BudgetScope, _BudgetMeter] = {}
+
+    def register(self, scope: BudgetScope, spec: BudgetSpec) -> None:
+        if scope in self._meters:
+            raise ValueError(f"budget scope already registered: {scope}")
+        self._meters[scope] = _BudgetMeter(spec)
+
+    def preview(
+        self, cost: Mapping[str, float], scopes: Sequence[BudgetScope]
+    ) -> BudgetOutcome:
+        normalized = _normalize_cost(cost)
+        charges = [
+            meter.evaluate(normalized, scope, mutate=False)
+            for scope in scopes
+            if (meter := self._meters.get(scope)) is not None
+        ]
+        return BudgetOutcome.from_charges(charges)
+
+    def commit(
+        self, cost: Mapping[str, float], scopes: Sequence[BudgetScope]
+    ) -> BudgetOutcome:
+        normalized = _normalize_cost(cost)
+        charges = [
+            meter.evaluate(normalized, scope, mutate=True)
+            for scope in scopes
+            if (meter := self._meters.get(scope)) is not None
+        ]
+        return BudgetOutcome.from_charges(charges)
+
+
+def _normalize_cost(cost: Mapping[str, float]) -> Mapping[str, float]:
+    """Normalize metric keys and ensure floats."""
+
+    normalized: dict[str, float] = {}
+    for raw_metric, value in cost.items():
+        metric = str(raw_metric)
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError(f"invalid cost value for metric {metric!r}") from exc
+        if numeric < 0:
+            raise ValueError("cost values must be non-negative")
+        if metric.endswith("_seconds"):
+            metric = metric[: -len("_seconds")] + "_ms"
+            numeric *= 1000
+        normalized[metric] = normalized.get(metric, 0.0) + numeric
+    return normalized

--- a/pkgs/dsl/runner.py
+++ b/pkgs/dsl/runner.py
@@ -1,0 +1,379 @@
+"""FlowRunner with budget management and policy integration."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Callable
+from uuid import uuid4
+
+from .budget import BudgetManager, BudgetOutcome, BudgetScope, BudgetSpec
+from .models import mapping_proxy
+from .policy import PolicyStack, PolicyViolationError
+from .trace import TraceEvent, TraceEventEmitter
+
+__all__ = ["ToolAdapter", "RunResult", "FlowRunner"]
+
+
+class ToolAdapter(ABC):
+    """Abstract adapter executed by FlowRunner unit nodes."""
+
+    @abstractmethod
+    def estimate_cost(
+        self, node_spec: Mapping[str, Any], context: Mapping[str, Any]
+    ) -> Mapping[str, float]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def execute(
+        self, node_spec: Mapping[str, Any], context: Mapping[str, Any]
+    ) -> tuple[Mapping[str, Any], Mapping[str, float]]:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, slots=True)
+class RunResult:
+    """Structured result returned by :class:`FlowRunner.run`."""
+
+    run_id: str
+    status: str
+    outputs: Mapping[str, tuple[Mapping[str, Any], ...]]
+    warnings: tuple[Mapping[str, object], ...]
+    stop_reason: Mapping[str, object] | None
+    trace_events: tuple[TraceEvent, ...]
+
+
+@dataclass(slots=True)
+class _LoopContext:
+    scope: BudgetScope | None
+    iteration: int
+
+
+@dataclass(slots=True)
+class _RunHalted(Exception):
+    reason: Mapping[str, object]
+
+
+class FlowRunner:
+    """Execute flow specifications with policy and budget enforcement."""
+
+    def __init__(
+        self,
+        *,
+        tool_adapters: Mapping[str, ToolAdapter],
+        tool_registry: Mapping[str, Mapping[str, object]] | None = None,
+        trace_emitter: TraceEventEmitter | None = None,
+        run_id_factory: Callable[[], str] | None = None,
+        enforce_budgets: bool = True,
+    ) -> None:
+        self._tool_adapters = dict(tool_adapters)
+        self._tool_registry = {name: dict(definition) for name, definition in (tool_registry or {}).items()}
+        self._trace = trace_emitter or TraceEventEmitter()
+        self._run_id_factory = run_id_factory or (lambda: uuid4().hex)
+        self._enforce_budgets = enforce_budgets
+        self._run_scope: BudgetScope | None = None
+        self._node_scopes: dict[str, BudgetScope] = {}
+        self._spec_scopes: dict[str, BudgetScope] = {}
+        self._loop_scopes: dict[str, BudgetScope] = {}
+
+    def run(self, spec: Mapping[str, Any], vars: Mapping[str, Any]) -> RunResult:
+        run_id = self._run_id_factory()
+        self._trace.reset()
+        self._run_scope = None
+        self._node_scopes.clear()
+        self._spec_scopes.clear()
+        self._loop_scopes.clear()
+        manager = BudgetManager()
+        self._register_budgets(manager, spec, run_id)
+        policy_stack = PolicyStack(tools=self._tool_registry)
+        outputs: dict[str, list[Mapping[str, Any]]] = {}
+        warnings: list[Mapping[str, object]] = []
+
+        try:
+            self._execute_graph(
+                spec.get("graph", []),
+                manager,
+                policy_stack,
+                outputs,
+                warnings,
+                vars,
+                loop_context=None,
+                run_id=run_id,
+            )
+            status = "ok"
+            stop_reason = None
+        except _RunHalted as halted:
+            status = "halted"
+            stop_reason = halted.reason
+        except PolicyViolationError as exc:
+            status = "error"
+            stop_reason = mapping_proxy({"reason": "policy_violation", "detail": str(exc)})
+        immutable_outputs = {key: tuple(values) for key, values in outputs.items()}
+        immutable_warnings = tuple(warnings)
+        immutable_stop = (
+            mapping_proxy(dict(stop_reason)) if isinstance(stop_reason, Mapping) else stop_reason
+        )
+        return RunResult(
+            run_id=run_id,
+            status=status,
+            outputs=mapping_proxy(immutable_outputs),
+            warnings=immutable_warnings,
+            stop_reason=immutable_stop,
+            trace_events=self._trace.events,
+        )
+
+    # ------------------------------------------------------------------
+    # Budget registration
+    # ------------------------------------------------------------------
+    def _register_budgets(
+        self, manager: BudgetManager, spec: Mapping[str, Any], run_id: str
+    ) -> None:
+        run_budget = (
+            spec.get("run", {}).get("budget")
+            if isinstance(spec.get("run"), Mapping)
+            else None
+        )
+        if run_budget:
+            run_scope = BudgetScope.run(run_id)
+            manager.register(run_scope, BudgetSpec.from_mapping(run_budget, name="run"))
+            self._run_scope = run_scope
+
+        for node in spec.get("graph", []):
+            self._register_node_budgets(manager, node)
+
+    def _register_node_budgets(self, manager: BudgetManager, node: Mapping[str, Any]) -> None:
+        node_id = str(node.get("id"))
+        node_budget = node.get("budget")
+        if isinstance(node_budget, Mapping):
+            scope = BudgetScope.node(node_id)
+            manager.register(scope, BudgetSpec.from_mapping(node_budget, name=node_id))
+            self._node_scopes[node_id] = scope
+
+        spec_budget = node.get("spec", {}).get("budget") if isinstance(node.get("spec"), Mapping) else None
+        if isinstance(spec_budget, Mapping):
+            scope = BudgetScope.spec(f"{node_id}:spec")
+            manager.register(scope, BudgetSpec.from_mapping(spec_budget, name=f"{node_id}:spec"))
+            self._spec_scopes[node_id] = scope
+
+        if node.get("kind") == "loop":
+            stop_conf = node.get("stop", {}) if isinstance(node.get("stop"), Mapping) else {}
+            loop_budget = stop_conf.get("budget") if isinstance(stop_conf, Mapping) else None
+            if isinstance(loop_budget, Mapping):
+                scope = BudgetScope.loop(node_id)
+                manager.register(scope, BudgetSpec.from_mapping(loop_budget, name=node_id))
+                self._loop_scopes[node_id] = scope
+            for child in node.get("target", []):
+                self._register_node_budgets(manager, child)
+
+    # ------------------------------------------------------------------
+    # Execution helpers
+    # ------------------------------------------------------------------
+    def _execute_graph(
+        self,
+        nodes: Iterable[Mapping[str, Any]],
+        manager: BudgetManager,
+        policy_stack: PolicyStack,
+        outputs: MutableMapping[str, list[Mapping[str, Any]]],
+        warnings: list[Mapping[str, object]],
+        vars: Mapping[str, Any],
+        *,
+        loop_context: _LoopContext | None,
+        run_id: str,
+    ) -> None:
+        for node in nodes:
+            kind = node.get("kind")
+            if kind == "unit":
+                self._execute_unit(
+                    node,
+                    manager,
+                    policy_stack,
+                    outputs,
+                    warnings,
+                    vars,
+                    loop_context=loop_context,
+                    run_id=run_id,
+                )
+            elif kind == "loop":
+                self._execute_loop(
+                    node,
+                    manager,
+                    policy_stack,
+                    outputs,
+                    warnings,
+                    vars,
+                    run_id=run_id,
+                )
+            else:
+                raise ValueError(f"unsupported node kind: {kind}")
+
+    def _execute_loop(
+        self,
+        node: Mapping[str, Any],
+        manager: BudgetManager,
+        policy_stack: PolicyStack,
+        outputs: MutableMapping[str, list[Mapping[str, Any]]],
+        warnings: list[Mapping[str, object]],
+        vars: Mapping[str, Any],
+        *,
+        run_id: str,
+    ) -> None:
+        loop_id = str(node.get("id"))
+        scope = self._loop_scopes.get(loop_id)
+        max_iterations = None
+        stop_conf = node.get("stop", {}) if isinstance(node.get("stop"), Mapping) else {}
+        if isinstance(stop_conf, Mapping):
+            max_iterations = stop_conf.get("max_iterations")
+        body = node.get("target", [])
+        if not isinstance(body, Sequence):
+            raise ValueError("loop target must be a sequence of nodes")
+
+        iteration = 0
+        while True:
+            iteration += 1
+            context = _LoopContext(scope=scope, iteration=iteration)
+            try:
+                self._execute_graph(
+                    body,
+                    manager,
+                    policy_stack,
+                    outputs,
+                    warnings,
+                    vars,
+                    loop_context=context,
+                    run_id=run_id,
+                )
+            except _RunHalted as halted:
+                raise halted
+            if max_iterations is not None and iteration >= int(max_iterations):
+                break
+            if scope is None and max_iterations is None:
+                break  # avoid infinite loops when no stop conditions are provided
+
+    def _execute_unit(
+        self,
+        node: Mapping[str, Any],
+        manager: BudgetManager,
+        policy_stack: PolicyStack,
+        outputs: MutableMapping[str, list[Mapping[str, Any]]],
+        warnings: list[Mapping[str, object]],
+        vars: Mapping[str, Any],
+        *,
+        loop_context: _LoopContext | None,
+        run_id: str,
+    ) -> None:
+        node_id = str(node.get("id"))
+        spec = node.get("spec", {})
+        if not isinstance(spec, Mapping):
+            raise ValueError("unit node spec must be a mapping")
+        tool_ref = spec.get("tool_ref")
+        if not isinstance(tool_ref, str):
+            raise ValueError("unit node requires a tool_ref")
+        adapter = self._tool_adapters.get(tool_ref)
+        if adapter is None:
+            raise ValueError(f"no adapter registered for tool '{tool_ref}'")
+
+        resolution = policy_stack.enforce(tool_ref)
+        self._trace.policy_resolved(
+            node_id,
+            resolution,
+            run_id=run_id,
+            iteration=loop_context.iteration if loop_context else None,
+        )
+
+        scope_chain = self._gather_scopes(node_id, loop_context)
+        context = {
+            "vars": vars,
+            "node_id": node_id,
+            "loop_iteration": loop_context.iteration if loop_context else None,
+        }
+
+        estimate = adapter.estimate_cost(spec, context)
+        preview = manager.preview(estimate, scope_chain)
+        self._emit_breaches(preview, loop_context, run_id)
+        self._record_warnings(preview, warnings)
+        if preview.should_stop and self._enforce_budgets:
+            reason = self._build_stop_reason(preview)
+            raise _RunHalted(reason)
+
+        outputs_map, actual_cost = adapter.execute(spec, context)
+        commit = manager.commit(actual_cost, scope_chain)
+        self._emit_charges(commit, loop_context, run_id)
+        self._record_warnings(commit, warnings)
+
+        outputs.setdefault(node_id, []).append(dict(outputs_map))
+
+    def _gather_scopes(
+        self, node_id: str, loop_context: _LoopContext | None
+    ) -> list[BudgetScope]:
+        scopes: list[BudgetScope] = []
+        if self._run_scope is not None:
+            scopes.append(self._run_scope)
+        if loop_context and loop_context.scope is not None:
+            scopes.append(loop_context.scope)
+        if node_id in self._node_scopes:
+            scopes.append(self._node_scopes[node_id])
+        if node_id in self._spec_scopes:
+            scopes.append(self._spec_scopes[node_id])
+        return scopes
+
+    def _emit_breaches(
+        self, outcome: BudgetOutcome, loop_context: _LoopContext | None, run_id: str
+    ) -> None:
+        if not outcome.charges:
+            return
+        iteration = loop_context.iteration if loop_context else None
+        for charge in outcome.charges:
+            if charge.breached:
+                stop_reason = "budget_stop" if charge.action == "stop" else "budget_warn"
+                self._trace.budget_breach(
+                    charge,
+                    loop_iteration=iteration,
+                    run_id=run_id,
+                    stop_reason=stop_reason,
+                )
+
+    def _emit_charges(
+        self, outcome: BudgetOutcome, loop_context: _LoopContext | None, run_id: str
+    ) -> None:
+        iteration = loop_context.iteration if loop_context else None
+        for charge in outcome.charges:
+            self._trace.budget_charge(
+                charge,
+                loop_iteration=iteration,
+                run_id=run_id,
+            )
+            if charge.breached:
+                stop_reason = "budget_stop" if charge.action == "stop" else "budget_warn"
+                self._trace.budget_breach(
+                    charge,
+                    loop_iteration=iteration,
+                    run_id=run_id,
+                    stop_reason=stop_reason,
+                )
+
+    def _record_warnings(
+        self, outcome: BudgetOutcome, warnings: list[Mapping[str, object]]
+    ) -> None:
+        for charge in outcome.warnings:
+            warnings.append(
+                mapping_proxy(
+                    {
+                        "scope": charge.scope.kind,
+                        "id": charge.scope.identifier,
+                        "breach_action": charge.action,
+                    }
+                )
+            )
+
+    def _build_stop_reason(self, outcome: BudgetOutcome) -> Mapping[str, object]:
+        for charge in outcome.charges:
+            if charge.breached and charge.action == "stop":
+                return mapping_proxy(
+                    {
+                        "scope": charge.scope.kind,
+                        "id": charge.scope.identifier,
+                        "reason": "budget_stop",
+                    }
+                )
+        return mapping_proxy({"reason": "budget_stop"})

--- a/pkgs/dsl/trace.py
+++ b/pkgs/dsl/trace.py
@@ -1,0 +1,107 @@
+"""Trace emission utilities shared by FlowRunner collaborators."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from .budget import BudgetCharge
+from .models import PolicyResolution, mapping_proxy
+
+__all__ = ["TraceEvent", "TraceEventEmitter"]
+
+
+@dataclass(frozen=True, slots=True)
+class TraceEvent:
+    """Structured event emitted by the FlowRunner."""
+
+    event: str
+    scope: str
+    data: Mapping[str, object]
+
+
+class TraceEventEmitter:
+    """Collect and emit immutable trace events."""
+
+    def __init__(self) -> None:
+        self._events: list[TraceEvent] = []
+
+    def reset(self) -> None:
+        """Clear previously captured events."""
+
+        self._events.clear()
+
+    def emit(self, event: str, scope: str, payload: Mapping[str, object]) -> None:
+        record = TraceEvent(event=event, scope=scope, data=mapping_proxy(payload))
+        self._events.append(record)
+
+    def budget_charge(
+        self,
+        charge: BudgetCharge,
+        *,
+        loop_iteration: int | None,
+        run_id: str,
+    ) -> None:
+        payload: dict[str, object] = {
+            "run_id": run_id,
+            "scope_kind": charge.scope.kind,
+            "scope_id": charge.scope.identifier,
+            "mode": charge.spec.mode.value,
+            "breach_action": charge.action,
+            "cost": dict(charge.cost),
+            "remaining": dict(charge.remaining),
+        }
+        if charge.overages:
+            payload["overages"] = dict(charge.overages)
+        if loop_iteration is not None:
+            payload["loop_iteration"] = loop_iteration
+        self.emit("budget_charge", f"{charge.scope.kind}:{charge.scope.identifier}", payload)
+
+    def budget_breach(
+        self,
+        charge: BudgetCharge,
+        *,
+        loop_iteration: int | None,
+        run_id: str,
+        stop_reason: str,
+    ) -> None:
+        payload: dict[str, object] = {
+            "run_id": run_id,
+            "scope_kind": charge.scope.kind,
+            "scope_id": charge.scope.identifier,
+            "breach_action": charge.action,
+            "remaining": dict(charge.remaining),
+            "overages": dict(charge.overages),
+            "stop_reason": stop_reason,
+        }
+        if loop_iteration is not None:
+            payload["loop_iteration"] = loop_iteration
+        self.emit("budget_breach", f"{charge.scope.kind}:{charge.scope.identifier}", payload)
+
+    def policy_resolved(
+        self,
+        node_id: str,
+        resolution: PolicyResolution,
+        *,
+        run_id: str,
+        iteration: int | None,
+    ) -> None:
+        payload: dict[str, object] = {
+            "run_id": run_id,
+            "node_id": node_id,
+            "allowed": tuple(sorted(resolution.allowed)),
+            "denied": {name: tuple(reasons) for name, reasons in resolution.denied.items()},
+            "stack_depth": resolution.stack_depth,
+        }
+        if iteration is not None:
+            payload["loop_iteration"] = iteration
+        self.emit("policy_resolved", f"node:{node_id}", payload)
+
+    @property
+    def events(self) -> tuple[TraceEvent, ...]:
+        """Expose captured events as an immutable sequence."""
+
+        return tuple(self._events)
+
+    def extend(self, events: Iterable[TraceEvent]) -> None:  # pragma: no cover - future use
+        self._events.extend(events)


### PR DESCRIPTION
## Summary
- add canonical budget models and manager with preview/commit lifecycle
- introduce a shared trace event emitter for budget and policy events
- implement FlowRunner budget enforcement with adapter execution plus unit tests and docs

## Testing
- pytest codex/code/work/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8a9dc8530832c914a518a356b62ed