### PR TITLE
Add budget-aware FlowRunner prototype with scope manager

### DIFF
--- a/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+++ b/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
@@ -1,0 +1,16 @@
+# Post-Execution Summary – Phase 3
+
+## Test Results
+- `pytest codex/code/work/tests -q`
+  - Outcome: PASS
+  - Notes: Validated cost normalisation, budget manager semantics, and runner integration including loop stop handling.
+
+## Coverage & Quality Notes
+- Manual inspection confirms budget warnings are de-duplicated via `consume_warnings`.
+- Trace ordering retains `run_end` as terminal event while preserving `budget_breach` payloads.
+- Adapter doubles enforce deterministic estimate/execute cycle; no external side effects observed.
+
+## Follow-ups
+- Consider integrating TraceEvent schema validation from shared spec modules.
+- Expand FlowRunner to cover decision/fallback branches once policy stack work from Phase 2 is merged.
+

--- a/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+++ b/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
@@ -1,0 +1,16 @@
+# Phase 3 Preview – Budget guards and runner integration
+
+## Objective
+Implement a self-contained FlowRunner prototype that unifies structured budget models, a scope-aware BudgetManager, and TraceWriter-backed telemetry while keeping adapter-driven execution and policy enforcement deterministic for unit testing.
+
+## Key Components
+- Canonical cost utilities that normalise seconds to milliseconds and guard metric names.
+- Immutable budget value objects and exceptions backing a `BudgetManager` orchestrator with scope registration and warning aggregation.
+- A `TraceEventEmitter` façade plus minimal `PolicyStack` to keep runner concerns loosely coupled.
+- FlowRunner implementation exercising adapter estimate/execute lifecycle, run/node/loop scopes, and trace emission.
+
+## Test Strategy
+Two pytest modules cover:
+1. Cost normalisation and budget manager semantics (soft warn, hard breach, loop stop).
+2. End-to-end runner behaviour for run halts, node warnings, and loop stop budgets with trace assertions.
+

--- a/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+++ b/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
@@ -1,0 +1,21 @@
+# Review Checklist – Phase 3
+
+## Budget Models & Normalisation
+- [x] `normalize_cost` converts seconds to integer milliseconds and rejects unsupported metrics.
+- [x] BudgetSpec/BudgetMeter enforce warn/error/stop actions with immutable outcomes.
+- [x] `BudgetManager` emits `budget_charge`/`budget_breach` and aggregates warnings.
+
+## Runner Integration
+- [x] FlowRunner registers run/node/loop scopes and propagates costs to the BudgetManager.
+- [x] Loop execution halts on `BudgetStopSignal` while preserving completed iterations.
+- [x] Policy resolution emits allow/deny traces and blocks unknown tools.
+
+## Tests & Determinism
+- [x] Pytest modules cover cost utilities, manager semantics, and runner integration.
+- [x] Fake adapters provide deterministic cost/output pairs; no network or timing dependencies.
+- [x] Trace assertions validate presence/order of `run_start`, `budget_breach`, and `run_end` events.
+
+## Outstanding Considerations
+- [ ] Integration with full DSL schema (decision nodes, fallback chains) – deferred.
+- [ ] Trace schema validation against shared spec – candidate for future augmentation.
+

--- a/codex/DOCUMENTATION/P3/work-20250509-gpt5codex.yaml
+++ b/codex/DOCUMENTATION/P3/work-20250509-gpt5codex.yaml
@@ -1,0 +1,104 @@
+version: 1
+component: FlowRunnerBudgetIntegrationPrototype
+purpose: >-
+  Provide a deterministic FlowRunner slice that exercises budget enforcement and trace emission while
+  remaining decoupled from external adapters or persistence layers.
+cli_usage:
+  - command: python -m pytest codex/code/work/tests
+    description: Execute unit tests that verify cost normalisation, budget manager semantics, and runner loops.
+public_interfaces:
+  - module: codex.code.work.pkgs.dsl.costs
+    objects:
+      - name: normalize_cost
+        type: function
+        doc: Convert heterogeneous metrics into canonical integers and validate keys.
+      - name: accumulate_cost
+        type: function
+        doc: Sum two cost dictionaries while preserving schema validation.
+  - module: codex.code.work.pkgs.dsl.budget
+    objects:
+      - name: BudgetSpec
+        type: dataclass
+        doc: Immutable configuration describing metric, limit, mode, and breach action.
+      - name: BudgetChargeOutcome
+        type: dataclass
+        doc: Structured result for trace payloads and diagnostics.
+      - name: BudgetMeter
+        type: class
+        doc: Per-scope counter enforcing soft/hard/stop semantics.
+      - name: BudgetBreachError
+        type: exception
+        doc: Raised when a hard budget cannot be honoured.
+      - name: BudgetStopSignal
+        type: exception
+        doc: Signals loop stop conditions without marking run failure.
+  - module: codex.code.work.pkgs.dsl.budget_manager
+    objects:
+      - name: BudgetManager
+        type: class
+        doc: Registers scopes, charges costs, and emits trace payloads for each event.
+  - module: codex.code.work.pkgs.dsl.trace
+    objects:
+      - name: TraceEventEmitter
+        type: class
+        doc: Facade that wraps a TraceWriter and enforces immutable payload emission.
+  - module: codex.code.work.pkgs.dsl.policy
+    objects:
+      - name: PolicyStack
+        type: class
+        doc: Minimal allow/deny evaluator used during node execution.
+      - name: PolicyViolationError
+        type: exception
+        doc: Raised when a node attempts to execute a tool outside the effective allowlist.
+  - module: codex.code.work.pkgs.dsl.runner
+    objects:
+      - name: FlowRunner
+        type: class
+        doc: Executes nodes and loops using adapters with budget and policy enforcement.
+      - name: RunResult
+        type: dataclass
+        doc: Structured outcome containing status, outputs, and accumulated warnings.
+base_classes:
+  - class: BudgetError
+    module: codex.code.work.pkgs.dsl.budget
+    role: Shared base for all budget enforcement exceptions.
+extension_hooks:
+  - location: FlowRunner._execute_unit
+    description: Override to support additional node kinds (decision, transform) while reusing budget hooks.
+  - location: BudgetManager.register_scope
+    description: Attach scope metadata (tenant, environment) before trace emission when integrating with the full runner.
+configurable_options:
+  - name: BudgetSpec.mode
+    description: Toggle between `soft` and `hard` enforcement at scope registration time.
+  - name: FlowRunner.id_factory
+    description: Inject deterministic run identifiers for reproducible testing.
+automation_triggers:
+  - name: phase3_runner
+    description: Optional script placeholder for future CI automation of this prototype.
+error_contracts:
+  - name: BudgetBreachError
+    behaviour: Raises on hard budgets; carries `outcome` with scope, overage, and action fields.
+  - name: BudgetStopSignal
+    behaviour: Raised to halt loops; caller should treat as graceful stop.
+serialization:
+  payloads:
+    - name: budget_charge
+      format: immutable mapping proxy, ready for JSON serialisation by upstream TraceWriter implementations.
+    - name: policy_resolved
+      format: JSON-safe primitives containing sorted allow/deny tuples.
+lifecycle:
+  phases:
+    - name: run_start
+      description: Emitted before node traversal begins.
+    - name: per_node_execution
+      description: Executes tool adapters, charges budgets, and appends outputs.
+    - name: run_end
+      description: Final trace event capturing terminal status.
+typing_notes:
+  - All public functions are type hinted for Python 3.12; enums and dataclasses support static analysis tooling.
+security_considerations:
+  - No external I/O or subprocesses invoked; adapters are provided as in-memory doubles for tests.
+  - Policy enforcement currently limited to allow/deny lists; audit logging hooks can be added where `emit_policy_resolution` is called.
+performance_notes:
+  - Cost normalisation coerces to integers to keep arithmetic deterministic and lightweight.
+  - BudgetManager caches warnings per scope and clears them via `consume_warnings` to avoid repeated allocations.

--- a/codex/TESTS/P3/work-20250509-gpt5codex.yaml
+++ b/codex/TESTS/P3/work-20250509-gpt5codex.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_budget_manager_rejects_negative_costs
+      rationale: Ensure normalization rejects negative metrics rather than silently clamping, preventing inaccurate remaining budgets.
+      source_module: codex/code/work/pkgs/dsl/costs.py
+      priority: medium
+    - name: test_flow_runner_policy_violation_traced
+      rationale: Validate that disallowed tools raise PolicyViolationError and emit `policy_violation` traces for observability.
+      source_module: codex/code/work/pkgs/dsl/runner.py
+      priority: high
+    - name: test_loop_budget_soft_warning_sequence
+      rationale: Cover soft loop budgets that warn but do not stop to ensure warnings propagate without breaking iteration counts.
+      source_module: codex/code/work/pkgs/dsl/runner.py
+      priority: medium

--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package marker for codex runtime scaffolding used in task phases."""

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.yaml
@@ -1,0 +1,72 @@
+summary: Integrate a budget-aware FlowRunner with deterministic trace emission by combining canonical budget models, a scope-aware manager, and adapter-driven execution.
+justification: |
+  Previous phases converged on three pillars: (1) immutable budget value objects with explicit remaining/overage math, (2) a BudgetManager orchestrating preview/commit flows per scope, and (3) FlowRunner wiring that preserves adapter execution semantics while emitting TraceWriter-backed events. This plan fuses those agreements while addressing review findings about soft-budget handling, loop stop signalling, and cost normalization drift.
+steps:
+  - name: Establish canonical cost and budget models
+    description: Create normalized cost utilities and immutable budget dataclasses with breach semantics adopted from zwi2ny/pbdel9/qhq0jq branches.
+  - name: Implement BudgetManager orchestration
+    description: Provide run/node/loop/spec scope registration, preview, charge, and trace outcome emission hooks, ensuring soft warnings and stop signals are surfaced consistently.
+  - name: Rewire FlowRunner execution with adapters and traces
+    description: Build a runner loop that estimates and charges budgets, drives adapters, and emits policy/budget events via the shared TraceEventEmitter while supporting loop stop actions.
+modules:
+  - path: codex/code/work/pkgs/__init__.py
+    role: Package marker for pkgs namespace used by tests and runner modules.
+  - path: codex/code/work/pkgs/dsl/__init__.py
+    role: Namespace initializer ensuring the DSL modules are importable.
+  - path: codex/code/work/pkgs/dsl/costs.py
+    role: Houses cost normalization helpers to standardize seconds→milliseconds and metric validation.
+  - path: codex/code/work/pkgs/dsl/budget.py
+    role: Defines BudgetSpec, CostSnapshot, BudgetChargeOutcome, and BudgetMeter abstractions with immutable bookkeeping.
+  - path: codex/code/work/pkgs/dsl/budget_manager.py
+    role: Encapsulates scope-aware BudgetManager coordinating preview/charge lifecycle and trace metadata synthesis.
+  - path: codex/code/work/pkgs/dsl/trace.py
+    role: Provides TraceWriter protocol and TraceEventEmitter emitting immutable payloads for budget/policy events.
+  - path: codex/code/work/pkgs/dsl/policy.py
+    role: Implements a minimal PolicyStack enforcing allowlist/denylist semantics for runner integration.
+  - path: codex/code/work/pkgs/dsl/runner.py
+    role: Implements FlowRunner using adapters, PolicyStack, and BudgetManager to execute nodes/loops with trace emission.
+tests:
+  - path: codex/code/work/tests/test_costs_and_budget_manager.py
+    coverage: Validate normalization edge cases, BudgetMeter breach handling, and manager scope orchestration.
+    mocks: Use deterministic fake TraceWriter and clock/id factories.
+  - path: codex/code/work/tests/test_flow_runner_budget_integration.py
+    coverage: Ensure FlowRunner enforces run/node/loop budgets, emits trace payloads, and respects policy allowlists during adapter execution.
+    mocks: Fake adapters providing estimate/execute hooks with deterministic costs and outputs.
+run_order:
+  - tests/test_costs_and_budget_manager.py
+  - tests/test_flow_runner_budget_integration.py
+  - implement pkgs/dsl/costs.py
+  - implement pkgs/dsl/budget.py
+  - implement pkgs/dsl/budget_manager.py
+  - implement pkgs/dsl/trace.py
+  - implement pkgs/dsl/policy.py
+  - implement pkgs/dsl/runner.py
+interfaces:
+  budget_models:
+    description: BudgetSpec and BudgetChargeOutcome dataclasses consumed by BudgetManager and FlowRunner.
+  trace_emitter:
+    description: TraceEventEmitter exposes emit(event, payload) used by FlowRunner; wraps TraceWriter dependency.
+  tool_adapter_protocol:
+    description: Runner expects adapters with estimate(spec) and execute(spec) returning outputs+cost.
+tdd_coverage_targets:
+  - module: codex/code/work/pkgs/dsl/costs.py
+    target: 95
+  - module: codex/code/work/pkgs/dsl/budget.py
+    target: 90
+  - module: codex/code/work/pkgs/dsl/budget_manager.py
+    target: 90
+  - module: codex/code/work/pkgs/dsl/runner.py
+    target: 85
+review_checklist:
+  - All budget breach actions (warn, error, stop) produce expected outcomes and trace payloads.
+  - Cost normalization handles seconds/duration_ms consistently and rejects unknown metrics.
+  - FlowRunner stops loops on budget stop signals and surfaces run halt status.
+  - PolicyStack ensures only allowed tools execute and violations are traced.
+  - Tests cover run/node/loop scopes with both soft and hard budgets.
+outputs:
+  preview: PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+  review: REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+  postexecution: POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+  documentation: codex/DOCUMENTATION/P3/work-20250509-gpt5codex.yaml
+  missing_tests: codex/TESTS/P3/work-20250509-gpt5codex.yaml
+  optional_runner: codex/code/07b_budget_guards_and_runner_integration.yaml/phase3_runner.py

--- a/codex/code/07b_budget_guards_and_runner_integration.yaml/phase3_runner.py
+++ b/codex/code/07b_budget_guards_and_runner_integration.yaml/phase3_runner.py
@@ -1,0 +1,24 @@
+"""Utility script to execute Phase 3 unit tests and persist a run log."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+LOG_PATH = Path("POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex-runlog.txt")
+
+
+def main() -> int:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        ["pytest", "codex/code/work/tests", "-q"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    LOG_PATH.write_text(result.stdout + "\n" + result.stderr)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/code/__init__.py
+++ b/codex/code/__init__.py
@@ -1,0 +1,1 @@
+"""Namespace for code artifacts produced during Codex phased tasks."""

--- a/codex/code/work/__init__.py
+++ b/codex/code/work/__init__.py
@@ -1,0 +1,1 @@
+"""Work branch namespace containing in-progress FlowRunner integrations."""

--- a/codex/code/work/pkgs/__init__.py
+++ b/codex/code/work/pkgs/__init__.py
@@ -1,0 +1,1 @@
+"""Package namespace for DSL runtime scaffolding."""

--- a/codex/code/work/pkgs/dsl/__init__.py
+++ b/codex/code/work/pkgs/dsl/__init__.py
@@ -1,0 +1,1 @@
+"""DSL module namespace for FlowRunner budget integration prototypes."""

--- a/codex/code/work/pkgs/dsl/budget.py
+++ b/codex/code/work/pkgs/dsl/budget.py
@@ -1,0 +1,134 @@
+"""Budget domain models and exceptions for FlowRunner integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Dict, Mapping
+
+from .costs import accumulate_cost
+
+
+class BudgetMode(str, Enum):
+    """Enumerates budget enforcement intensity."""
+
+    SOFT = "soft"
+    HARD = "hard"
+
+
+@dataclass(frozen=True)
+class BudgetSpec:
+    """Configuration for a single budget meter."""
+
+    metric: str
+    limit: int | float
+    breach_action: str = "error"
+    mode: BudgetMode = BudgetMode.HARD
+
+    def normalized_limit(self) -> int:
+        return int(round(float(self.limit)))
+
+
+@dataclass(frozen=True)
+class CostSnapshot:
+    """Immutable snapshot of spent and remaining budget."""
+
+    metric: str
+    spent: int
+    remaining: int
+    limit: int
+
+
+@dataclass(frozen=True)
+class BudgetChargeOutcome:
+    """Result of a budget charge application."""
+
+    scope_id: str
+    action: str
+    breached: bool
+    cost: Mapping[str, int]
+    remaining: int
+    overage: int
+    spec: BudgetSpec
+
+    def as_mapping(self) -> Mapping[str, object]:
+        return MappingProxyType(
+            {
+                "scope_id": self.scope_id,
+                "action": self.action,
+                "breached": self.breached,
+                "cost": dict(self.cost),
+                "remaining": self.remaining,
+                "overage": self.overage,
+                "limit": self.spec.normalized_limit(),
+                "metric": self.spec.metric,
+            }
+        )
+
+
+class BudgetError(RuntimeError):
+    """Base exception for budget enforcement."""
+
+    def __init__(self, outcome: BudgetChargeOutcome):
+        super().__init__(
+            f"Budget breach in scope {outcome.scope_id}: action={outcome.action} overage={outcome.overage}"
+        )
+        self.outcome = outcome
+
+
+class BudgetBreachError(BudgetError):
+    """Raised when a hard budget is breached and execution must halt."""
+
+
+class BudgetStopSignal(BudgetError):
+    """Raised to request a controlled stop, typically for loop budgets."""
+
+
+class BudgetMeter:
+    """Tracks spend against a single budget specification."""
+
+    def __init__(self, scope_id: str, spec: BudgetSpec) -> None:
+        self.scope_id = scope_id
+        self.spec = spec
+        self._spent: Dict[str, int] = {}
+
+    def snapshot(self) -> CostSnapshot:
+        spent = int(self._spent.get(self.spec.metric, 0))
+        limit = self.spec.normalized_limit()
+        remaining = max(limit - spent, 0)
+        return CostSnapshot(metric=self.spec.metric, spent=spent, remaining=remaining, limit=limit)
+
+    def charge(self, cost: Mapping[str, int]) -> BudgetChargeOutcome:
+        limit = self.spec.normalized_limit()
+        metric_value = int(cost.get(self.spec.metric, 0))
+        prior = int(self._spent.get(self.spec.metric, 0))
+        new_spent = prior + metric_value
+        remaining = max(limit - new_spent, 0)
+        overage = max(new_spent - limit, 0)
+
+        if metric_value:
+            self._spent[self.spec.metric] = new_spent
+
+        breached = new_spent > limit
+        outcome = BudgetChargeOutcome(
+            scope_id=self.scope_id,
+            action=self.spec.breach_action,
+            breached=breached,
+            cost=MappingProxyType(dict(cost)),
+            remaining=remaining,
+            overage=overage,
+            spec=self.spec,
+        )
+
+        if breached:
+            if self.spec.breach_action == "warn" and self.spec.mode == BudgetMode.SOFT:
+                return outcome
+            if self.spec.breach_action == "stop":
+                raise BudgetStopSignal(outcome)
+            raise BudgetBreachError(outcome)
+
+        return outcome
+
+    def accumulate(self, additional_cost: Mapping[str, int]) -> None:
+        self._spent = accumulate_cost(self._spent, additional_cost)

--- a/codex/code/work/pkgs/dsl/budget_manager.py
+++ b/codex/code/work/pkgs/dsl/budget_manager.py
@@ -1,0 +1,80 @@
+"""Scope-aware budget manager coordinating trace emission."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, MutableMapping
+
+from .budget import (
+    BudgetBreachError,
+    BudgetChargeOutcome,
+    BudgetMeter,
+    BudgetMode,
+    BudgetSpec,
+    BudgetStopSignal,
+)
+from .costs import normalize_cost
+
+
+class BudgetManager:
+    """Manage multiple budget scopes and emit structured events."""
+
+    def __init__(self, trace_writer) -> None:
+        self._trace_writer = trace_writer
+        self._meters: Dict[str, BudgetMeter] = {}
+        self._warnings: MutableMapping[str, list[str]] = {}
+
+    def register_scope(self, scope_id: str, spec: BudgetSpec | Mapping[str, object]) -> None:
+        if scope_id in self._meters:
+            raise ValueError(f"Budget scope already registered: {scope_id}")
+        budget_spec = self._coerce_spec(spec)
+        self._meters[scope_id] = BudgetMeter(scope_id=scope_id, spec=budget_spec)
+
+    def scopes(self) -> Iterable[str]:
+        return self._meters.keys()
+
+    def get_remaining(self, scope_id: str) -> int:
+        meter = self._meters[scope_id]
+        return meter.snapshot().remaining
+
+    def charge(self, scope_id: str, cost: Mapping[str, int | float]) -> BudgetChargeOutcome:
+        meter = self._meters[scope_id]
+        normalized = normalize_cost(cost)
+        try:
+            outcome = meter.charge(normalized)
+        except BudgetStopSignal as stop:
+            self._emit("budget_breach", stop.outcome)
+            raise
+        except BudgetBreachError as breach:
+            self._emit("budget_breach", breach.outcome)
+            raise
+        else:
+            self._emit("budget_charge", outcome)
+            if outcome.breached and outcome.action == "warn":
+                self._emit("budget_breach", outcome)
+                self._warnings.setdefault(scope_id, []).append(
+                    f"{scope_id} exceeded {outcome.spec.metric} by {outcome.overage}"
+                )
+            return outcome
+
+    def warnings_for(self, scope_id: str) -> list[str]:
+        return list(self._warnings.get(scope_id, []))
+
+    def consume_warnings(self, scope_id: str) -> list[str]:
+        return self._warnings.pop(scope_id, [])
+
+    def _emit(self, event: str, outcome: BudgetChargeOutcome) -> None:
+        payload = dict(outcome.as_mapping())
+        payload["scope"] = outcome.scope_id
+        payload["action"] = outcome.action
+        self._trace_writer.write(event, payload)
+
+    @staticmethod
+    def _coerce_spec(spec: BudgetSpec | Mapping[str, object]) -> BudgetSpec:
+        if isinstance(spec, BudgetSpec):
+            return spec
+        metric = spec.get("metric")
+        limit = spec.get("limit")
+        action = spec.get("breach_action", "error")
+        mode_raw = spec.get("mode", BudgetMode.HARD.value)
+        mode = BudgetMode(mode_raw)
+        return BudgetSpec(metric=metric, limit=limit, breach_action=str(action), mode=mode)

--- a/codex/code/work/pkgs/dsl/costs.py
+++ b/codex/code/work/pkgs/dsl/costs.py
@@ -1,0 +1,59 @@
+"""Utilities for normalising cost metrics used by the FlowRunner budget pipeline."""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+_ALLOWED_METRICS = {
+    "duration_ms",
+    "calls",
+    "tokens_in",
+    "tokens_out",
+    "tokens_total",
+}
+
+
+def _coerce_numeric(value: float | int) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"Cost metric must be numeric, got {value!r}") from exc
+    if numeric < 0:
+        raise ValueError("Cost metrics cannot be negative")
+    return numeric
+
+
+def normalize_cost(cost: Mapping[str, float | int]) -> Dict[str, int]:
+    """Normalise a raw cost mapping.
+
+    * Accepts `seconds` and converts to integer milliseconds (`duration_ms`).
+    * Validates metric names against the allowed schema.
+    * Returns a dictionary with integer values where applicable for determinism.
+    """
+
+    normalized: Dict[str, int] = {}
+    duration: float | None = None
+
+    for key, value in cost.items():
+        if key == "seconds":
+            duration = _coerce_numeric(value) * 1000.0
+            continue
+        if key not in _ALLOWED_METRICS:
+            raise ValueError(f"Unsupported cost metric: {key}")
+        normalized[key] = int(round(_coerce_numeric(value)))
+
+    if duration is not None:
+        normalized["duration_ms"] = int(round(duration))
+
+    return normalized
+
+
+def accumulate_cost(base: Mapping[str, int], delta: Mapping[str, int]) -> Dict[str, int]:
+    """Add two cost dictionaries while preserving allowed metric constraints."""
+
+    combined: Dict[str, int] = {key: int(value) for key, value in base.items()}
+    for key, value in delta.items():
+        if key not in _ALLOWED_METRICS:
+            raise ValueError(f"Unsupported cost metric during accumulation: {key}")
+        combined[key] = combined.get(key, 0) + int(value)
+    return combined

--- a/codex/code/work/pkgs/dsl/policy.py
+++ b/codex/code/work/pkgs/dsl/policy.py
@@ -1,0 +1,50 @@
+"""Minimal policy stack enforcement used by the FlowRunner tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Set
+
+
+class PolicyViolationError(RuntimeError):
+    """Raised when a node attempts to execute a disallowed tool."""
+
+    def __init__(self, node_id: str, tool_ref: str, allowlist: Iterable[str]):
+        allow_display = ", ".join(sorted(set(allowlist))) or "<empty>"
+        super().__init__(f"Tool '{tool_ref}' not permitted for node '{node_id}' (allow: {allow_display})")
+        self.node_id = node_id
+        self.tool_ref = tool_ref
+        self.allowlist = tuple(sorted(set(allowlist)))
+
+
+@dataclass
+class PolicyFrame:
+    allow: Set[str]
+    deny: Set[str]
+
+
+class PolicyStack:
+    """Simple allow/deny based policy evaluation stack."""
+
+    def __init__(self, global_allow: Optional[Iterable[str]] = None, global_deny: Optional[Iterable[str]] = None) -> None:
+        self._frames = [
+            PolicyFrame(allow=set(global_allow or []), deny=set(global_deny or []))
+        ]
+
+    def resolve(self, node_id: str, tool_ref: str, node_policy: Optional[dict] = None) -> list[str]:
+        frame = self._frames[-1]
+        effective = set(frame.allow) if frame.allow else set()
+        if not effective:
+            effective = {tool_ref}
+        effective -= frame.deny
+
+        if node_policy:
+            node_allow = set(node_policy.get("allow", []))
+            node_deny = set(node_policy.get("deny", []))
+            if node_allow:
+                effective &= node_allow
+            effective -= node_deny
+
+        if tool_ref not in effective:
+            raise PolicyViolationError(node_id=node_id, tool_ref=tool_ref, allowlist=effective)
+        return sorted(effective)

--- a/codex/code/work/pkgs/dsl/runner.py
+++ b/codex/code/work/pkgs/dsl/runner.py
@@ -1,0 +1,161 @@
+"""FlowRunner prototype integrating budget guards and trace emission."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Mapping, MutableMapping, Optional
+
+from .budget import BudgetBreachError, BudgetStopSignal
+from .budget_manager import BudgetManager
+from .costs import normalize_cost
+from .policy import PolicyStack, PolicyViolationError
+from .trace import TraceEventEmitter
+
+
+@dataclass
+class RunResult:
+    run_id: str
+    status: str
+    outputs: MutableMapping[str, object] = field(default_factory=dict)
+    stop_reason: Optional[str] = None
+    warnings: List[str] = field(default_factory=list)
+
+
+class FlowRunner:
+    """Minimal FlowRunner implementation sufficient for budget integration tests."""
+
+    def __init__(
+        self,
+        adapters: Mapping[str, object],
+        trace_emitter: TraceEventEmitter,
+        id_factory: Optional[Callable[[], str]] = None,
+        budget_manager_factory: Callable[..., BudgetManager] | None = None,
+    ) -> None:
+        self._adapters = dict(adapters)
+        self._trace = trace_emitter
+        self._id_factory = id_factory or (lambda: "run")
+        self._budget_manager_factory = budget_manager_factory or BudgetManager
+
+    def run(self, spec: Mapping[str, object], vars: Mapping[str, object]) -> RunResult:  # noqa: ARG002
+        run_id = self._id_factory()
+        budget_manager = self._budget_manager_factory(trace_writer=self._trace)
+        result = RunResult(run_id=run_id, status="ok")
+
+        run_budget = spec.get("run_budget")
+        if run_budget:
+            budget_manager.register_scope("run", run_budget)
+
+        policy_spec = spec.get("policies", {})
+        policy_stack = PolicyStack(
+            global_allow=policy_spec.get("allow"),
+            global_deny=policy_spec.get("deny"),
+        )
+
+        self._trace.emit("run_start", flow_id=spec.get("flow_id"), run_id=run_id)
+
+        try:
+            for node in spec.get("nodes", []):
+                kind = node.get("kind", "unit")
+                if kind == "loop":
+                    result.outputs[node["id"]] = self._execute_loop(node, policy_stack, budget_manager, result)
+                elif kind == "unit":
+                    output, warnings = self._execute_unit(node, policy_stack, budget_manager, parent_scopes=None)
+                    result.outputs[node["id"]] = output
+                    result.warnings.extend(warnings)
+                else:
+                    raise NotImplementedError(f"Unsupported node kind: {kind}")
+        except BudgetBreachError as breach:
+            result.status = "halted"
+            result.stop_reason = f"budget_breach:{breach.outcome.scope_id}"
+        except PolicyViolationError as violation:
+            result.status = "error"
+            result.stop_reason = f"policy_violation:{violation.node_id}"
+            raise
+        finally:
+            self._trace.emit("run_end", run_id=run_id, status=result.status)
+
+        return result
+
+    def _execute_unit(
+        self,
+        node: Mapping[str, object],
+        policy_stack: PolicyStack,
+        budget_manager: BudgetManager,
+        parent_scopes: Optional[List[str]],
+    ) -> tuple[Mapping[str, object], List[str]]:
+        node_id = node["id"]
+        node_spec = node.get("spec", {})
+        tool_ref = node_spec.get("tool_ref")
+        allow = policy_stack.resolve(node_id=node_id, tool_ref=tool_ref, node_policy=node.get("policy"))
+        deny = node.get("policy", {}).get("deny", []) if node.get("policy") else []
+        self._trace.emit_policy_resolution(node_id=node_id, allow=allow, deny=deny)
+
+        if tool_ref not in self._adapters:
+            raise KeyError(f"Adapter for tool '{tool_ref}' not registered")
+        adapter = self._adapters[tool_ref]
+
+        adapter.estimate(node_spec)
+        outputs, raw_cost = adapter.execute(node_spec)
+        normalized_cost = normalize_cost(raw_cost)
+
+        scopes: List[str] = []
+        if "run" in budget_manager.scopes():
+            scopes.append("run")
+        if parent_scopes:
+            scopes.extend(parent_scopes)
+
+        node_scope: Optional[str] = None
+        if node.get("budget"):
+            node_scope = f"node:{node_id}"
+            if node_scope not in budget_manager.scopes():
+                budget_manager.register_scope(node_scope, node["budget"])
+            scopes.append(node_scope)
+
+        warnings: List[str] = []
+        for scope_id in scopes:
+            budget_manager.charge(scope_id, normalized_cost)
+            warnings.extend(budget_manager.consume_warnings(scope_id))
+        if node_scope:
+            warnings.extend(budget_manager.consume_warnings(node_scope))
+
+        return outputs, warnings
+
+    def _execute_loop(
+        self,
+        node: Mapping[str, object],
+        policy_stack: PolicyStack,
+        budget_manager: BudgetManager,
+        result: RunResult,
+    ) -> List[Mapping[str, object]]:
+        node_id = node["id"]
+        loop_scope = f"loop:{node_id}"
+        stop_spec = node.get("stop", {})
+        loop_budget = stop_spec.get("budget")
+        if loop_budget and loop_scope not in budget_manager.scopes():
+            budget_manager.register_scope(loop_scope, loop_budget)
+
+        max_iterations = stop_spec.get("max_iterations", 100)
+        body = node.get("body", [])
+        iterations: List[Mapping[str, object]] = []
+
+        for iteration_index in range(max_iterations):
+            try:
+                iteration_outputs: Dict[str, object] = {}
+                for body_node in body:
+                    output, warnings = self._execute_unit(
+                        body_node,
+                        policy_stack,
+                        budget_manager,
+                        parent_scopes=[loop_scope] if loop_budget else None,
+                    )
+                    iteration_outputs[body_node["id"]] = output
+                    result.warnings.extend(warnings)
+                iterations.append(iteration_outputs)
+            except BudgetStopSignal:
+                result.warnings.extend(budget_manager.consume_warnings(loop_scope))
+                break
+        else:
+            # loop exhausted max iterations without stop signal
+            pass
+
+        return iterations

--- a/codex/code/work/pkgs/dsl/trace.py
+++ b/codex/code/work/pkgs/dsl/trace.py
@@ -1,0 +1,35 @@
+"""Trace emission utilities wrapping an underlying TraceWriter."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Mapping, Protocol
+
+
+class TraceWriter(Protocol):
+    def write(self, event_name: str, payload: Mapping[str, object]) -> None:
+        ...
+
+
+class TraceEventEmitter:
+    """Emit immutable trace payloads for runner subsystems."""
+
+    def __init__(self, trace_writer: TraceWriter) -> None:
+        self._trace_writer = trace_writer
+
+    def write(self, event_name: str, payload: Mapping[str, object]) -> None:
+        self._trace_writer.write(event_name, MappingProxyType(dict(payload)))
+
+    def emit(self, event_name: str, **payload: object) -> None:
+        self.write(event_name, payload)
+
+    def emit_budget(self, event_name: str, budget_payload: Mapping[str, object]) -> None:
+        self.write(event_name, budget_payload)
+
+    def emit_policy_resolution(self, node_id: str, allow: list[str], deny: list[str]) -> None:
+        self.emit(
+            "policy_resolved",
+            node_id=node_id,
+            allow=tuple(sorted(allow)),
+            deny=tuple(sorted(deny)),
+        )

--- a/codex/code/work/tests/test_costs_and_budget_manager.py
+++ b/codex/code/work/tests/test_costs_and_budget_manager.py
@@ -1,0 +1,76 @@
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from codex.code.work.pkgs.dsl.costs import normalize_cost
+from codex.code.work.pkgs.dsl.budget import BudgetSpec, BudgetMode, BudgetBreachError, BudgetStopSignal
+from codex.code.work.pkgs.dsl.budget_manager import BudgetManager
+
+
+class DummyTraceWriter:
+    def __init__(self):
+        self.events = []
+
+    def write(self, event_name: str, payload: dict) -> None:
+        self.events.append((event_name, payload))
+
+
+def test_normalize_cost_converts_seconds_and_validates_metrics():
+    normalized = normalize_cost({"seconds": 1.5, "calls": 2})
+    assert normalized["duration_ms"] == 1500
+    assert normalized["calls"] == 2
+
+    with pytest.raises(ValueError):
+        normalize_cost({"unknown": 1})
+
+
+def test_budget_manager_warns_on_soft_breach_without_raising():
+    manager = BudgetManager(trace_writer=DummyTraceWriter())
+    manager.register_scope(
+        scope_id="node:unit",
+        spec=BudgetSpec(metric="calls", limit=1, mode=BudgetMode.SOFT, breach_action="warn"),
+    )
+
+    outcome = manager.charge("node:unit", {"calls": 2})
+
+    assert outcome.breached is True
+    assert outcome.action == "warn"
+    assert outcome.remaining == 0
+    assert outcome.overage == 1
+
+
+def test_budget_manager_raises_on_hard_breach():
+    manager = BudgetManager(trace_writer=DummyTraceWriter())
+    manager.register_scope(
+        scope_id="run",
+        spec=BudgetSpec(metric="calls", limit=1, mode=BudgetMode.HARD, breach_action="error"),
+    )
+
+    with pytest.raises(BudgetBreachError) as exc:
+        manager.charge("run", {"calls": 2})
+
+    assert exc.value.outcome.scope_id == "run"
+    assert exc.value.outcome.overage == 1
+    assert exc.value.outcome.action == "error"
+
+
+def test_budget_manager_emits_stop_signal():
+    trace = DummyTraceWriter()
+    manager = BudgetManager(trace_writer=trace)
+    manager.register_scope(
+        scope_id="loop:jobs",
+        spec=BudgetSpec(metric="calls", limit=1, mode=BudgetMode.HARD, breach_action="stop"),
+    )
+
+    with pytest.raises(BudgetStopSignal) as exc:
+        manager.charge("loop:jobs", {"calls": 3})
+
+    assert exc.value.outcome.overage == 2
+    assert exc.value.outcome.action == "stop"
+    assert trace.events[-1][0] == "budget_breach"
+    assert trace.events[-1][1]["scope"] == "loop:jobs"

--- a/codex/code/work/tests/test_flow_runner_budget_integration.py
+++ b/codex/code/work/tests/test_flow_runner_budget_integration.py
@@ -1,0 +1,137 @@
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from codex.code.work.pkgs.dsl.runner import FlowRunner, RunResult
+from codex.code.work.pkgs.dsl.trace import TraceEventEmitter
+
+
+class DummyTraceWriter:
+    def __init__(self):
+        self.events = []
+
+    def write(self, event_name: str, payload: dict) -> None:
+        self.events.append((event_name, payload))
+
+
+class FixedCostAdapter:
+    def __init__(self, cost, output):
+        self.cost = cost
+        self.output = output
+        self.estimate_calls = 0
+        self.execute_calls = 0
+
+    def estimate(self, node_spec: dict) -> dict:
+        self.estimate_calls += 1
+        return dict(self.cost)
+
+    def execute(self, node_spec: dict) -> tuple:
+        self.execute_calls += 1
+        return dict(self.output), dict(self.cost)
+
+
+@pytest.fixture
+def trace_emitter():
+    writer = DummyTraceWriter()
+    return TraceEventEmitter(trace_writer=writer), writer
+
+
+def build_runner(adapters, trace_emitter):
+    emitter, writer = trace_emitter
+    return FlowRunner(
+        adapters=adapters,
+        trace_emitter=emitter,
+        id_factory=lambda: "run-fixed",
+    ), writer
+
+
+def test_runner_halts_on_run_budget_breach(trace_emitter):
+    adapters = {"expensive": FixedCostAdapter({"calls": 3}, {"result": "x"})}
+    runner, writer = build_runner(adapters, trace_emitter)
+
+    spec = {
+        "flow_id": "flow",
+        "run_budget": {"metric": "calls", "limit": 2, "breach_action": "error", "mode": "hard"},
+        "policies": {"allow": ["expensive"]},
+        "nodes": [
+            {
+                "id": "n1",
+                "kind": "unit",
+                "spec": {"tool_ref": "expensive"},
+            }
+        ],
+    }
+
+    result: RunResult = runner.run(spec, vars={})
+
+    assert result.status == "halted"
+    assert result.stop_reason.startswith("budget_breach")
+    assert writer.events[-1][0] == "run_end"
+    breach_events = [evt for evt in writer.events if evt[0] == "budget_breach"]
+    assert breach_events, "budget breach event missing"
+    assert breach_events[-1][1]["scope"] == "run"
+
+
+def test_runner_warns_on_node_soft_budget(trace_emitter):
+    adapters = {"echo": FixedCostAdapter({"calls": 2}, {"payload": "value"})}
+    runner, writer = build_runner(adapters, trace_emitter)
+
+    spec = {
+        "flow_id": "flow",
+        "run_budget": {"metric": "calls", "limit": 10, "breach_action": "error", "mode": "hard"},
+        "policies": {"allow": ["echo"]},
+        "nodes": [
+            {
+                "id": "n1",
+                "kind": "unit",
+                "spec": {"tool_ref": "echo"},
+                "budget": {"metric": "calls", "limit": 1, "breach_action": "warn", "mode": "soft"},
+            }
+        ],
+    }
+
+    result = runner.run(spec, vars={})
+
+    assert result.status == "ok"
+    assert result.outputs["n1"] == {"payload": "value"}
+    warn_events = [evt for evt in writer.events if evt[0] == "budget_breach"]
+    assert warn_events[0][1]["action"] == "warn"
+    assert "n1" in result.warnings[0]
+
+
+def test_runner_loop_budget_stop(trace_emitter):
+    adapters = {"cheap": FixedCostAdapter({"calls": 1}, {"ok": True})}
+    runner, writer = build_runner(adapters, trace_emitter)
+
+    spec = {
+        "flow_id": "flow",
+        "run_budget": {"metric": "calls", "limit": 10, "breach_action": "error", "mode": "hard"},
+        "policies": {"allow": ["cheap"]},
+        "nodes": [
+            {
+                "id": "loop",
+                "kind": "loop",
+                "stop": {"budget": {"metric": "calls", "limit": 2, "breach_action": "stop", "mode": "hard"}},
+                "body": [
+                    {
+                        "id": "task",
+                        "kind": "unit",
+                        "spec": {"tool_ref": "cheap"},
+                    }
+                ],
+            }
+        ],
+    }
+
+    result = runner.run(spec, vars={})
+
+    assert result.status == "ok"
+    assert len(result.outputs["loop"]) == 2
+    stop_events = [evt for evt in writer.events if evt[0] == "budget_breach" and evt[1]["action"] == "stop"]
+    assert stop_events, "loop stop event missing"
+    assert result.outputs["loop"][0]["task"] == {"ok": True}


### PR DESCRIPTION
## Summary
- add canonical cost helpers and immutable budget domain models for budget enforcement
- implement a scope-aware BudgetManager, policy stack, and trace emitter for FlowRunner integration tests
- create a FlowRunner prototype with loop handling plus comprehensive phase-3 documentation and fixtures

## Testing
- pytest codex/code/work/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8a9d6c0cc832cad4bba842aaf9290