### PR TITLE
Implement budget manager and runner integration scaffolding

### DIFF
--- a/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.md
+++ b/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.md
@@ -1,0 +1,14 @@
+# Phase 3 Post-execution Summary — Task 07b_budget_guards_and_runner_integration
+
+## Test Results
+- `pytest codex/code/work/tests -q`
+  - Status: ✅ Passed (see chunk `fb1dad`)
+
+## Coverage & Quality Notes
+- BudgetManager tests exercised both preflight and commit paths, including soft/hard divergence and unknown scope handling.
+- FlowRunner integration tests validated stop reasons, policy events, and trace emission.
+- Additional property-based coverage for metric normalisation remains a recommended enhancement.
+
+## Follow-ups
+- Align simplified PolicyStack with production DSL policy module to ensure parity in trace schema fields.
+- Expand telemetry assertions once the runner integrates with the canonical trace schema validators.

--- a/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.md
+++ b/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.md
@@ -1,0 +1,19 @@
+# Phase 3 Preview — Task 07b_budget_guards_and_runner_integration
+
+## Overview
+- Introduced immutable budget domain objects (`BudgetSpec`, `CostSnapshot`, `BudgetBreach`, `BudgetCheck`, `BudgetChargeOutcome`).
+- Added a trace-aware `BudgetManager` that performs preflight and commit bookkeeping while emitting schema-aligned events.
+- Implemented a lightweight FlowRunner that coordinates policy enforcement, adapter execution, and budget outcomes via a shared `TraceEventEmitter`.
+
+## Key Design Decisions
+1. **Trace Normalisation** — Centralised trace emission through `TraceEventEmitter` to guarantee mapping-proxy payloads and optional sink fan-out.
+2. **Deterministic Budget Arithmetic** — Normalised all metrics to floats and stored remaining/overages in immutable mappings to avoid mutable-state leaks noted in Phase 2 reviews.
+3. **Stop Semantics** — Encoded soft vs. hard behaviour through `BudgetMode` and `breach_action`, with preflight and commit stages both capable of emitting `budget_breach` events.
+
+## Test Coverage
+- `tests/test_budget_manager.py`: Validates soft/hard semantics, trace immutability, and unknown scope handling.
+- `tests/test_flow_runner.py`: Exercises runner stop reasons, combined policy/budget tracing, and policy violation handling.
+
+## Next Checks
+- Confirm integration with broader DSL policy stack once upstream modules adopt the shared emitter.
+- Extend property-based tests for metric normalisation edge cases.

--- a/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.md
+++ b/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.md
@@ -1,0 +1,13 @@
+# Phase 3 Review Notes — Task 07b_budget_guards_and_runner_integration
+
+## Review Checklist
+- [x] Budget dataclasses enforce immutability and float normalisation.
+- [x] `BudgetManager.preflight` and `.commit` emit consistent breach payloads and stop semantics.
+- [x] FlowRunner halts on preflight stop with deterministic reason codes.
+- [x] PolicyStack emits both resolved and violation events through shared emitter.
+- [x] Unit tests cover soft vs. hard budgets and policy/budget interaction traces.
+
+## Reviewer Notes
+- Consider extending warnings to include aggregate totals for better telemetry.
+- Future integration should reconcile this simplified PolicyStack with the canonical DSL policy module.
+- Ensure downstream consumers handle the optional `phase` key on `budget_breach` events introduced for preflight contexts.

--- a/codex/DOCUMENTATION/P3/work-20250511-gpt5codex.yaml
+++ b/codex/DOCUMENTATION/P3/work-20250511-gpt5codex.yaml
@@ -1,0 +1,97 @@
+summary:
+  component: codex.code.work.runner.FlowRunner
+  purpose: Coordinated execution harness combining policy enforcement with budget metering and trace emission.
+  status: experimental
+cli:
+  usage: Not exposed via CLI; instantiate `FlowRunner` from application code with adapter, policy, and budget manager collaborators.
+interfaces:
+  - name: TraceEventEmitter.emit
+    description: Normalises payloads and forwards trace events to optional sinks.
+    parameters:
+      event: Event name string (e.g., `budget_charge`, `policy_violation`).
+      scope: Identifier for the entity emitting the event.
+      payload: Mapping serialised via `mapping_proxy` to ensure immutability.
+    returns: `TraceEvent` instance captured locally and optionally forwarded.
+  - name: BudgetManager.preflight
+    description: Calculates projected remaining budgets and determines whether execution may proceed.
+    parameters:
+      scope: Budget scope identifier (run/loop/node/etc.).
+      projected_cost: Mapping of metrics to estimated spend.
+    returns: `BudgetCheck` with remaining budgets, breaches, warnings, and stop flag.
+  - name: BudgetManager.commit
+    description: Persists cost spend, emits trace events, and returns immutable diagnostics.
+    parameters:
+      scope: Budget scope identifier.
+      actual_cost: Mapping of metrics to realised spend.
+    returns: `BudgetChargeOutcome` including spent totals, remaining limits, breaches, and stop indicator.
+  - name: FlowRunner.run
+    description: Executes each node via the adapter, enforcing policies and budgets until completion or stop.
+    parameters:
+      flow: `FlowDefinition` containing run scope and ordered node list.
+    returns: `RunResult` with executed node records, warnings, and optional stop reason.
+extension_points:
+  adapters:
+    protocol: `ToolAdapter`
+    methods:
+      - name: estimate
+        contract: Return deterministic cost estimates keyed by metric names.
+      - name: execute
+        contract: Execute node work and return (result payload, actual cost mapping).
+  policies:
+    component: `PolicyStack`
+    hooks:
+      - enforce(node)
+configuration:
+  options:
+    - name: BudgetSpec.breach_action
+      type: enum[warn|stop]
+      default: stop
+      description: Controls whether soft-mode budgets halt execution or emit warnings.
+automation:
+  triggers:
+    - on `budget_breach` events consumers may halt downstream orchestration or alert operators.
+    - trace buffers can feed structured logging pipelines as defined in Phase-2 specs.
+errors:
+  - name: PolicyViolationError
+    raised_by: `PolicyStack.enforce`
+    contract: Raised when tool is denied; trace event `policy_violation` emitted prior to exception.
+  - name: KeyError
+    raised_by: `BudgetManager.preflight/commit`
+    contract: Unknown scope requested; caller must register scope beforehand.
+serialization:
+  events:
+    - name: budget_charge
+      payload:
+        charged: Mapping[str, float]
+        spent: Mapping[str, float]
+        remaining: Mapping[str, float]
+        overages: Mapping[str, float]
+        warnings: tuple[str, ...]
+    - name: budget_breach
+      payload:
+        breaches: list[metric, limit, observed/ projected, overage]
+        stop: bool (commit phase)
+        phase: preflight|commit (optional)
+    - name: policy_resolved
+      payload:
+        tool: str
+        status: allowed
+    - name: policy_violation
+      payload:
+        tool: str
+lifecycle:
+  phases:
+    - configure BudgetSpecs and TraceEventEmitter
+    - instantiate BudgetManager, PolicyStack, FlowRunner with shared emitter
+    - execute FlowRunner.run; inspect RunResult and trace buffer
+    - drain trace emitter to logging sinks or tests
+typing:
+  strict: Uses dataclasses with type annotations; mypy-compatible when repository config enables checking of codex modules.
+security:
+  trust_boundary: FlowRunner does not execute untrusted code; adapter implementations must guard against unsafe inputs.
+  considerations:
+    - Trace payloads avoid embedding secrets; adapters should scrub sensitive data before returning results.
+performance:
+  notes:
+    - Budget arithmetic is O(metrics) per node; metrics sets are expected to remain small (tokens/time counts).
+    - Trace emission involves mapping_proxy copies to guarantee immutability; overhead acceptable for DSL control-plane workloads.

--- a/codex/TESTS/P3/work-20250511-gpt5codex.yaml
+++ b/codex/TESTS/P3/work-20250511-gpt5codex.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_budget_manager_multiple_metrics
+      rationale: Validate simultaneous breaches across heterogeneous metrics and ensure warnings aggregate correctly.
+      source_module: codex/code/work/budget.py
+      priority: medium
+    - name: test_flow_runner_commit_stop_reason
+      rationale: Cover scenarios where commit-stage stop is triggered after execution to assert stop_reason == "budget_commit" and confirm node_end traces still emit.
+      source_module: codex/code/work/runner.py
+      priority: high
+    - name: property_budget_normalisation_invariants
+      rationale: Use property-based testing to ensure `_normalize_cost` handles decimal inputs and ignores unsupported metrics deterministically.
+      source_module: codex/code/work/budget.py
+      priority: medium

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.yaml
@@ -1,0 +1,77 @@
+summary: Integrate immutable budget domain models with a trace-aware FlowRunner harness while preserving adapter and policy wiring.
+justification: |
+  Phase-2 reviews identified the need to combine the stable adapter-driven FlowRunner with
+  immutable budget models, a cohesive BudgetManager, and trace emission shared between
+  policy and budget layers. The chosen approach keeps the baseline runner execution but
+  layers an object-oriented budget subsystem that normalises costs and honours soft vs
+  hard breach semantics. Trace events are funnelled through a reusable emitter to avoid
+  the mutable payload regressions flagged across prior branches.
+steps:
+  - id: domain_models
+    description: Establish immutable budget dataclasses and helpers for cost normalisation.
+    rationale: Aligns with zwi2ny and pbdel9 strengths while removing mutable charge state.
+  - id: manager_orchestration
+    description: Implement BudgetManager preflight/commit lifecycle with trace emission hooks.
+    rationale: Synthesises orchestration concepts from test-first branches and ensures
+      breach_action semantics are enforced consistently.
+  - id: runner_integration
+    description: Retrofit FlowRunner to invoke adapters, enforce policies, and coordinate
+      BudgetManager outcomes while emitting schema-aligned events.
+    rationale: Restores the baseline end-to-end loop highlighted in reviews and adds
+      coverage for combined policy+budget behaviour.
+modules:
+  - path: codex/code/work/budget.py
+    role: Budget data models, cost helpers, and BudgetManager orchestration.
+  - path: codex/code/work/trace.py
+    role: Shared TraceEvent/TraceEventEmitter abstractions for policy and budget events.
+  - path: codex/code/work/runner.py
+    role: FlowRunner facade coordinating adapters, policies, and budgets with trace outputs.
+tests:
+  - path: codex/code/work/tests/test_budget_manager.py
+    coverage_targets:
+      - BudgetManager preflight/commit soft and hard semantics
+      - Trace emission of budget_charge/budget_breach events
+    fixtures: deterministic trace recorder, fake scope specs
+  - path: codex/code/work/tests/test_flow_runner.py
+    coverage_targets:
+      - FlowRunner stop reasoning on budget breaches
+      - Policy trace emission alongside budget traces
+      - Node execution record integrity
+run_order:
+  - Write budget manager unit tests (fail expected)
+  - Write flow runner integration tests (fail expected)
+  - Implement trace emitter, budget module, then runner to satisfy tests
+  - Execute pytest for targeted suite
+interfaces:
+  - name: TraceEventEmitter.emit
+    contract: Accepts event metadata and produces immutable payload snapshots routed to optional sinks.
+  - name: BudgetManager.preflight
+    contract: Returns BudgetCheck including stop/warn semantics without mutating internal state.
+  - name: BudgetManager.commit
+    contract: Persists spend, emits traces, and returns BudgetChargeOutcome with immutable diagnostics.
+  - name: FlowRunner.run
+    contract: Executes nodes via adapter/policy checks, halting when BudgetManager instructs a stop.
+tdd_coverage_targets:
+  codex/code/work/budget.py: 0.9
+  codex/code/work/runner.py: 0.85
+  codex/code/work/trace.py: 0.8
+review_checklist:
+  - Validate cost normalisation handles unknown metrics deterministically.
+  - Ensure trace payloads use mapping_proxy to prevent mutation.
+  - Confirm FlowRunner stop reasons map to manager outcomes without exceptions.
+  - Check warnings vs hard-stop semantics align with BudgetMode and breach_action.
+outputs:
+  plan: codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.yaml
+  tests:
+    - codex/code/work/tests/test_budget_manager.py
+    - codex/code/work/tests/test_flow_runner.py
+  modules:
+    - codex/code/work/budget.py
+    - codex/code/work/trace.py
+    - codex/code/work/runner.py
+  documentation:
+    - PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.md
+    - REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.md
+    - POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250511-gpt5codex.md
+    - codex/DOCUMENTATION/P3/work-20250511-gpt5codex.yaml
+  missing_tests: codex/TESTS/P3/work-20250511-gpt5codex.yaml

--- a/codex/code/work/budget.py
+++ b/codex/code/work/budget.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+
+from pkgs.dsl.models import mapping_proxy
+
+from .trace import TraceEventEmitter
+
+
+class BudgetMode(Enum):
+    """Operational mode for a budget scope."""
+
+    HARD = "hard"
+    SOFT = "soft"
+
+
+@dataclass(frozen=True, slots=True)
+class CostSnapshot:
+    """Immutable snapshot describing spend per metric."""
+
+    metrics: Mapping[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        normalized = {str(metric): float(amount) for metric, amount in self.metrics.items()}
+        object.__setattr__(self, "metrics", mapping_proxy(normalized))
+
+    def get(self, metric: str, default: float = 0.0) -> float:
+        return float(self.metrics.get(metric, default))
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetSpec:
+    """Configuration describing the limits for a scope."""
+
+    scope: str
+    limits: Mapping[str, float]
+    mode: BudgetMode = BudgetMode.HARD
+    breach_action: str = "stop"
+
+    def __post_init__(self) -> None:
+        normalized_limits = {str(metric): float(value) for metric, value in self.limits.items()}
+        object.__setattr__(self, "limits", mapping_proxy(normalized_limits))
+        if self.breach_action not in {"warn", "stop"}:
+            raise ValueError("breach_action must be 'warn' or 'stop'")
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetBreach:
+    """Details about a specific metric exceeding its limit."""
+
+    metric: str
+    limit: float
+    observed: float
+    overage: float
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetCheck:
+    """Result of calling :meth:`BudgetManager.preflight`."""
+
+    scope: str
+    projected: CostSnapshot
+    remaining: Mapping[str, float]
+    breaches: tuple[BudgetBreach, ...]
+    stop_requested: bool
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetChargeOutcome:
+    """Snapshot returned by :meth:`BudgetManager.commit`."""
+
+    scope: str
+    charged: CostSnapshot
+    spent: CostSnapshot
+    remaining: Mapping[str, float]
+    overages: Mapping[str, float]
+    breaches: tuple[BudgetBreach, ...]
+    warnings: tuple[str, ...]
+    stop: bool
+
+
+class BudgetManager:
+    """Co-ordinates budgets across run/loop/node scopes."""
+
+    def __init__(
+        self,
+        specs: Mapping[str, BudgetSpec],
+        *,
+        trace_emitter: TraceEventEmitter | None = None,
+    ) -> None:
+        self._specs = {scope: spec for scope, spec in specs.items()}
+        self._spent: dict[str, dict[str, float]] = {
+            scope: {metric: 0.0 for metric in spec.limits}
+            for scope, spec in self._specs.items()
+        }
+        self._emitter = trace_emitter
+
+    def preflight(self, scope: str, projected_cost: Mapping[str, float]) -> BudgetCheck:
+        spec, spent = self._resolve_scope(scope)
+        normalized_cost = self._normalize_cost(projected_cost)
+        projected_snapshot = CostSnapshot(normalized_cost)
+
+        remaining: dict[str, float] = {}
+        breaches: list[BudgetBreach] = []
+        warnings: list[str] = []
+
+        for metric, limit in spec.limits.items():
+            projected_total = spent.get(metric, 0.0) + normalized_cost.get(metric, 0.0)
+            remaining_value = max(0.0, limit - projected_total)
+            remaining[metric] = remaining_value
+            if projected_total > limit:
+                overage = projected_total - limit
+                breaches.append(
+                    BudgetBreach(
+                        metric=metric,
+                        limit=limit,
+                        observed=projected_total,
+                        overage=overage,
+                    )
+                )
+                if not self._should_stop(spec):
+                    warnings.append(
+                        f"{scope}:{metric} projected over by {overage:.2f}"
+                    )
+
+        stop_requested = self._should_stop(spec) and bool(breaches)
+        check = BudgetCheck(
+            scope=scope,
+            projected=projected_snapshot,
+            remaining=mapping_proxy(remaining),
+            breaches=tuple(breaches),
+            stop_requested=stop_requested,
+            warnings=tuple(warnings),
+        )
+        self._emit_preflight(spec, check)
+        return check
+
+    def commit(self, scope: str, actual_cost: Mapping[str, float]) -> BudgetChargeOutcome:
+        spec, spent = self._resolve_scope(scope)
+        normalized_cost = self._normalize_cost(actual_cost)
+
+        for metric, value in normalized_cost.items():
+            spent[metric] = spent.get(metric, 0.0) + value
+
+        charged_snapshot = CostSnapshot(normalized_cost)
+        spent_snapshot = CostSnapshot(spent)
+
+        remaining: dict[str, float] = {}
+        overages: dict[str, float] = {}
+        breaches: list[BudgetBreach] = []
+
+        for metric, limit in spec.limits.items():
+            observed = spent.get(metric, 0.0)
+            remaining_value = max(0.0, limit - observed)
+            remaining[metric] = remaining_value
+            if observed > limit:
+                overage = observed - limit
+                overages[metric] = overage
+                breaches.append(
+                    BudgetBreach(
+                        metric=metric,
+                        limit=limit,
+                        observed=observed,
+                        overage=overage,
+                    )
+                )
+            else:
+                overages[metric] = 0.0
+
+        stop = self._should_stop(spec) and bool(breaches)
+        warnings = self._build_warnings(scope, spec, breaches, stop)
+
+        outcome = BudgetChargeOutcome(
+            scope=scope,
+            charged=charged_snapshot,
+            spent=spent_snapshot,
+            remaining=mapping_proxy(remaining),
+            overages=mapping_proxy(overages),
+            breaches=tuple(breaches),
+            warnings=tuple(warnings),
+            stop=stop,
+        )
+        self._emit_events(spec, outcome)
+        return outcome
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _resolve_scope(self, scope: str) -> tuple[BudgetSpec, dict[str, float]]:
+        if scope not in self._specs:
+            raise KeyError(f"Unknown budget scope: {scope}")
+        return self._specs[scope], self._spent[scope]
+
+    @staticmethod
+    def _normalize_cost(cost: Mapping[str, float]) -> dict[str, float]:
+        return {str(metric): float(value) for metric, value in cost.items()}
+
+    @staticmethod
+    def _should_stop(spec: BudgetSpec) -> bool:
+        if spec.mode is BudgetMode.HARD:
+            return True
+        return spec.breach_action == "stop"
+
+    def _build_warnings(
+        self,
+        scope: str,
+        spec: BudgetSpec,
+        breaches: list[BudgetBreach],
+        stop: bool,
+    ) -> list[str]:
+        if stop or not breaches:
+            return []
+        return [f"{scope}:{breach.metric} exceeded by {breach.overage:.2f}" for breach in breaches]
+
+    def _emit_events(self, spec: BudgetSpec, outcome: BudgetChargeOutcome) -> None:
+        if self._emitter is None:
+            return
+
+        payload = {
+            "charged": outcome.charged.metrics,
+            "spent": outcome.spent.metrics,
+            "remaining": outcome.remaining,
+            "overages": outcome.overages,
+            "warnings": outcome.warnings,
+        }
+        breach_kind = "hard" if outcome.stop else "soft"
+        self._emitter.emit(
+            event="budget_charge",
+            scope=spec.scope,
+            scope_type="budget",
+            payload=payload,
+            breach_kind=breach_kind,
+        )
+        if outcome.breaches:
+            breach_payload = {
+                "breaches": [
+                    {
+                        "metric": breach.metric,
+                        "observed": breach.observed,
+                        "limit": breach.limit,
+                        "overage": breach.overage,
+                    }
+                    for breach in outcome.breaches
+                ],
+                "stop": outcome.stop,
+            }
+            self._emitter.emit(
+                event="budget_breach",
+                scope=spec.scope,
+                scope_type="budget",
+                payload=breach_payload,
+                breach_kind=breach_kind,
+            )
+
+    def _emit_preflight(self, spec: BudgetSpec, check: BudgetCheck) -> None:
+        if self._emitter is None or not check.breaches:
+            return
+        payload = {
+            "breaches": [
+                {
+                    "metric": breach.metric,
+                    "limit": breach.limit,
+                    "projected": breach.observed,
+                    "overage": breach.overage,
+                }
+                for breach in check.breaches
+            ],
+            "warnings": check.warnings,
+            "phase": "preflight",
+        }
+        breach_kind = "hard" if check.stop_requested else "soft"
+        self._emitter.emit(
+            event="budget_breach",
+            scope=spec.scope,
+            scope_type="budget",
+            payload=payload,
+            breach_kind=breach_kind,
+        )

--- a/codex/code/work/runner.py
+++ b/codex/code/work/runner.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from .budget import BudgetChargeOutcome, BudgetManager, BudgetMode, BudgetSpec
+from .trace import TraceEventEmitter
+
+
+class PolicyViolationError(RuntimeError):
+    """Raised when a tool fails policy enforcement."""
+
+    def __init__(self, tool: str) -> None:
+        super().__init__(f"Tool '{tool}' blocked by policy")
+        self.tool = tool
+
+
+@dataclass(frozen=True, slots=True)
+class NodeDefinition:
+    """Declarative description for a flow node."""
+
+    id: str
+    tool: str
+    scope: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FlowDefinition:
+    """Minimal flow abstraction for the runner."""
+
+    run_scope: str
+    nodes: Sequence[NodeDefinition]
+
+
+@dataclass(frozen=True, slots=True)
+class NodeExecution:
+    """Captured execution metadata for a node."""
+
+    node_id: str
+    result: Mapping[str, object]
+    cost: Mapping[str, float]
+
+
+@dataclass(frozen=True, slots=True)
+class RunResult:
+    """Aggregate execution outcome for a flow run."""
+
+    executions: tuple[NodeExecution, ...]
+    warnings: tuple[str, ...]
+    stop_reason: str | None
+
+
+class ToolAdapter(Protocol):
+    """Protocol describing adapters consumed by :class:`FlowRunner`."""
+
+    def estimate(self, node: NodeDefinition) -> Mapping[str, float]:
+        ...
+
+    def execute(self, node: NodeDefinition) -> tuple[Mapping[str, object], Mapping[str, float]]:
+        ...
+
+
+class PolicyStack:
+    """Simplified policy stack honouring allow/deny semantics."""
+
+    def __init__(
+        self,
+        *,
+        allow_tools: Sequence[str] | None = None,
+        deny_tools: Sequence[str] | None = None,
+        trace_emitter: TraceEventEmitter | None = None,
+    ) -> None:
+        self._allow = frozenset(allow_tools or [])
+        self._deny = frozenset(deny_tools or [])
+        self._emitter = trace_emitter
+
+    def enforce(self, node: NodeDefinition) -> None:
+        if node.tool in self._deny or (self._allow and node.tool not in self._allow):
+            self._emit(
+                event="policy_violation",
+                node=node,
+                payload={"tool": node.tool},
+            )
+            raise PolicyViolationError(node.tool)
+        self._emit(
+            event="policy_resolved",
+            node=node,
+            payload={"tool": node.tool, "status": "allowed"},
+        )
+
+    def _emit(self, *, event: str, node: NodeDefinition, payload: Mapping[str, object]) -> None:
+        if self._emitter is None:
+            return
+        self._emitter.emit(
+            event=event,
+            scope=node.id,
+            scope_type="policy",
+            payload=payload,
+        )
+
+
+class FlowRunner:
+    """Coordinates adapter execution, policy enforcement, and budget metering."""
+
+    def __init__(
+        self,
+        *,
+        adapter: ToolAdapter,
+        budget_manager: BudgetManager,
+        policy_stack: PolicyStack,
+        trace_emitter: TraceEventEmitter | None = None,
+    ) -> None:
+        self._adapter = adapter
+        self._budget_manager = budget_manager
+        self._policy_stack = policy_stack
+        self._emitter = trace_emitter
+
+    def run(self, flow: FlowDefinition) -> RunResult:
+        executions: list[NodeExecution] = []
+        warnings: list[str] = []
+        stop_reason: str | None = None
+
+        for node in flow.nodes:
+            self._policy_stack.enforce(node)
+            scope = node.scope or flow.run_scope
+
+            estimate = self._adapter.estimate(node)
+            preflight = self._budget_manager.preflight(scope, estimate)
+            warnings.extend(preflight.warnings)
+            if preflight.stop_requested:
+                stop_reason = "budget_preflight"
+                break
+
+            self._emit(event="node_start", node=node, payload={"estimate": estimate})
+            result, cost = self._adapter.execute(node)
+            outcome = self._budget_manager.commit(scope, cost)
+            executions.append(
+                NodeExecution(
+                    node_id=node.id,
+                    result=result,
+                    cost=outcome.charged.metrics,
+                )
+            )
+            warnings.extend(outcome.warnings)
+            self._emit(event="node_end", node=node, payload={"result": result})
+
+            if outcome.stop:
+                stop_reason = "budget_commit"
+                break
+
+        return RunResult(
+            executions=tuple(executions),
+            warnings=tuple(warnings),
+            stop_reason=stop_reason,
+        )
+
+    def _emit(self, *, event: str, node: NodeDefinition, payload: Mapping[str, object]) -> None:
+        if self._emitter is None:
+            return
+        self._emitter.emit(
+            event=event,
+            scope=node.id,
+            scope_type="runner",
+            payload=payload,
+        )
+
+
+__all__ = [
+    "BudgetChargeOutcome",
+    "BudgetManager",
+    "BudgetMode",
+    "BudgetSpec",
+    "FlowDefinition",
+    "FlowRunner",
+    "NodeDefinition",
+    "NodeExecution",
+    "PolicyStack",
+    "PolicyViolationError",
+    "RunResult",
+    "ToolAdapter",
+]

--- a/codex/code/work/tests/test_budget_manager.py
+++ b/codex/code/work/tests/test_budget_manager.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from codex.code.work.budget import (  # noqa: E402
+    BudgetManager,
+    BudgetMode,
+    BudgetSpec,
+)
+from codex.code.work.trace import TraceEventEmitter  # noqa: E402
+
+
+@pytest.fixture()
+def trace_emitter() -> TraceEventEmitter:
+    return TraceEventEmitter()
+
+
+def _build_manager(*, mode: BudgetMode, breach_action: str, emitter: TraceEventEmitter) -> BudgetManager:
+    spec = BudgetSpec(
+        scope="run",
+        limits={"tokens": 10, "milliseconds": 1000},
+        mode=mode,
+        breach_action=breach_action,
+    )
+    return BudgetManager({"run": spec}, trace_emitter=emitter)
+
+
+def test_soft_budget_warns_but_allows_execution(trace_emitter: TraceEventEmitter) -> None:
+    manager = _build_manager(mode=BudgetMode.SOFT, breach_action="warn", emitter=trace_emitter)
+
+    check_ok = manager.preflight("run", {"tokens": 6})
+    assert check_ok.stop_requested is False
+    assert not check_ok.breaches
+
+    outcome_ok = manager.commit("run", {"tokens": 6})
+    assert outcome_ok.stop is False
+    assert outcome_ok.remaining["tokens"] == 4
+    assert not outcome_ok.warnings
+
+    check_warn = manager.preflight("run", {"tokens": 5})
+    assert check_warn.stop_requested is False
+    assert check_warn.breaches
+
+    outcome_warn = manager.commit("run", {"tokens": 5})
+    assert outcome_warn.stop is False
+    assert outcome_warn.overages["tokens"] == 1
+    assert outcome_warn.warnings
+
+    breach_events = [event for event in trace_emitter.events if event.event == "budget_breach"]
+    assert breach_events, "expected a budget_breach trace event to be emitted"
+    payload = breach_events[0].payload
+    with pytest.raises(TypeError):
+        payload["tokens"] = 0  # mapping_proxy enforces immutability
+
+
+def test_hard_budget_requests_stop(trace_emitter: TraceEventEmitter) -> None:
+    manager = _build_manager(mode=BudgetMode.HARD, breach_action="stop", emitter=trace_emitter)
+
+    check_stop = manager.preflight("run", {"tokens": 11, "milliseconds": 800})
+    assert check_stop.stop_requested is True
+    assert any(b.metric == "tokens" for b in check_stop.breaches)
+
+    outcome_stop = manager.commit("run", {"tokens": 11, "milliseconds": 800})
+    assert outcome_stop.stop is True
+    assert outcome_stop.overages["tokens"] == 1
+    assert any(event.event == "budget_breach" for event in trace_emitter.events)
+
+
+def test_unknown_scope_is_rejected(trace_emitter: TraceEventEmitter) -> None:
+    manager = _build_manager(mode=BudgetMode.SOFT, breach_action="warn", emitter=trace_emitter)
+    with pytest.raises(KeyError):
+        manager.preflight("loop-1", {"tokens": 1})

--- a/codex/code/work/tests/test_flow_runner.py
+++ b/codex/code/work/tests/test_flow_runner.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from codex.code.work.budget import BudgetManager, BudgetMode, BudgetSpec  # noqa: E402
+from codex.code.work.runner import (  # noqa: E402
+    FlowDefinition,
+    FlowRunner,
+    NodeDefinition,
+    PolicyStack,
+    PolicyViolationError,
+)
+from codex.code.work.trace import TraceEventEmitter  # noqa: E402
+
+
+class DummyAdapter:
+    def __init__(self, estimates: dict[str, dict[str, float]], actuals: dict[str, dict[str, float]]) -> None:
+        self._estimates = estimates
+        self._actuals = actuals
+        self.calls: list[str] = []
+
+    def estimate(self, node: NodeDefinition) -> dict[str, float]:
+        return dict(self._estimates[node.id])
+
+    def execute(self, node: NodeDefinition) -> tuple[dict[str, str], dict[str, float]]:
+        self.calls.append(node.id)
+        return {"node": node.id}, dict(self._actuals[node.id])
+
+
+@pytest.fixture()
+def runner_components() -> tuple[BudgetManager, PolicyStack, TraceEventEmitter]:
+    emitter = TraceEventEmitter()
+    spec = BudgetSpec(
+        scope="run",
+        limits={"tokens": 10},
+        mode=BudgetMode.HARD,
+        breach_action="stop",
+    )
+    manager = BudgetManager({"run": spec}, trace_emitter=emitter)
+    policy_stack = PolicyStack(allow_tools={"alpha", "beta"}, trace_emitter=emitter)
+    return manager, policy_stack, emitter
+
+
+def test_flow_runner_stops_on_budget_breach(runner_components: tuple[BudgetManager, PolicyStack, TraceEventEmitter]) -> None:
+    manager, policy_stack, emitter = runner_components
+    adapter = DummyAdapter(
+        estimates={
+            "n1": {"tokens": 4},
+            "n2": {"tokens": 7},
+        },
+        actuals={
+            "n1": {"tokens": 4},
+            "n2": {"tokens": 7},
+        },
+    )
+    flow = FlowDefinition(run_scope="run", nodes=[NodeDefinition(id="n1", tool="alpha"), NodeDefinition(id="n2", tool="alpha")])
+    runner = FlowRunner(adapter=adapter, budget_manager=manager, policy_stack=policy_stack, trace_emitter=emitter)
+
+    result = runner.run(flow)
+
+    assert [execution.node_id for execution in result.executions] == ["n1"]
+    assert result.stop_reason == "budget_preflight"
+    assert any(event.event == "budget_breach" for event in emitter.events)
+
+
+def test_flow_runner_emits_policy_events(runner_components: tuple[BudgetManager, PolicyStack, TraceEventEmitter]) -> None:
+    manager, policy_stack, emitter = runner_components
+    adapter = DummyAdapter(
+        estimates={"n1": {"tokens": 2}},
+        actuals={"n1": {"tokens": 2}},
+    )
+    flow = FlowDefinition(run_scope="run", nodes=[NodeDefinition(id="n1", tool="alpha")])
+    runner = FlowRunner(adapter=adapter, budget_manager=manager, policy_stack=policy_stack, trace_emitter=emitter)
+
+    result = runner.run(flow)
+
+    assert result.stop_reason is None
+    policy_events = [event for event in emitter.events if event.event.startswith("policy_")]
+    assert {event.event for event in policy_events} >= {"policy_resolved"}
+
+    charge_events = [event for event in emitter.events if event.event == "budget_charge"]
+    assert charge_events, "expected budget_charge trace events"
+
+
+def test_flow_runner_raises_on_policy_violation(runner_components: tuple[BudgetManager, PolicyStack, TraceEventEmitter]) -> None:
+    manager, policy_stack, emitter = runner_components
+    adapter = DummyAdapter(
+        estimates={"n1": {"tokens": 2}},
+        actuals={"n1": {"tokens": 2}},
+    )
+    violating_flow = FlowDefinition(run_scope="run", nodes=[NodeDefinition(id="n1", tool="gamma")])
+    runner = FlowRunner(adapter=adapter, budget_manager=manager, policy_stack=policy_stack, trace_emitter=emitter)
+
+    with pytest.raises(PolicyViolationError):
+        runner.run(violating_flow)
+
+    violation_events = [event for event in emitter.events if event.event == "policy_violation"]
+    assert violation_events, "policy violation should be traced"

--- a/codex/code/work/trace.py
+++ b/codex/code/work/trace.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+
+from pkgs.dsl.models import mapping_proxy
+
+
+@dataclass(frozen=True, slots=True)
+class TraceEvent:
+    """Immutable trace payload routed through :class:`TraceEventEmitter`."""
+
+    event: str
+    scope: str
+    scope_type: str
+    payload: Mapping[str, object]
+    breach_kind: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=mapping_proxy)
+
+
+class TraceWriter:
+    """Optional sink that can consume emitted trace events."""
+
+    def __init__(self, sink: Callable[[TraceEvent], None] | None = None) -> None:
+        self._sink = sink
+        self._events: list[TraceEvent] = []
+
+    def emit(self, event: TraceEvent) -> None:
+        self._events.append(event)
+        if self._sink is not None:
+            self._sink(event)
+
+    @property
+    def events(self) -> Sequence[TraceEvent]:
+        return tuple(self._events)
+
+
+class TraceEventEmitter:
+    """Factory that normalises trace payloads before forwarding them."""
+
+    def __init__(self, writer: TraceWriter | None = None) -> None:
+        self._writer = writer
+        self._buffer: list[TraceEvent] = []
+
+    def emit(
+        self,
+        *,
+        event: str,
+        scope: str,
+        payload: Mapping[str, object] | None = None,
+        scope_type: str = "runtime",
+        breach_kind: str | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ) -> TraceEvent:
+        frozen_payload = mapping_proxy(payload or {})
+        frozen_metadata = mapping_proxy(metadata or {})
+        trace_event = TraceEvent(
+            event=event,
+            scope=scope,
+            scope_type=scope_type,
+            payload=frozen_payload,
+            breach_kind=breach_kind,
+            metadata=frozen_metadata,
+        )
+        self._buffer.append(trace_event)
+        if self._writer is not None:
+            self._writer.emit(trace_event)
+        return trace_event
+
+    @property
+    def events(self) -> Sequence[TraceEvent]:
+        return tuple(self._buffer)


### PR DESCRIPTION
## Summary
- add immutable budget domain models with preflight/commit orchestration and shared trace emission
- implement a trace-aware FlowRunner coordinating policies, adapters, and budgets
- create focused unit tests plus phase documentation and metadata for phase 3 delivery

## Testing
- pytest codex/code/work/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8a9dc8530832c914a518a356b62ed