### PR TITLE
Implement FlowRunner budget guards with tests

### DIFF
--- a/codex/DOCUMENTATION/P3/work-20250505T120000Z-gpt5codex.yaml
+++ b/codex/DOCUMENTATION/P3/work-20250505T120000Z-gpt5codex.yaml
@@ -1,0 +1,69 @@
+component:
+  name: FlowRunner Budget Guards
+  purpose: |
+    Execute DSL unit and loop nodes while enforcing hierarchical policies and multi-scope
+    budget guards. Provides deterministic orchestration for adapters with immutable trace
+    emission.
+cli:
+  usage: |
+    No dedicated CLI entry point yet. Runner is consumed as a Python class:
+      from pkgs.dsl.runner import FlowRunner
+      runner = FlowRunner(adapters=my_adapters)
+      result = runner.run(spec=flow_spec, vars={})
+interfaces:
+  primary:
+    - name: FlowRunner.run
+      params:
+        spec: Mapping[str, object]
+        vars: Mapping[str, object]
+      returns: RunResult(run_id, status, outputs, stop_reasons)
+      notes: |
+        Supports `unit` and `loop` nodes. Other node kinds raise `KeyError` or are skipped.
+    - name: BudgetManager.preflight/commit
+      params:
+        scope: BudgetScope(scope_type, scope_id)
+        cost: CostSnapshot
+      returns: BudgetDecision with breach metadata
+      notes: Handles run/node/loop scopes and emits trace events.
+    - name: TraceEventEmitter.emit
+      params: event, scope_type, scope_id, payload
+      returns: TraceEvent with immutable payload
+      notes: Payload recursively converts mappings/lists to immutable structures.
+  extension_hooks:
+    - description: Implement additional ToolAdapter classes adhering to estimate/execute protocol.
+    - description: Extend FlowRunner to cover transform/decision nodes by reusing `_collect_scopes` helpers.
+configuration:
+  options:
+    run_budget: globals.run_budget mapping (max_usd, max_calls, max_tokens, time_limit_sec, mode)
+    node_budget: node.budget mapping (same fields + breach_action)
+    loop_budget: loop.stop.budget mapping controlling iteration stop semantics
+  defaults:
+    mode: hard unless explicitly set to soft
+    breach_action: error except when stop budgets specify "stop"
+automation:
+  triggers:
+    - pytest codex/code/work/tests/unit/test_budget_models.py
+    - pytest codex/code/work/tests/unit/test_budget_manager.py
+    - pytest codex/code/work/tests/unit/test_flow_runner_budgets.py
+errors:
+  contracts:
+    - BudgetBreachError raised when hard budgets exceed limits (unless breach_action == "stop")
+    - PolicyViolationError surfaced when PolicyStack denies a tool
+    - RuntimeError raised if no adapter registered for a referenced tool
+serialization:
+  trace_events:
+    format: JSON-friendly mapping with immutable MappingProxyType payloads
+    fields: [event, scope_type, scope_id, payload]
+lifecycle:
+  phases:
+    - Instantiate FlowRunner with adapter registry
+    - Run execution plan with budgets/policies enforced
+    - Consume RunResult and inspect stop_reasons/warnings
+typing:
+  notes: All public dataclasses enable type checking with Python 3.12; Protocol used for ToolAdapter.
+security:
+  notes: PolicyStack enforces allow/deny lists; no external I/O performed beyond adapters supplied by caller.
+performance:
+  considerations:
+    - BudgetMeter arithmetic uses pure Python; overhead negligible for unit tests.
+    - FlowRunner executes sequentially; concurrency support deferred.

--- a/codex/TESTS/P3/work-20250505T120000Z-gpt5codex.yaml
+++ b/codex/TESTS/P3/work-20250505T120000Z-gpt5codex.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_flow_runner_soft_budget_warning_trace
+      rationale: Ensure soft budgets append warnings and emit `budget_warning` events without halting execution.
+      source_module: pkgs/dsl/budget_manager.py
+      priority: medium
+    - name: test_runner_policy_and_budget_violation_same_iteration
+      rationale: Validate that FlowRunner surfaces both policy denial and loop budget stop when occurring in the same iteration.
+      source_module: pkgs/dsl/runner.py
+      priority: medium
+    - name: test_trace_event_emitter_schema_validation
+      rationale: Add jsonschema validation of emitted payloads to catch contract drift.
+      source_module: pkgs/dsl/trace.py
+      priority: low

--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.md
@@ -1,0 +1,12 @@
+# Post-execution Summary — Phase 3
+
+## Test Results
+- ✅ `pytest codex/code/work/tests/unit -q`
+
+## Coverage Notes
+- Budget domain models and manager operations are exercised via deterministic unit tests; loop stop, hard breach, and soft warning pathways are covered.
+- FlowRunner tests execute loop and node scenarios ensuring policy enforcement and budget propagation.
+
+## Remaining Gaps
+- No integration with caching/adapters beyond synchronous stubs; real adapter cost variance untested.
+- Trace schema validation remains TODO; current emitter ensures immutability only.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.md
@@ -1,0 +1,17 @@
+# Phase 3 Preview — Budget Guards and Runner Integration
+
+## Highlights
+- Added immutable budget domain models (`BudgetSpec`, `CostSnapshot`, `BudgetDecision`) with normalization helpers and stop semantics that differentiate hard vs. soft behaviour.
+- Introduced a `BudgetManager` orchestrator with scope-aware meters, trace emission, and loop stack management.
+- Implemented a minimal FlowRunner capable of executing unit and loop nodes while enforcing policy allowlists and budget guards.
+- Shared `TraceEventEmitter` ensures schema-friendly, immutable payloads reused by budgets and runner traces.
+
+## Test Plan
+- `pytest codex/code/work/tests/unit/test_budget_models.py`
+- `pytest codex/code/work/tests/unit/test_budget_manager.py`
+- `pytest codex/code/work/tests/unit/test_flow_runner_budgets.py`
+
+## Open Considerations
+- Transform/decision node execution is deferred; follow-up tasks should expand FlowRunner coverage.
+- Trace payload schema validation is stubbed; future work should integrate JSON schema checks.
+- Runner currently propagates first policy/budget violation; multi-error aggregation may be desirable later.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.md
@@ -1,0 +1,18 @@
+# Review Checklist — Phase 3 Budget Guards Integration
+
+## Code Quality
+- [x] `BudgetSpec.from_mapping` normalizes floats/ints and converts seconds → ms.
+- [x] `BudgetMeter` marks loop stop scopes when limits are reached or exceeded.
+- [x] `BudgetManager.commit` emits `budget_commit`, `budget_warning`, and `budget_breach` events with immutable payloads.
+- [x] FlowRunner handles policy push/pop symmetry and reports policy violations with scope-aware reasons.
+- [x] Loop execution halts on budget stop reasons and honours max_iterations.
+
+## Tests
+- [x] Unit tests cover budget models, manager semantics, and runner loop/node policies.
+- [x] Tests inject deterministic fake adapters to avoid nondeterminism.
+- [x] `conftest.py` adds repo root to `sys.path` for test discovery.
+
+## Follow-ups
+- [ ] Extend FlowRunner to support transform/decision nodes.
+- [ ] Add schema validation for emitted trace payloads.
+- [ ] Provide integration tests combining policy violations and soft budget warnings.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.yaml
@@ -1,0 +1,66 @@
+summary: Integrate budget domain models, manager orchestration, and FlowRunner enforcement with schema-aligned tracing.
+justification: |
+  Consolidates reusable assets from prior branches by pairing immutable budget data classes with a BudgetManager
+  facade and runner integration that respects DSL breach semantics. Emphasizes deterministic tests for hard/soft
+  budgets and loop stop signals to close Phase 2 gaps.
+steps:
+  - id: domain_models
+    description: Reintroduce canonical budget value objects and trace emitter utilities with normalization helpers.
+  - id: budget_manager
+    description: Build BudgetManager orchestration for run/node/loop scopes using preflight/commit with immutable outcomes.
+  - id: runner_integration
+    description: Wire FlowRunner to adapters, policy stack, and BudgetManager enforcing breach actions and trace emission.
+  - id: validation
+    description: Expand unit/e2e-style coverage for hard/soft budgets, loop halts, and warning propagation.
+modules:
+  - path: pkgs/dsl/budget.py
+    role: Immutable budget domain objects, normalization helpers, BudgetMeter, and breach errors.
+  - path: pkgs/dsl/trace.py
+    role: TraceEventEmitter utility shared by policy and budget layers with immutable payloads.
+  - path: pkgs/dsl/budget_manager.py
+    role: BudgetManager coordinating scope meters, preflight/commit outcomes, and trace emission.
+  - path: pkgs/dsl/runner.py
+    role: FlowRunner orchestration with adapter execution, policy enforcement, budget guards, and loop control.
+  - path: pkgs/dsl/__init__.py
+    role: Export newly added budget and runner types for external consumption.
+tests:
+  - path: codex/code/work/tests/unit/test_budget_models.py
+    coverage: BudgetSpec normalization, BudgetMeter breach semantics, trace emitter immutability.
+    mocks: Use fake trace sink and deterministic time factory.
+  - path: codex/code/work/tests/unit/test_budget_manager.py
+    coverage: Preflight/commit flows, run/node/loop scopes, soft warning aggregation.
+    mocks: Fake meters, dummy trace emitter, adapter estimates.
+  - path: codex/code/work/tests/unit/test_flow_runner_budgets.py
+    coverage: FlowRunner integration with loop stop budget, node budgets, and policy allowlist interactions.
+    mocks: Stub ToolAdapter implementations, in-memory trace collector.
+run_order:
+  - tests/unit/test_budget_models.py
+  - tests/unit/test_budget_manager.py
+  - tests/unit/test_flow_runner_budgets.py
+interfaces:
+  - name: ToolAdapter
+    module: pkgs/dsl/runner.py
+    contract: estimate_cost(spec, context) -> CostSnapshot; execute(spec, context) -> ExecutionResult with cost snapshot.
+  - name: BudgetManager
+    module: pkgs/dsl/budget_manager.py
+    contract: preflight(scope, cost) -> BudgetDecision; commit(scope, cost) -> BudgetDecision; push_loop(scope_id, spec); pop_loop().
+  - name: TraceEventEmitter
+    module: pkgs/dsl/trace.py
+    contract: emit(event, scope_type, scope_id, payload) storing immutable MappingProxyType payloads and forwarding to sinks.
+tdd_coverage_targets:
+  pkgs/dsl/budget.py: 0.9
+  pkgs/dsl/budget_manager.py: 0.85
+  pkgs/dsl/runner.py: 0.8
+review_checklist:
+  - Ensure BudgetSpec normalization handles seconds/ms conversions consistently.
+  - Verify BudgetManager enforces breach_action semantics for soft/hard modes.
+  - Confirm FlowRunner integrates PolicyStack to filter adapters before execution.
+  - Check trace payloads are immutable and schema-aligned keys are used.
+outputs:
+  plan_file: codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.yaml
+  tests_root: codex/code/work/tests
+  docs_preview: codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.md
+  docs_review: codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.md
+  docs_postexecution: codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250505T120000Z-gpt5codex.md
+  documentation_yaml: codex/DOCUMENTATION/P3/work-20250505T120000Z-gpt5codex.yaml
+  missing_tests_yaml: codex/TESTS/P3/work-20250505T120000Z-gpt5codex.yaml

--- a/codex/code/work/pkgs/dsl/__init__.py
+++ b/codex/code/work/pkgs/dsl/__init__.py
@@ -1,0 +1,6 @@
+"""Workspace convenience exports mirroring :mod:`pkgs.dsl`."""
+
+from pkgs import dsl as _dsl  # type: ignore[attr-defined]
+from pkgs.dsl import *  # noqa: F401,F403
+
+__all__ = _dsl.__all__  # type: ignore[attr-defined]

--- a/codex/code/work/pkgs/dsl/budget.py
+++ b/codex/code/work/pkgs/dsl/budget.py
@@ -1,0 +1,3 @@
+"""Workspace mirror for :mod:`pkgs.dsl.budget`."""
+
+from pkgs.dsl.budget import *  # noqa: F401,F403

--- a/codex/code/work/pkgs/dsl/budget_manager.py
+++ b/codex/code/work/pkgs/dsl/budget_manager.py
@@ -1,0 +1,3 @@
+"""Workspace mirror for :mod:`pkgs.dsl.budget_manager`."""
+
+from pkgs.dsl.budget_manager import *  # noqa: F401,F403

--- a/codex/code/work/pkgs/dsl/runner.py
+++ b/codex/code/work/pkgs/dsl/runner.py
@@ -1,0 +1,3 @@
+"""Workspace mirror for :mod:`pkgs.dsl.runner`."""
+
+from pkgs.dsl.runner import *  # noqa: F401,F403

--- a/codex/code/work/pkgs/dsl/trace.py
+++ b/codex/code/work/pkgs/dsl/trace.py
@@ -1,0 +1,3 @@
+"""Workspace mirror for :mod:`pkgs.dsl.trace`."""
+
+from pkgs.dsl.trace import *  # noqa: F401,F403

--- a/codex/code/work/tests/conftest.py
+++ b/codex/code/work/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration for codex workspace tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/codex/code/work/tests/unit/test_budget_manager.py
+++ b/codex/code/work/tests/unit/test_budget_manager.py
@@ -1,0 +1,64 @@
+import pytest
+
+from pkgs.dsl.budget import BudgetBreachError, BudgetMode, BudgetSpec, CostSnapshot
+from pkgs.dsl.budget_manager import BudgetManager, BudgetScope
+from pkgs.dsl.trace import TraceEventEmitter
+
+
+def test_budget_manager_preflight_and_commit() -> None:
+    emitter = TraceEventEmitter()
+    manager = BudgetManager(
+        run_spec=BudgetSpec.from_mapping({"max_usd": 3.0, "mode": "hard"}),
+        trace=emitter,
+    )
+    cost = CostSnapshot(usd=1.25)
+    preview = manager.preflight(BudgetScope("run", "run"), cost)
+    assert preview.remaining.usd == pytest.approx(1.75)
+    commit = manager.commit(BudgetScope("run", "run"), cost)
+    assert commit.spent.usd == pytest.approx(1.25)
+    assert emitter.events[-1].event == "budget_commit"
+
+
+def test_budget_manager_soft_warning_accumulates() -> None:
+    manager = BudgetManager(run_spec=None, trace=None)
+    manager.configure_scope(
+        BudgetScope("node", "n1"),
+        BudgetSpec.from_mapping({"max_usd": 1.0, "mode": "soft"}),
+    )
+    decision = manager.commit(BudgetScope("node", "n1"), CostSnapshot(usd=1.5))
+    assert decision.breached
+    assert manager.warnings == (decision,)
+
+
+def test_budget_manager_hard_breach_raises() -> None:
+    manager = BudgetManager(
+        run_spec=BudgetSpec.from_mapping({"max_usd": 1.0, "mode": "hard"}),
+        trace=None,
+    )
+    manager.commit(BudgetScope("run", "run"), CostSnapshot(usd=0.6))
+    with pytest.raises(BudgetBreachError):
+        manager.commit(BudgetScope("run", "run"), CostSnapshot(usd=0.5))
+
+
+def test_budget_manager_loop_budget_stops_iteration() -> None:
+    manager = BudgetManager(run_spec=None, trace=None)
+    manager.configure_scope(
+        BudgetScope("loop", "loop-1"),
+        BudgetSpec.from_mapping(
+            {"max_calls": 2, "breach_action": "stop", "mode": "hard"}
+        ),
+    )
+    first = manager.commit(BudgetScope("loop", "loop-1"), CostSnapshot(calls=1))
+    assert not first.should_stop
+    second = manager.commit(BudgetScope("loop", "loop-1"), CostSnapshot(calls=1))
+    assert second.should_stop
+
+
+def test_budget_manager_time_limit_enforced() -> None:
+    manager = BudgetManager(
+        run_spec=BudgetSpec.from_mapping({"time_limit_sec": 1.0, "mode": "hard"}),
+        trace=None,
+    )
+    manager.commit(BudgetScope("run", "run"), CostSnapshot(elapsed_ms=500))
+    with pytest.raises(BudgetBreachError):
+        manager.commit(BudgetScope("run", "run"), CostSnapshot(elapsed_ms=600))

--- a/codex/code/work/tests/unit/test_budget_models.py
+++ b/codex/code/work/tests/unit/test_budget_models.py
@@ -1,0 +1,68 @@
+import pytest
+
+from pkgs.dsl.budget import (
+    BudgetBreachError,
+    BudgetMeter,
+    BudgetMode,
+    BudgetSpec,
+    CostSnapshot,
+)
+from pkgs.dsl.trace import TraceEventEmitter
+
+
+def test_budget_spec_normalization_and_defaults() -> None:
+    spec = BudgetSpec.from_mapping(
+        {
+            "max_usd": "1.5",
+            "max_calls": 3,
+            "max_tokens": 1200,
+            "time_limit_sec": 2.5,
+            "mode": "soft",
+        }
+    )
+    assert spec.mode is BudgetMode.SOFT
+    assert spec.time_limit_ms == 2500
+    assert spec.max_usd == pytest.approx(1.5)
+    assert spec.max_calls == 3
+    assert spec.max_tokens == 1200
+
+
+def test_cost_snapshot_arithmetic_and_meter_commit() -> None:
+    spec = BudgetSpec.from_mapping({"max_usd": 2.0, "mode": "hard"})
+    meter = BudgetMeter(scope_type="run", scope_id="run", spec=spec)
+    preview = meter.preview(CostSnapshot(usd=1.0))
+    assert not preview.breached
+    decision = meter.commit(CostSnapshot(usd=0.75))
+    assert decision.spent.usd == pytest.approx(0.75)
+    assert decision.remaining.usd == pytest.approx(1.25)
+
+
+def test_budget_meter_hard_breach_raises() -> None:
+    spec = BudgetSpec.from_mapping({"max_usd": 1.0, "mode": "hard"})
+    meter = BudgetMeter(scope_type="run", scope_id="run", spec=spec)
+    meter.commit(CostSnapshot(usd=0.6))
+    with pytest.raises(BudgetBreachError):
+        meter.commit(CostSnapshot(usd=0.5))
+
+
+def test_budget_meter_soft_budget_records_warning() -> None:
+    spec = BudgetSpec.from_mapping({"max_usd": 1.0, "mode": "soft"})
+    meter = BudgetMeter(scope_type="node", scope_id="n1", spec=spec)
+    decision = meter.commit(CostSnapshot(usd=1.2))
+    assert decision.breached
+    assert decision.warnings == ("budget_soft_limit_exceeded",)
+
+
+def test_trace_event_emitter_returns_immutable_payload() -> None:
+    emitter = TraceEventEmitter()
+    event = emitter.emit(
+        event="budget_commit",
+        scope_type="run",
+        scope_id="run",
+        payload={"spent": {"usd": 1.0}},
+    )
+    assert event.event == "budget_commit"
+    with pytest.raises(TypeError):
+        event.payload["spent"] = {"usd": 2.0}
+    with pytest.raises(TypeError):
+        event.payload["spent"]["usd"] = 2.0

--- a/codex/code/work/tests/unit/test_flow_runner_budgets.py
+++ b/codex/code/work/tests/unit/test_flow_runner_budgets.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pkgs.dsl.budget import CostSnapshot
+from pkgs.dsl.runner import FlowRunner, RunResult, ToolAdapter, ToolExecutionResult
+
+
+@dataclass
+class CountingAdapter(ToolAdapter):
+    cost_per_call: CostSnapshot
+    output_value: str = "ok"
+    calls: int = 0
+
+    def estimate_cost(self, node_spec: dict, context: dict) -> CostSnapshot:
+        return self.cost_per_call
+
+    def execute(self, node_spec: dict, context: dict) -> ToolExecutionResult:
+        self.calls += 1
+        return ToolExecutionResult(
+            outputs={"value": f"{self.output_value}-{self.calls}"},
+            cost=self.cost_per_call,
+        )
+
+
+def make_runner_spec() -> dict:
+    return {
+        "globals": {
+            "tools": {
+                "alpha": {"tags": []},
+            },
+            "run_budget": {"max_usd": 10.0, "mode": "hard"},
+        },
+        "graph": {
+            "sequence": ["loop"],
+            "nodes": {
+                "loop": {
+                    "id": "loop",
+                    "kind": "loop",
+                    "target_subgraph": ["loop_step"],
+                    "stop": {
+                        "budget": {"max_calls": 2, "breach_action": "stop"}
+                    },
+                },
+                "loop_step": {
+                    "id": "loop_step",
+                    "kind": "unit",
+                    "outputs": ["value"],
+                    "spec": {"tool_ref": "alpha"},
+                },
+            },
+        },
+    }
+
+
+def test_flow_runner_loop_budget_stop() -> None:
+    spec = make_runner_spec()
+    adapters = {"alpha": CountingAdapter(cost_per_call=CostSnapshot(calls=1))}
+    runner = FlowRunner(adapters=adapters)
+    result = runner.run(spec=spec, vars={})
+    assert isinstance(result, RunResult)
+    assert result.status == "halted"
+    assert result.stop_reasons == ("loop:loop:budget_stop",)
+    assert adapters["alpha"].calls == 2
+
+
+def test_flow_runner_node_budget_error_sets_failure() -> None:
+    spec = {
+        "globals": {
+            "tools": {"alpha": {"tags": []}},
+            "run_budget": {"max_usd": 5.0, "mode": "hard"},
+        },
+        "graph": {
+            "sequence": ["expensive"],
+            "nodes": {
+                "expensive": {
+                    "id": "expensive",
+                    "kind": "unit",
+                    "outputs": ["value"],
+                    "budget": {"max_usd": 1.0, "mode": "hard"},
+                    "spec": {"tool_ref": "alpha"},
+                }
+            },
+        },
+    }
+    adapters = {
+        "alpha": CountingAdapter(cost_per_call=CostSnapshot(usd=2.0), output_value="exp"),
+    }
+    runner = FlowRunner(adapters=adapters)
+    result = runner.run(spec=spec, vars={})
+    assert result.status == "error"
+    assert result.stop_reasons[0].startswith("node:expensive")
+
+
+def test_flow_runner_respects_policy_allowlist() -> None:
+    spec = {
+        "globals": {
+            "tools": {
+                "alpha": {"tags": []},
+                "beta": {"tags": []},
+            },
+            "tool_sets": {},
+            "run_budget": {"max_usd": 5.0, "mode": "hard"},
+        },
+        "graph": {
+            "sequence": ["restricted"],
+            "nodes": {
+                "restricted": {
+                    "id": "restricted",
+                    "kind": "unit",
+                    "outputs": ["value"],
+                    "policy": {"allow_tools": ["alpha"]},
+                    "spec": {"tool_ref": "beta"},
+                }
+            },
+        },
+    }
+    adapters = {
+        "alpha": CountingAdapter(cost_per_call=CostSnapshot(usd=1.0), output_value="alpha"),
+        "beta": CountingAdapter(cost_per_call=CostSnapshot(usd=1.0), output_value="beta"),
+    }
+    runner = FlowRunner(adapters=adapters)
+    result = runner.run(spec=spec, vars={})
+    assert result.status == "error"
+    assert result.stop_reasons == ("policy:restricted:beta",)

--- a/pkgs/__init__.py
+++ b/pkgs/__init__.py
@@ -1,0 +1,3 @@
+"""Top-level namespace package for DSL components."""
+
+__all__ = ["dsl"]

--- a/pkgs/dsl/__init__.py
+++ b/pkgs/dsl/__init__.py
@@ -14,6 +14,22 @@ from .policy import (  # noqa: F401
     PolicyTraceRecorder,
     PolicyViolationError,
 )
+from .budget import (  # noqa: F401
+    BudgetBreachError,
+    BudgetDecision,
+    BudgetMeter,
+    BudgetMode,
+    BudgetSpec,
+    CostSnapshot,
+)
+from .budget_manager import BudgetManager, BudgetScope  # noqa: F401
+from .runner import (  # noqa: F401
+    FlowRunner,
+    RunResult,
+    ToolAdapter,
+    ToolExecutionResult,
+)
+from .trace import TraceEvent, TraceEventEmitter  # noqa: F401
 
 __all__ = [
     "PolicyDecision",
@@ -26,4 +42,18 @@ __all__ = [
     "PolicyTraceRecorder",
     "PolicyViolationError",
     "ToolDescriptor",
+    "BudgetBreachError",
+    "BudgetDecision",
+    "BudgetMeter",
+    "BudgetMode",
+    "BudgetSpec",
+    "BudgetManager",
+    "BudgetScope",
+    "CostSnapshot",
+    "FlowRunner",
+    "RunResult",
+    "ToolAdapter",
+    "ToolExecutionResult",
+    "TraceEvent",
+    "TraceEventEmitter",
 ]

--- a/pkgs/dsl/budget.py
+++ b/pkgs/dsl/budget.py
@@ -1,0 +1,263 @@
+"""Budget domain models and helpers for the FlowRunner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+__all__ = [
+    "BudgetBreachError",
+    "BudgetDecision",
+    "BudgetMeter",
+    "BudgetMode",
+    "BudgetSpec",
+    "CostSnapshot",
+]
+
+
+class BudgetMode(Enum):
+    """Budget enforcement mode."""
+
+    HARD = "hard"
+    SOFT = "soft"
+
+    @classmethod
+    def from_value(cls, value: object | None) -> "BudgetMode":
+        if isinstance(value, BudgetMode):
+            return value
+        if isinstance(value, str):
+            normalized = value.lower().strip()
+            if normalized == "soft":
+                return cls.SOFT
+        return cls.HARD
+
+
+@dataclass(frozen=True, slots=True)
+class CostSnapshot:
+    """Immutable cost bookkeeping snapshot."""
+
+    usd: float = 0.0
+    calls: int = 0
+    tokens: int = 0
+    elapsed_ms: int = 0
+
+    def __add__(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot(
+            usd=self.usd + other.usd,
+            calls=self.calls + other.calls,
+            tokens=self.tokens + other.tokens,
+            elapsed_ms=self.elapsed_ms + other.elapsed_ms,
+        )
+
+    def __sub__(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot(
+            usd=max(self.usd - other.usd, 0.0),
+            calls=max(self.calls - other.calls, 0),
+            tokens=max(self.tokens - other.tokens, 0),
+            elapsed_ms=max(self.elapsed_ms - other.elapsed_ms, 0),
+        )
+
+    @classmethod
+    def zero(cls) -> "CostSnapshot":
+        return cls()
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetSpec:
+    """Declarative description of a budget."""
+
+    max_usd: float | None = None
+    max_calls: int | None = None
+    max_tokens: int | None = None
+    time_limit_ms: int | None = None
+    mode: BudgetMode = BudgetMode.HARD
+    breach_action: str = "error"
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, object] | None) -> "BudgetSpec":
+        if data is None:
+            return cls()
+        mapping = dict(data)
+        mode = BudgetMode.from_value(mapping.get("mode"))
+        breach_action = str(mapping.get("breach_action", "warn" if mode is BudgetMode.SOFT else "error"))
+        max_usd = cls._coerce_float(mapping.get("max_usd"))
+        max_calls = cls._coerce_int(mapping.get("max_calls"))
+        max_tokens = cls._coerce_int(mapping.get("max_tokens"))
+        time_limit_sec = cls._coerce_float(mapping.get("time_limit_sec"))
+        time_limit_ms = cls._coerce_int(mapping.get("time_limit_ms"))
+        if time_limit_ms is None and time_limit_sec is not None:
+            time_limit_ms = int(round(time_limit_sec * 1000))
+        return cls(
+            max_usd=max_usd,
+            max_calls=max_calls,
+            max_tokens=max_tokens,
+            time_limit_ms=time_limit_ms,
+            mode=mode,
+            breach_action=breach_action,
+        )
+
+    @staticmethod
+    def _coerce_float(value: object | None) -> float | None:
+        if value is None:
+            return None
+        try:
+            result = float(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError(f"invalid float value {value!r}") from exc
+        return result
+
+    @staticmethod
+    def _coerce_int(value: object | None) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError(f"invalid int value {value!r}") from exc
+
+    def has_limits(self) -> bool:
+        return any(
+            limit is not None
+            for limit in (self.max_usd, self.max_calls, self.max_tokens, self.time_limit_ms)
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetDecision:
+    """Outcome of a budget charge for a scope."""
+
+    scope_type: str
+    scope_id: str
+    spec: BudgetSpec
+    cost: CostSnapshot
+    spent: CostSnapshot
+    remaining: CostSnapshot
+    overage: CostSnapshot
+    stage: str
+    breached: bool
+    mode: BudgetMode
+    breach_action: str
+    should_stop: bool
+    warnings: tuple[str, ...]
+
+
+class BudgetBreachError(RuntimeError):
+    """Raised when a hard budget is exceeded."""
+
+    def __init__(self, decision: BudgetDecision) -> None:
+        action = decision.breach_action or "error"
+        message = (
+            f"Budget breach on {decision.scope_type}:{decision.scope_id} action={action}"
+        )
+        super().__init__(message)
+        self.decision = decision
+
+
+class BudgetMeter:
+    """Track budget consumption for a single scope."""
+
+    def __init__(self, *, scope_type: str, scope_id: str, spec: BudgetSpec) -> None:
+        self._scope_type = scope_type
+        self._scope_id = scope_id
+        self._spec = spec
+        self._spent = CostSnapshot.zero()
+
+    @property
+    def spec(self) -> BudgetSpec:
+        return self._spec
+
+    @property
+    def spent(self) -> CostSnapshot:
+        return self._spent
+
+    def preview(self, cost: CostSnapshot) -> BudgetDecision:
+        return self._evaluate(cost, stage="preflight", mutate=False)
+
+    def commit(self, cost: CostSnapshot) -> BudgetDecision:
+        return self._evaluate(cost, stage="commit", mutate=True)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _evaluate(self, cost: CostSnapshot, *, stage: str, mutate: bool) -> BudgetDecision:
+        projected = self._spent + cost
+        spec = self._spec
+        remaining = self._compute_remaining(spec, projected)
+        overage = self._compute_overage(spec, projected)
+        breached = any(
+            value > 0
+            for value in (overage.usd, overage.calls, overage.tokens, overage.elapsed_ms)
+        )
+        exhausted = self._is_exhausted(spec, projected)
+        should_stop = spec.breach_action == "stop" and (exhausted or breached)
+        warnings: tuple[str, ...] = ()
+        if breached and spec.mode is BudgetMode.SOFT:
+            warnings = ("budget_soft_limit_exceeded",)
+
+        decision = BudgetDecision(
+            scope_type=self._scope_type,
+            scope_id=self._scope_id,
+            spec=spec,
+            cost=cost,
+            spent=projected,
+            remaining=remaining,
+            overage=overage,
+            stage=stage,
+            breached=breached,
+            mode=spec.mode,
+            breach_action=spec.breach_action,
+            should_stop=should_stop,
+            warnings=warnings,
+        )
+
+        if mutate:
+            if breached and spec.mode is BudgetMode.HARD and spec.breach_action != "stop":
+                raise BudgetBreachError(decision)
+            self._spent = projected
+        return decision
+
+    @staticmethod
+    def _compute_remaining(spec: BudgetSpec, spent: CostSnapshot) -> CostSnapshot:
+        return CostSnapshot(
+            usd=max((spec.max_usd or float("inf")) - spent.usd, 0.0)
+            if spec.max_usd is not None
+            else float("inf"),
+            calls=max((spec.max_calls or float("inf")) - spent.calls, 0)
+            if spec.max_calls is not None
+            else float("inf"),
+            tokens=max((spec.max_tokens or float("inf")) - spent.tokens, 0)
+            if spec.max_tokens is not None
+            else float("inf"),
+            elapsed_ms=max((spec.time_limit_ms or float("inf")) - spent.elapsed_ms, 0)
+            if spec.time_limit_ms is not None
+            else float("inf"),
+        )
+
+    @staticmethod
+    def _compute_overage(spec: BudgetSpec, spent: CostSnapshot) -> CostSnapshot:
+        usd_over = max(spent.usd - spec.max_usd, 0.0) if spec.max_usd is not None else 0.0
+        call_over = max(spent.calls - spec.max_calls, 0) if spec.max_calls is not None else 0
+        token_over = max(spent.tokens - spec.max_tokens, 0) if spec.max_tokens is not None else 0
+        time_over = (
+            max(spent.elapsed_ms - spec.time_limit_ms, 0)
+            if spec.time_limit_ms is not None
+            else 0
+        )
+        return CostSnapshot(
+            usd=usd_over,
+            calls=call_over,
+            tokens=token_over,
+            elapsed_ms=time_over,
+        )
+
+    @staticmethod
+    def _is_exhausted(spec: BudgetSpec, spent: CostSnapshot) -> bool:
+        return any(
+            (
+                spec.max_usd is not None and spent.usd >= spec.max_usd,
+                spec.max_calls is not None and spent.calls >= spec.max_calls,
+                spec.max_tokens is not None and spent.tokens >= spec.max_tokens,
+                spec.time_limit_ms is not None and spent.elapsed_ms >= spec.time_limit_ms,
+            )
+        )

--- a/pkgs/dsl/budget_manager.py
+++ b/pkgs/dsl/budget_manager.py
@@ -1,0 +1,190 @@
+"""BudgetManager orchestration for FlowRunner scopes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Sequence
+
+from .budget import (
+    BudgetBreachError,
+    BudgetDecision,
+    BudgetMeter,
+    BudgetMode,
+    BudgetSpec,
+    CostSnapshot,
+)
+from .trace import TraceEventEmitter
+
+__all__ = ["BudgetManager", "BudgetScope"]
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetScope:
+    """Hashable identifier for a budget scope."""
+
+    scope_type: str
+    scope_id: str
+
+    def key(self) -> tuple[str, str]:
+        return (self.scope_type, self.scope_id)
+
+
+class BudgetManager:
+    """Coordinate budget meters across run/node/loop scopes."""
+
+    def __init__(
+        self,
+        *,
+        run_spec: BudgetSpec | Mapping[str, object] | None,
+        trace: TraceEventEmitter | None = None,
+    ) -> None:
+        self._trace = trace or TraceEventEmitter()
+        self._meters: Dict[tuple[str, str], BudgetMeter] = {}
+        self._warnings: list[BudgetDecision] = []
+        self._loop_stack: list[BudgetScope] = []
+        if run_spec is not None:
+            spec = self._normalize_spec(run_spec)
+            self.configure_scope(BudgetScope("run", "run"), spec)
+
+    # ------------------------------------------------------------------
+    # Scope configuration
+    # ------------------------------------------------------------------
+    def configure_scope(
+        self,
+        scope: BudgetScope,
+        spec: BudgetSpec | Mapping[str, object] | None,
+    ) -> None:
+        spec_obj = self._normalize_spec(spec)
+        self._meters[scope.key()] = BudgetMeter(
+            scope_type=scope.scope_type,
+            scope_id=scope.scope_id,
+            spec=spec_obj,
+        )
+
+    def push_loop(self, loop_id: str, spec: BudgetSpec | Mapping[str, object] | None) -> BudgetScope:
+        scope = BudgetScope("loop", loop_id)
+        self.configure_scope(scope, spec)
+        self._loop_stack.append(scope)
+        return scope
+
+    def pop_loop(self, expected_id: str | None = None) -> None:
+        if not self._loop_stack:
+            raise RuntimeError("loop stack underflow")
+        scope = self._loop_stack.pop()
+        if expected_id is not None and scope.scope_id != expected_id:
+            self._loop_stack.append(scope)
+            raise RuntimeError(
+                f"loop scope mismatch: expected {expected_id!r}, got {scope.scope_id!r}"
+            )
+
+    # ------------------------------------------------------------------
+    # Budget evaluation
+    # ------------------------------------------------------------------
+    def preflight(self, scope: BudgetScope, cost: CostSnapshot) -> BudgetDecision:
+        meter = self._ensure_meter(scope)
+        decision = meter.preview(cost)
+        self._emit_decision("budget_preflight", decision)
+        if decision.breached and decision.mode is BudgetMode.HARD and not decision.should_stop:
+            self._emit_breach(decision)
+            raise BudgetBreachError(decision)
+        return decision
+
+    def commit(self, scope: BudgetScope, cost: CostSnapshot) -> BudgetDecision:
+        meter = self._ensure_meter(scope)
+        try:
+            decision = meter.commit(cost)
+        except BudgetBreachError as exc:
+            self._emit_breach(exc.decision)
+            raise
+        else:
+            self._emit_decision("budget_commit", decision)
+            if decision.breached:
+                if decision.mode is BudgetMode.SOFT:
+                    self._warnings.append(decision)
+                    self._emit_warning(decision)
+                if decision.should_stop or decision.mode is BudgetMode.HARD:
+                    self._emit_breach(decision)
+            return decision
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+    @property
+    def warnings(self) -> Sequence[BudgetDecision]:
+        return tuple(self._warnings)
+
+    @property
+    def loop_stack(self) -> Sequence[BudgetScope]:
+        return tuple(self._loop_stack)
+
+    @property
+    def trace(self) -> TraceEventEmitter:
+        return self._trace
+
+    def has_scope(self, scope: BudgetScope) -> bool:
+        return scope.key() in self._meters
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_meter(self, scope: BudgetScope) -> BudgetMeter:
+        meter = self._meters.get(scope.key())
+        if meter is None:
+            self.configure_scope(scope, None)
+            meter = self._meters[scope.key()]
+        return meter
+
+    def _normalize_spec(
+        self, spec: BudgetSpec | Mapping[str, object] | None
+    ) -> BudgetSpec:
+        if isinstance(spec, BudgetSpec):
+            return spec
+        return BudgetSpec.from_mapping(spec)
+
+    def _emit_decision(self, event: str, decision: BudgetDecision) -> None:
+        self._trace.emit(
+            event=event,
+            scope_type=decision.scope_type,
+            scope_id=decision.scope_id,
+            payload={
+                "stage": decision.stage,
+                "breached": decision.breached,
+                "mode": decision.mode.value,
+                "breach_action": decision.breach_action,
+                "cost": self._snapshot_payload(decision.cost),
+                "spent": self._snapshot_payload(decision.spent),
+                "remaining": self._snapshot_payload(decision.remaining),
+                "overage": self._snapshot_payload(decision.overage),
+            },
+        )
+
+    def _emit_warning(self, decision: BudgetDecision) -> None:
+        self._trace.emit(
+            event="budget_warning",
+            scope_type=decision.scope_type,
+            scope_id=decision.scope_id,
+            payload={
+                "warnings": list(decision.warnings),
+                "breach_action": decision.breach_action,
+            },
+        )
+
+    def _emit_breach(self, decision: BudgetDecision) -> None:
+        self._trace.emit(
+            event="budget_breach",
+            scope_type=decision.scope_type,
+            scope_id=decision.scope_id,
+            payload={
+                "breach_action": decision.breach_action,
+                "mode": decision.mode.value,
+            },
+        )
+
+    @staticmethod
+    def _snapshot_payload(snapshot: CostSnapshot) -> Mapping[str, object]:
+        return {
+            "usd": snapshot.usd,
+            "calls": snapshot.calls,
+            "tokens": snapshot.tokens,
+            "elapsed_ms": snapshot.elapsed_ms,
+        }

--- a/pkgs/dsl/runner.py
+++ b/pkgs/dsl/runner.py
@@ -1,0 +1,286 @@
+"""FlowRunner implementation with budget guards and policy enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, MutableMapping, Protocol, Sequence
+from uuid import uuid4
+
+from .budget import BudgetBreachError, CostSnapshot
+from .budget_manager import BudgetManager, BudgetScope
+from .policy import PolicyStack, PolicyViolationError
+from .trace import TraceEventEmitter
+
+__all__ = [
+    "FlowRunner",
+    "RunResult",
+    "ToolAdapter",
+    "ToolExecutionResult",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolExecutionResult:
+    """Result returned by a tool adapter execution."""
+
+    outputs: Mapping[str, object]
+    cost: CostSnapshot
+
+
+class ToolAdapter(Protocol):
+    """Adapter protocol used by the runner to execute nodes."""
+
+    def estimate_cost(self, node_spec: Mapping[str, object], context: Mapping[str, object]) -> CostSnapshot:  # noqa: D401
+        """Return a conservative cost estimate for preflight checks."""
+
+    def execute(self, node_spec: Mapping[str, object], context: Mapping[str, object]) -> ToolExecutionResult:  # noqa: D401
+        """Execute the tool and return structured outputs plus actual cost."""
+
+
+@dataclass(frozen=True, slots=True)
+class RunResult:
+    """Structured result returned by :class:`FlowRunner.run`."""
+
+    run_id: str
+    status: str
+    outputs: Mapping[str, Mapping[str, object]]
+    stop_reasons: tuple[str, ...]
+
+
+class FlowRunner:
+    """Execute a simple flow spec with budget and policy guards."""
+
+    def __init__(
+        self,
+        *,
+        adapters: Mapping[str, ToolAdapter],
+        trace: TraceEventEmitter | None = None,
+    ) -> None:
+        self._adapters: Dict[str, ToolAdapter] = dict(adapters)
+        self._trace = trace or TraceEventEmitter()
+        self._budget_manager: BudgetManager | None = None
+        self._policy_stack: PolicyStack | None = None
+        self._node_map: Mapping[str, Mapping[str, object]] = {}
+        self._sequence: Sequence[str] = ()
+        self._vars: Mapping[str, object] = {}
+        self._outputs: MutableMapping[str, Mapping[str, object]] = {}
+        self._stop_reasons: list[str] = []
+        self._status: str = "ok"
+        self._current_node: str | None = None
+        self._run_id: str = uuid4().hex
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self, *, spec: Mapping[str, object], vars: Mapping[str, object]) -> RunResult:
+        self._reset_state(vars)
+        globals_cfg = spec.get("globals", {})
+        tools = globals_cfg.get("tools", {})
+        tool_sets = globals_cfg.get("tool_sets", {})
+        self._policy_stack = PolicyStack(tools=tools, tool_sets=tool_sets)
+        run_budget = globals_cfg.get("run_budget")
+        self._budget_manager = BudgetManager(run_spec=run_budget, trace=self._trace)
+
+        graph = spec.get("graph", {})
+        self._sequence = tuple(graph.get("sequence", []))
+        nodes_mapping = graph.get("nodes", {})
+        self._node_map = {
+            node_id: node_spec for node_id, node_spec in nodes_mapping.items()
+        }
+
+        try:
+            self._execute_sequence()
+        except BudgetBreachError as exc:
+            self._handle_budget_breach(exc)
+        except PolicyViolationError as exc:
+            self._handle_policy_violation(exc)
+
+        return RunResult(
+            run_id=self._run_id,
+            status=self._status,
+            outputs={node_id: dict(payload) for node_id, payload in self._outputs.items()},
+            stop_reasons=tuple(self._stop_reasons),
+        )
+
+    @property
+    def trace(self) -> TraceEventEmitter:
+        return self._trace
+
+    # ------------------------------------------------------------------
+    # Internal execution helpers
+    # ------------------------------------------------------------------
+    def _reset_state(self, vars: Mapping[str, object]) -> None:
+        self._vars = dict(vars)
+        self._outputs = {}
+        self._stop_reasons = []
+        self._status = "ok"
+        self._current_node = None
+        self._run_id = uuid4().hex
+
+    def _execute_sequence(self) -> None:
+        for node_id in self._sequence:
+            if self._status != "ok":
+                break
+            node = self._node_map.get(node_id)
+            if node is None:
+                raise KeyError(f"unknown node id {node_id!r}")
+            self._current_node = node_id
+            kind = node.get("kind")
+            if kind == "unit":
+                self._execute_unit(node_id, node)
+            elif kind == "loop":
+                self._execute_loop(node_id, node)
+            else:
+                # Transform/decision nodes are out of scope for this phase.
+                continue
+
+    def _execute_unit(self, node_id: str, node: Mapping[str, object]) -> None:
+        assert self._budget_manager is not None
+        assert self._policy_stack is not None
+
+        spec = node.get("spec")
+        if not isinstance(spec, Mapping):
+            raise ValueError(f"node {node_id!r} missing spec")
+        tool_ref = spec.get("tool_ref")
+        if not isinstance(tool_ref, str):
+            raise ValueError(f"node {node_id!r} missing tool_ref")
+
+        policy_cfg = node.get("policy")
+        if policy_cfg:
+            self._policy_stack.push(policy_cfg, scope=f"node:{node_id}", source=node_id)
+        try:
+            self._policy_stack.enforce(tool_ref)
+            adapter = self._resolve_adapter(tool_ref)
+            context = {
+                "vars": self._vars,
+                "outputs": self._outputs,
+                "node_id": node_id,
+            }
+            estimate = adapter.estimate_cost(spec, context)
+            scopes = self._collect_scopes(node_id, node)
+            self._preflight_cost(scopes, estimate)
+            result = adapter.execute(spec, context)
+            self._outputs[node_id] = dict(result.outputs)
+            decisions = self._commit_cost(scopes, result.cost)
+            if any(decision.should_stop for decision in decisions):
+                self._status = "halted"
+        finally:
+            if policy_cfg:
+                self._policy_stack.pop(expected_scope=f"node:{node_id}")
+
+    def _execute_loop(self, node_id: str, loop_node: Mapping[str, object]) -> None:
+        assert self._budget_manager is not None
+        policy_cfg = loop_node.get("policy")
+        if self._policy_stack is None:
+            raise RuntimeError("policy stack not initialised")
+        if policy_cfg:
+            self._policy_stack.push(policy_cfg, scope=f"loop:{node_id}", source=node_id)
+
+        stop_cfg = loop_node.get("stop", {})
+        loop_budget = stop_cfg.get("budget")
+        loop_scope = self._budget_manager.push_loop(node_id, loop_budget)
+        max_iterations = stop_cfg.get("max_iterations")
+        target_ids = list(loop_node.get("target_subgraph", []))
+
+        iteration = 0
+        try:
+            while self._status == "ok":
+                if max_iterations is not None and iteration >= int(max_iterations):
+                    self._status = "halted"
+                    self._stop_reasons.append(f"loop:{node_id}:max_iterations")
+                    break
+                for target_id in target_ids:
+                    self._current_node = target_id
+                    inner = self._node_map.get(target_id)
+                    if inner is None:
+                        raise KeyError(f"unknown loop target {target_id!r}")
+                    kind = inner.get("kind")
+                    if kind == "unit":
+                        self._execute_unit(target_id, inner)
+                    elif kind == "loop":
+                        self._execute_loop(target_id, inner)
+                    if self._status != "ok":
+                        break
+                iteration += 1
+                if self._status != "ok":
+                    break
+            if any(reason.startswith(f"loop:{node_id}:budget_stop") for reason in self._stop_reasons):
+                self._status = "halted"
+        finally:
+            self._budget_manager.pop_loop(node_id)
+            if policy_cfg:
+                self._policy_stack.pop(expected_scope=f"loop:{node_id}")
+
+    # ------------------------------------------------------------------
+    # Budget helpers
+    # ------------------------------------------------------------------
+    def _collect_scopes(self, node_id: str, node: Mapping[str, object]) -> list[BudgetScope]:
+        assert self._budget_manager is not None
+        scopes: list[BudgetScope] = []
+        run_scope = BudgetScope("run", "run")
+        if self._budget_manager.has_scope(run_scope):
+            scopes.append(run_scope)
+        scopes.extend(self._budget_manager.loop_stack)
+
+        hard_budget = node.get("budget")
+        if hard_budget:
+            scope = BudgetScope("node", node_id)
+            if not self._budget_manager.has_scope(scope):
+                self._budget_manager.configure_scope(scope, hard_budget)
+            scopes.append(scope)
+
+        spec = node.get("spec")
+        soft_budget = spec.get("budget") if isinstance(spec, Mapping) else None
+        if soft_budget:
+            scope = BudgetScope("node_soft", node_id)
+            if not self._budget_manager.has_scope(scope):
+                self._budget_manager.configure_scope(scope, soft_budget)
+            scopes.append(scope)
+        return scopes
+
+    def _preflight_cost(self, scopes: Sequence[BudgetScope], cost: CostSnapshot) -> None:
+        for scope in scopes:
+            self._budget_manager.preflight(scope, cost)
+
+    def _commit_cost(self, scopes: Sequence[BudgetScope], cost: CostSnapshot) -> list:
+        decisions = []
+        for scope in scopes:
+            decision = self._budget_manager.commit(scope, cost)
+            decisions.append(decision)
+            if decision.should_stop:
+                reason = f"{scope.scope_type}:{scope.scope_id}:budget_stop"
+                if reason not in self._stop_reasons:
+                    self._stop_reasons.append(reason)
+        return decisions
+
+    # ------------------------------------------------------------------
+    # Error handling
+    # ------------------------------------------------------------------
+    def _handle_budget_breach(self, exc: BudgetBreachError) -> None:
+        decision = exc.decision
+        if decision.should_stop:
+            self._status = "halted"
+            reason = f"{decision.scope_type}:{decision.scope_id}:budget_stop"
+        else:
+            self._status = "error"
+            reason = f"{decision.scope_type}:{decision.scope_id}:budget_error"
+        if reason not in self._stop_reasons:
+            self._stop_reasons.append(reason)
+
+    def _handle_policy_violation(self, exc: PolicyViolationError) -> None:
+        self._status = "error"
+        tool = getattr(exc.denial, "tool", "unknown")
+        scope = self._current_node or "graph"
+        reason = f"policy:{scope}:{tool}"
+        if reason not in self._stop_reasons:
+            self._stop_reasons.append(reason)
+
+    def _resolve_adapter(self, tool_ref: str) -> ToolAdapter:
+        adapter = self._adapters.get(tool_ref)
+        if adapter is None:
+            self._status = "error"
+            reason = f"adapter:{self._current_node or 'node'}:missing"
+            if reason not in self._stop_reasons:
+                self._stop_reasons.append(reason)
+            raise RuntimeError(f"no adapter registered for tool {tool_ref!r}")
+        return adapter

--- a/pkgs/dsl/trace.py
+++ b/pkgs/dsl/trace.py
@@ -1,0 +1,79 @@
+"""Shared trace event utilities for DSL components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Callable, Iterable, Mapping, Sequence
+
+__all__ = ["TraceEvent", "TraceEventEmitter", "freeze_payload"]
+
+
+@dataclass(frozen=True, slots=True)
+class TraceEvent:
+    """Immutable trace event record."""
+
+    event: str
+    scope_type: str
+    scope_id: str
+    payload: Mapping[str, object]
+
+
+def freeze_payload(data: Mapping[str, object] | None) -> Mapping[str, object]:
+    """Return an immutable, recursively frozen mapping suitable for traces."""
+
+    def _freeze(value: object) -> object:
+        if isinstance(value, Mapping):
+            return MappingProxyType({k: _freeze(v) for k, v in value.items()})
+        if isinstance(value, (list, tuple)):
+            return tuple(_freeze(v) for v in value)
+        if isinstance(value, set):
+            return frozenset(_freeze(v) for v in value)
+        return value
+
+    return MappingProxyType({} if data is None else {k: _freeze(v) for k, v in data.items()})
+
+
+class TraceEventEmitter:
+    """Emit immutable trace events to in-memory buffers and optional sinks."""
+
+    def __init__(self, *, sinks: Sequence[Callable[[TraceEvent], None]] | None = None) -> None:
+        self._events: list[TraceEvent] = []
+        self._sinks: list[Callable[[TraceEvent], None]] = list(sinks or [])
+
+    def subscribe(self, sink: Callable[[TraceEvent], None]) -> None:
+        """Register an additional sink invoked for every emitted event."""
+
+        self._sinks.append(sink)
+
+    def emit(
+        self,
+        *,
+        event: str,
+        scope_type: str,
+        scope_id: str,
+        payload: Mapping[str, object] | None = None,
+    ) -> TraceEvent:
+        frozen_payload = freeze_payload(payload)
+        record = TraceEvent(
+            event=event,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            payload=frozen_payload,
+        )
+        self._events.append(record)
+        for sink in list(self._sinks):
+            sink(record)
+        return record
+
+    @property
+    def events(self) -> Sequence[TraceEvent]:
+        """Return a snapshot of emitted events."""
+
+        return tuple(self._events)
+
+    def extend(self, events: Iterable[TraceEvent]) -> None:
+        """Append pre-created events to the emitter buffer."""
+
+        for event in events:
+            self._events.append(event)


### PR DESCRIPTION
## Summary
- add immutable budget domain models and shared trace emitter utilities
- introduce a scope-aware BudgetManager and FlowRunner enforcement for unit and loop nodes
- cover hard/soft budgets and policy gating with deterministic pytest suites

## Testing
- pytest codex/code/work/tests/unit -q

------
https://chatgpt.com/codex/tasks/task_e_68e8a9d6c0cc832cad4bba842aaf9290