### PR TITLE
Implement FlowRunner budget guard integration

### DIFF
--- a/codex/DOCUMENTATION/P3/work-20250514T120000Z-gpt5codex.yaml
+++ b/codex/DOCUMENTATION/P3/work-20250514T120000Z-gpt5codex.yaml
@@ -1,0 +1,109 @@
+version: 1
+metadata:
+  task_id: 07b_budget_guards_and_runner_integration
+  phase: P3
+  branch: work
+  generated_at: 2025-05-14T12:00:00Z
+component:
+  name: FlowRunner Budget Guard Integration
+  purpose: >-
+    Enforces DSL budget scopes (run, loop, node, spec) within FlowRunner while emitting
+    structured trace events for observability and diagnostics.
+  cli_usage: >-
+    Imported as a library component; no direct CLI entrypoint. Integrate via FlowRunner
+    invocation in DSL execution pipelines.
+interfaces:
+  public:
+    - name: BudgetSpec.from_dict
+      type: factory
+      description: Parse raw budget dictionaries into immutable specifications.
+      parameters:
+        - name: data
+          type: Mapping[str, Any]
+          required: true
+      returns: BudgetSpec
+    - name: CostSnapshot.from_costs
+      type: factory
+      description: Normalise heterogeneous cost metrics to Decimal-backed snapshots.
+      parameters:
+        - name: costs
+          type: Mapping[str, Any]
+          required: true
+      returns: CostSnapshot
+    - name: BudgetManager.charge
+      type: method
+      description: Apply a cost to multiple scopes, returning structured outcomes and enforcing hard breaches.
+      parameters:
+        - name: scopes
+          type: Sequence[BudgetScope]
+          required: true
+        - name: cost
+          type: CostSnapshot
+          required: true
+      returns: List[BudgetChargeOutcome]
+      raises:
+        - name: BudgetBreachError
+          condition: Raised when any scope with `breach_action: error` exceeds its limit.
+    - name: FlowRunner.run
+      type: method
+      description: Execute looped flow definitions while coordinating adapters, budget enforcement, and trace emission.
+      parameters:
+        - name: flow
+          type: FlowDefinition
+          required: true
+        - name: context
+          type: RunContext
+          required: true
+      returns: FlowResult
+  extension_hooks:
+    - name: TraceWriter
+      type: protocol
+      description: Custom sinks can implement `emit(event, payload)` to capture structured JSONL events.
+    - name: Adapter estimate/execute
+      type: protocol
+      description: Tool adapters must expose `estimate(node_id, iteration)` and `execute(node_id, iteration)` for deterministic cost control.
+configuration:
+  options:
+    - name: breach_action
+      scope: BudgetSpec
+      values: [error, warn, stop]
+      description: Controls enforcement mode for each budget scope.
+    - name: mode
+      scope: BudgetSpec
+      values: [hard, soft]
+      description: Determines default breach action (hard→error, soft→warn) unless overridden.
+automation_triggers:
+  - trigger: FlowRunner.run invoked
+    action: Emit `run_start` trace event and initialise budget tracking.
+  - trigger: Budget breach detected
+    action: Emit `budget_breach` trace, append stop reason or warning, and optionally halt execution.
+error_contracts:
+  - name: BudgetBreachError
+    type: RuntimeError
+    payload:
+      scope: BudgetScope (serialized)
+      outcome: BudgetChargeOutcome (includes overages, remaining, action)
+      outcomes: Sequence[BudgetChargeOutcome] | None
+    caller_actions:
+      - Inspect `outcome.action`; abort run when `error`, handle diagnostics otherwise.
+serialization:
+  formats:
+    - name: Trace payloads
+      format: JSON-compatible dicts with decimal values stringified for deterministic storage.
+lifecycle:
+  stages:
+    - initialise BudgetManager with static specs before run start.
+    - emit `run_start` → iterate loop nodes applying `charge` per iteration.
+    - on stop/warn, capture payload and continue/abort according to action.
+    - emit `run_end` with final status and stop reason.
+typing:
+  notes:
+    - All monetary/token/call metrics stored as `Decimal` to avoid floating rounding errors.
+    - Type hints rely on `Sequence` and `Mapping` to encourage deterministic inputs.
+security:
+  considerations:
+    - No external I/O; ensure adapters validated upstream to avoid executing arbitrary code.
+performance:
+  notes:
+    - CostSnapshot operations are O(n) over limited metric set (usd/tokens/calls) and negligible.
+    - Trace emission uses simple dict merges; no heavy serialization.

--- a/codex/TESTS/P3/work-20250514T120000Z-gpt5codex.yaml
+++ b/codex/TESTS/P3/work-20250514T120000Z-gpt5codex.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_flow_runner_policy_violation_precedence
+      rationale: Ensure policy violations and budget breaches occurring in the same iteration resolve stop reasons deterministically.
+      source_module: codex/code/work/runner/flow_runner.py
+      priority: high
+    - name: test_budget_manager_mixed_metrics_overflow
+      rationale: Validate simultaneous USD and token limits to guarantee metric-specific overages remain independent.
+      source_module: codex/code/work/runner/budget_manager.py
+      priority: medium
+    - name: test_trace_emitter_custom_writer_integration
+      rationale: Confirm custom TraceWriter implementations receive payloads without mutation, enabling streaming sinks.
+      source_module: codex/code/work/runner/trace.py
+      priority: low

--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -1,0 +1,1 @@
+"""Codex task automation package namespace."""

--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.md
@@ -1,0 +1,11 @@
+# Phase 3 Post-Execution — Budget Guards & FlowRunner Integration
+
+## Test Results
+- `pytest codex/code/work/tests -q` (pass) — validates budget manager limits and FlowRunner loop stop integration. 【b2ec7f†L1-L1】
+
+## Coverage & Gaps
+- Unit coverage exercises both hard/soft modes and preview path; integration test inspects trace payloads and stop reasons.
+- Remaining gap: no regression around policy-stack interactions or mixed policy/budget violations (captured in missing tests list).
+
+## Follow-ups
+- Package `codex` namespace for automatic discovery to remove explicit `sys.path` adjustments in tests.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.md
@@ -1,0 +1,15 @@
+# Phase 3 Preview — Budget Guards & FlowRunner Integration
+
+## Overview
+- Normalised budget domain objects (`BudgetSpec`, `CostSnapshot`, `BudgetChargeOutcome`) with deterministic math and immutable payloads.
+- Centralised `BudgetManager` orchestrating run/loop/node/spec scopes with preview + charge lifecycles and stop/warn semantics.
+- FlowRunner wiring adapters, budget manager, and trace emitter to halt loops on stop budgets, warn on soft breaches, and emit structured events.
+
+## Key Design Decisions
+- Treated `breach_action: stop` as inclusive (`remaining <= 0`) to stop loops exactly at the limit.
+- Propagated immutable trace payloads via `TraceEventEmitter` to satisfy JSONL schema expectations.
+- Captured hard-breach outcomes in `BudgetBreachError` to allow trace emission prior to aborting runs.
+
+## Test Strategy
+- Unit tests assert hard vs soft enforcement and preview immutability for `BudgetManager`.
+- Integration test runs FlowRunner through loop iterations verifying stop reasons, warnings, adapter execution counts, and trace events.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.md
@@ -1,0 +1,12 @@
+# Phase 3 Review — Budget Guards & FlowRunner Integration
+
+## Checklist
+- [x] Budget models convert numeric inputs to decimals and freeze payloads.
+- [x] `BudgetManager` enforces hard stop, loop stop, and soft warn semantics with preview immutability.
+- [x] FlowRunner emits `run_start`, `budget_charge`, `budget_breach`, and `run_end` events with scope metadata.
+- [x] Stop reason payloads include scope level, action, remaining, and overages.
+- [x] Tests cover hard breach exception, soft warning accumulation, and loop stop halting adapters.
+
+## Notes
+- Added `BudgetBreachError.outcomes` to recover partial outcomes for trace emission after hard stops.
+- Tests append repo root to `sys.path` to ensure importability when executed in isolation; revisit once repository packaging is standardised.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.yaml
@@ -1,0 +1,93 @@
+summary: "Phase 3 execution plan for FlowRunner budget guard integration"
+justification: >-
+  Consolidates prior branch strengths (fa0vm9 loop orchestration, zwi2ny trace writer,
+  pbdel9 remaining/overage math, qhq0jq budget modes) into a cohesive, test-driven
+  implementation that satisfies DSL budget scopes without regressing policy wiring.
+steps:
+  - order: 1
+    name: Define budget domain models
+    description: >-
+      Implement immutable cost snapshots, budget specs, and breach outcomes supporting
+      hierarchical scopes and deterministic math before orchestrating budgets.
+  - order: 2
+    name: Implement BudgetManager orchestration
+    description: >-
+      Coordinate run, loop, node, and spec scopes with preview/charge lifecycle and
+      trace-friendly outcomes, reusing normalized costs and breach semantics.
+  - order: 3
+    name: Integrate FlowRunner execution
+    description: >-
+      Wire adapters, loop control, and budget manager decisions to emit schema-compliant
+      trace events and stop reasons.
+  - order: 4
+    name: Validate via targeted tests
+    description: >-
+      Exercise unit coverage for BudgetManager and integration coverage for FlowRunner
+      budget stops, including soft-warn handling and loop stop conditions.
+modules:
+  - path: codex/code/work/runner/budget_models.py
+    role: Budget and cost dataclasses, enums, and normalization helpers.
+  - path: codex/code/work/runner/budget_manager.py
+    role: BudgetManager coordinating scopes, preview, and charge outcomes.
+  - path: codex/code/work/runner/trace.py
+    role: TraceWriter protocol and TraceEventEmitter utilities.
+  - path: codex/code/work/runner/flow_runner.py
+    role: FlowRunner integrating adapters, policies placeholder, and budget enforcement.
+  - path: codex/code/work/runner/__init__.py
+    role: Package exports for runner components.
+tests:
+  - path: codex/code/work/tests/test_budget_manager.py
+    coverage: >-
+      Validate run/node/spec scope interactions, hard vs soft breaches, and remaining/overage math.
+    mocks: None (pure BudgetManager logic).
+  - path: codex/code/work/tests/test_flow_runner_budget_integration.py
+    coverage: >-
+      Ensure FlowRunner emits trace events, halts on loop stop budgets, and records stop reasons
+      while propagating soft warnings.
+    mocks: Adapter doubles implementing estimate/execute.
+run_order:
+  - Write tests for budget models and manager.
+  - Write FlowRunner integration tests.
+  - Implement budget models and helpers.
+  - Implement BudgetManager.
+  - Implement trace utilities.
+  - Implement FlowRunner and adapters integration.
+  - Run pytest focused on new tests, then full suite segment if required.
+interfaces:
+  TraceWriter: emit(event: str, payload: Mapping[str, Any]) -> None
+  BudgetManager:
+    preview(scopes: Sequence[BudgetScope], cost: CostSnapshot) -> List[BudgetChargeOutcome]
+    charge(scopes: Sequence[BudgetScope], cost: CostSnapshot) -> List[BudgetChargeOutcome]
+    reset_loop(loop_id: str) -> None
+  FlowRunner.run(flow: FlowDefinition, context: RunContext) -> FlowResult
+  CostSnapshot: normalized(cost_dict) -> CostSnapshot
+  BudgetSpec: from_dict(data) -> BudgetSpec
+  TraceEventEmitter.emit_budget_charge(scope, outcome, context) -> None
+  TraceEventEmitter.emit_budget_breach(scope, outcome, context) -> None
+tdd_coverage_targets:
+  budget_models: 0.9
+  budget_manager: 0.95
+  flow_runner: 0.9
+review_checklist:
+  - Do tests cover both hard and soft budget scenarios?
+  - Are trace payloads immutable and schema-aligned?
+  - Is cost normalization consistent across scopes?
+  - Does FlowRunner stop reason reflect highest-priority breach?
+  - Are adapters/policy hooks easily swappable for future work?
+outputs:
+  plan: codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.yaml
+  tests:
+    - codex/code/work/tests/test_budget_manager.py
+    - codex/code/work/tests/test_flow_runner_budget_integration.py
+  modules:
+    - codex/code/work/runner/budget_models.py
+    - codex/code/work/runner/budget_manager.py
+    - codex/code/work/runner/trace.py
+    - codex/code/work/runner/flow_runner.py
+    - codex/code/work/runner/__init__.py
+  documentation:
+    - codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.md
+    - codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.md
+    - codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250514T120000Z-gpt5codex.md
+    - codex/DOCUMENTATION/P3/work-20250514T120000Z-gpt5codex.yaml
+  missing_tests: codex/TESTS/P3/work-20250514T120000Z-gpt5codex.yaml

--- a/codex/code/__init__.py
+++ b/codex/code/__init__.py
@@ -1,0 +1,1 @@
+"""Code artifacts generated during Codex tasks."""

--- a/codex/code/work/__init__.py
+++ b/codex/code/work/__init__.py
@@ -1,0 +1,1 @@
+"""Work-in-progress code namespace for the active branch."""

--- a/codex/code/work/runner/__init__.py
+++ b/codex/code/work/runner/__init__.py
@@ -1,0 +1,25 @@
+"""FlowRunner budget guard integration exports."""
+
+from .budget_manager import BudgetBreachError, BudgetManager
+from .budget_models import BudgetChargeOutcome, BudgetMode, BudgetScope, BudgetSpec, CostSnapshot
+from .flow_runner import FlowDefinition, FlowNode, FlowResult, FlowRunner, LoopDefinition, RunContext
+from .trace import InMemoryTraceWriter, TraceEventEmitter, TraceWriter
+
+__all__ = [
+    "BudgetBreachError",
+    "BudgetManager",
+    "BudgetChargeOutcome",
+    "BudgetMode",
+    "BudgetScope",
+    "BudgetSpec",
+    "CostSnapshot",
+    "FlowDefinition",
+    "FlowNode",
+    "FlowResult",
+    "FlowRunner",
+    "LoopDefinition",
+    "RunContext",
+    "InMemoryTraceWriter",
+    "TraceEventEmitter",
+    "TraceWriter",
+]

--- a/codex/code/work/runner/budget_manager.py
+++ b/codex/code/work/runner/budget_manager.py
@@ -1,0 +1,80 @@
+"""BudgetManager coordinating hierarchical scope enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Sequence
+
+from .budget_models import BudgetChargeOutcome, BudgetScope, BudgetSpec, CostSnapshot
+
+__all__ = ["BudgetBreachError", "BudgetManager"]
+
+
+@dataclass
+class BudgetBreachError(RuntimeError):
+    """Raised when a hard budget is exceeded."""
+
+    scope: BudgetScope
+    outcome: BudgetChargeOutcome
+    outcomes: Sequence[BudgetChargeOutcome] | None = None
+
+    def __post_init__(self) -> None:
+        message = (
+            f"Budget breached at {self.scope}: action={self.outcome.action} overages={dict(self.outcome.overages)}"
+        )
+        super().__init__(message)
+
+
+class BudgetManager:
+    """Manages budget scopes and evaluates charges."""
+
+    def __init__(self, *, budgets: Mapping[BudgetScope, BudgetSpec]):
+        self._specs: Dict[BudgetScope, BudgetSpec] = dict(budgets)
+        self._spent: MutableMapping[BudgetScope, CostSnapshot] = {
+            scope: CostSnapshot.zero() for scope in self._specs
+        }
+
+    def preview(self, scopes: Sequence[BudgetScope], cost: CostSnapshot) -> List[BudgetChargeOutcome]:
+        """Return outcomes without mutating internal state."""
+
+        outcomes: List[BudgetChargeOutcome] = []
+        for scope in scopes:
+            spec = self._require_scope(scope)
+            spent = self._spent.get(scope, CostSnapshot.zero()).add(cost)
+            outcomes.append(
+                BudgetChargeOutcome.build(scope=scope, spec=spec, cost=cost, spent=spent)
+            )
+        return outcomes
+
+    def charge(self, scopes: Sequence[BudgetScope], cost: CostSnapshot) -> List[BudgetChargeOutcome]:
+        """Apply a cost to multiple scopes and enforce hard breaches."""
+
+        outcomes: List[BudgetChargeOutcome] = []
+        hard_breach: BudgetBreachError | None = None
+        for scope in scopes:
+            spec = self._require_scope(scope)
+            current = self._spent.get(scope, CostSnapshot.zero())
+            updated = current.add(cost)
+            self._spent[scope] = updated
+            outcome = BudgetChargeOutcome.build(scope=scope, spec=spec, cost=cost, spent=updated)
+            outcomes.append(outcome)
+            if outcome.breached and outcome.action == "error" and hard_breach is None:
+                hard_breach = BudgetBreachError(scope=scope, outcome=outcome)
+        if hard_breach is not None:
+            hard_breach.outcomes = tuple(outcomes)
+            raise hard_breach
+        return outcomes
+
+    def reset_loop(self, scope: BudgetScope) -> None:
+        """Reset loop spend when a new loop instance starts."""
+
+        if scope in self._specs:
+            self._spent[scope] = CostSnapshot.zero()
+
+    def _require_scope(self, scope: BudgetScope) -> BudgetSpec:
+        if scope not in self._specs:
+            raise KeyError(f"Unknown budget scope: {scope}")
+        return self._specs[scope]
+
+    def spent(self, scope: BudgetScope) -> CostSnapshot:
+        return self._spent.get(scope, CostSnapshot.zero())

--- a/codex/code/work/runner/budget_models.py
+++ b/codex/code/work/runner/budget_models.py
@@ -1,0 +1,208 @@
+"""Budget domain models for FlowRunner integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import Enum
+from types import MappingProxyType
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional, Tuple
+
+__all__ = [
+    "BudgetMode",
+    "BudgetScope",
+    "BudgetSpec",
+    "BudgetChargeOutcome",
+    "CostSnapshot",
+]
+
+
+class BudgetMode(str, Enum):
+    """Modes supported by budget specifications."""
+
+    HARD = "hard"
+    SOFT = "soft"
+
+
+_LIMIT_KEYS = {
+    "usd": "max_usd",
+    "tokens": "max_tokens",
+    "calls": "max_calls",
+}
+
+
+def _to_decimal(value: object) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if isinstance(value, str):
+        return Decimal(value)
+    raise TypeError(f"Unsupported numeric value: {value!r}")
+
+
+@dataclass(frozen=True)
+class CostSnapshot:
+    """Immutable representation of metered costs."""
+
+    _values: Mapping[str, Decimal] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        normalized: Dict[str, Decimal] = {metric: _to_decimal(amount) for metric, amount in self._values.items()}
+        for key in _LIMIT_KEYS:
+            normalized.setdefault(key, Decimal("0"))
+        object.__setattr__(self, "_values", MappingProxyType(normalized))
+
+    @classmethod
+    def from_costs(cls, costs: Mapping[str, object]) -> "CostSnapshot":
+        return cls(costs)
+
+    @classmethod
+    def zero(cls) -> "CostSnapshot":
+        return cls({})
+
+    def as_dict(self) -> Mapping[str, Decimal]:
+        return self._values
+
+    def get(self, metric: str) -> Decimal:
+        return self._values.get(metric, Decimal("0"))
+
+    @property
+    def usd(self) -> Decimal:
+        return self.get("usd")
+
+    @property
+    def tokens(self) -> Decimal:
+        return self.get("tokens")
+
+    @property
+    def calls(self) -> Decimal:
+        return self.get("calls")
+
+    def add(self, other: "CostSnapshot") -> "CostSnapshot":
+        merged: Dict[str, Decimal] = {}
+        for key in set(self._values) | set(other._values):
+            merged[key] = self.get(key) + other.get(key)
+        return CostSnapshot(merged)
+
+
+@dataclass(frozen=True)
+class BudgetScope:
+    """Identifies the logical scope of a budget."""
+
+    level: str
+    identifier: Tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> Mapping[str, object]:
+        return {"level": self.level, "identifier": list(self.identifier)}
+
+    @classmethod
+    def run(cls, run_id: str) -> "BudgetScope":
+        return cls(level="run", identifier=(run_id,))
+
+    @classmethod
+    def loop(cls, loop_id: str) -> "BudgetScope":
+        return cls(level="loop", identifier=(loop_id,))
+
+    @classmethod
+    def node(cls, node_id: str) -> "BudgetScope":
+        return cls(level="node", identifier=(node_id,))
+
+    @classmethod
+    def spec(cls, node_id: str, spec_name: str) -> "BudgetScope":
+        return cls(level="spec", identifier=(node_id, spec_name))
+
+    def __str__(self) -> str:  # pragma: no cover - debug helper
+        return f"{self.level}:{'/'.join(self.identifier)}"
+
+
+@dataclass(frozen=True)
+class BudgetSpec:
+    """Configuration for a budget scope."""
+
+    mode: BudgetMode
+    limits: Mapping[str, Decimal]
+    breach_action: str
+    name: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "BudgetSpec":
+        mode = BudgetMode(str(data.get("mode", BudgetMode.HARD.value)))
+        breach_action = str(data.get("breach_action", "warn" if mode is BudgetMode.SOFT else "error"))
+        limits: Dict[str, Decimal] = {}
+        for metric, key in _LIMIT_KEYS.items():
+            if key in data and data[key] is not None:
+                limits[metric] = _to_decimal(data[key])
+        return cls(mode=mode, limits=MappingProxyType(limits), breach_action=breach_action, name=str(data.get("name")) if data.get("name") else None)
+
+    def has_limit(self, metric: str) -> bool:
+        return metric in self.limits
+
+    def limit_for(self, metric: str) -> Optional[Decimal]:
+        return self.limits.get(metric)
+
+
+@dataclass(frozen=True)
+class BudgetChargeOutcome:
+    """Result of charging a budget scope."""
+
+    scope: BudgetScope
+    spec: BudgetSpec
+    cost: CostSnapshot
+    spent: CostSnapshot
+    remaining: Mapping[str, Decimal]
+    overages: Mapping[str, Decimal]
+    breached: bool
+    action: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        scope: BudgetScope,
+        spec: BudgetSpec,
+        cost: CostSnapshot,
+        spent: CostSnapshot,
+    ) -> "BudgetChargeOutcome":
+        remaining: MutableMapping[str, Decimal] = {}
+        overages: MutableMapping[str, Decimal] = {}
+        breached = False
+        for metric in _LIMIT_KEYS:
+            limit = spec.limit_for(metric)
+            value = spent.get(metric)
+            if limit is None:
+                continue
+            remaining_value = limit - value
+            remaining[metric] = remaining_value
+            breach_here = remaining_value < 0
+            if spec.breach_action == "stop" and remaining_value <= 0:
+                breach_here = True
+            if breach_here:
+                breached = True
+                overages[metric] = -remaining_value if remaining_value < 0 else Decimal("0")
+            else:
+                overages[metric] = Decimal("0")
+        outcome_action = spec.breach_action if breached else "none"
+        return cls(
+            scope=scope,
+            spec=spec,
+            cost=cost,
+            spent=spent,
+            remaining=MappingProxyType(dict(remaining)),
+            overages=MappingProxyType(dict(overages)),
+            breached=breached,
+            action=outcome_action,
+        )
+
+    def to_trace_payload(self) -> Mapping[str, object]:
+        return {
+            "scope": self.scope.as_dict(),
+            "cost": {k: str(v) for k, v in self.cost.as_dict().items()},
+            "spent": {k: str(v) for k, v in self.spent.as_dict().items()},
+            "remaining": {k: str(v) for k, v in self.remaining.items()},
+            "overages": {k: str(v) for k, v in self.overages.items()},
+            "breached": self.breached,
+            "action": self.action,
+            "mode": self.spec.mode.value,
+            "name": self.spec.name,
+        }

--- a/codex/code/work/runner/flow_runner.py
+++ b/codex/code/work/runner/flow_runner.py
@@ -1,0 +1,178 @@
+"""FlowRunner integrating budget guards and trace emission."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, MutableMapping, Sequence
+
+from .budget_manager import BudgetBreachError, BudgetManager
+from .budget_models import BudgetChargeOutcome, BudgetScope
+from .trace import TraceEventEmitter
+
+__all__ = [
+    "FlowNode",
+    "LoopDefinition",
+    "FlowDefinition",
+    "RunContext",
+    "FlowResult",
+    "FlowRunner",
+]
+
+
+@dataclass(frozen=True)
+class FlowNode:
+    node_id: str
+    adapter_id: str
+    scopes: Sequence[BudgetScope]
+
+
+@dataclass(frozen=True)
+class LoopDefinition:
+    loop_id: str
+    scope: BudgetScope | None
+    iterations: int
+    nodes: Sequence[FlowNode]
+
+
+@dataclass(frozen=True)
+class FlowDefinition:
+    flow_id: str
+    run_scope: BudgetScope
+    loop: LoopDefinition
+
+
+@dataclass(frozen=True)
+class RunContext:
+    flow_id: str
+    run_id: str
+
+
+@dataclass
+class FlowResult:
+    status: str
+    iterations_executed: int
+    stop_reason: Mapping[str, object] | None
+    warnings: List[Mapping[str, object]]
+
+
+class FlowRunner:
+    """Executes a FlowDefinition while enforcing budgets."""
+
+    def __init__(
+        self,
+        *,
+        budget_manager: BudgetManager,
+        trace_emitter: TraceEventEmitter,
+        adapters: Mapping[str, object],
+    ) -> None:
+        self._budget_manager = budget_manager
+        self._trace = trace_emitter
+        self._adapters: Dict[str, object] = dict(adapters)
+
+    def run(self, flow: FlowDefinition, context: RunContext) -> FlowResult:
+        self._trace.emit_run_event("run_start", flow_id=context.flow_id, run_id=context.run_id)
+        warnings: List[Mapping[str, object]] = []
+        stop_reason: Mapping[str, object] | None = None
+        iterations_executed = 0
+        loop = flow.loop
+        for iteration in range(loop.iterations):
+            for node in loop.nodes:
+                adapter = self._adapter_for(node.adapter_id)
+                estimate = adapter.estimate(node_id=node.node_id, iteration=iteration)
+                scopes: List[BudgetScope] = [flow.run_scope]
+                if loop.scope is not None:
+                    scopes.append(loop.scope)
+                scopes.extend(node.scopes)
+                context_payload = self._context_payload(context, loop, node, iteration)
+                try:
+                    outcomes = self._budget_manager.charge(scopes, estimate)
+                except BudgetBreachError as error:
+                    outcomes = list(error.outcomes or [])
+                    for outcome in outcomes:
+                        self._trace.emit_budget_charge(outcome=outcome, context=context_payload)
+                    breach_outcome = error.outcome
+                    self._trace.emit_budget_breach(outcome=breach_outcome, context=context_payload)
+                    stop_reason = self._stop_payload("budget_hard_breach", breach_outcome, context_payload)
+                    self._trace.emit_run_event(
+                        "run_end",
+                        flow_id=context.flow_id,
+                        run_id=context.run_id,
+                        status="failed",
+                        stop_reason=stop_reason,
+                    )
+                    return FlowResult(
+                        status="failed",
+                        iterations_executed=iterations_executed,
+                        stop_reason=stop_reason,
+                        warnings=warnings,
+                    )
+                else:
+                    for outcome in outcomes:
+                        self._trace.emit_budget_charge(outcome=outcome, context=context_payload)
+                        if outcome.breached:
+                            self._trace.emit_budget_breach(outcome=outcome, context=context_payload)
+                            if outcome.action == "warn":
+                                payload = self._stop_payload("budget_soft_breach", outcome, context_payload)
+                                warnings.append(payload)
+                            elif outcome.action == "stop" and stop_reason is None:
+                                payload = self._stop_payload("budget_loop_stop", outcome, context_payload)
+                                stop_reason = payload
+                    adapter.execute(node_id=node.node_id, iteration=iteration)
+            iterations_executed += 1
+            if stop_reason is not None:
+                break
+        status = "stopped" if stop_reason else "completed"
+        self._trace.emit_run_event(
+            "run_end",
+            flow_id=context.flow_id,
+            run_id=context.run_id,
+            status=status,
+            stop_reason=stop_reason,
+        )
+        return FlowResult(
+            status=status,
+            iterations_executed=iterations_executed,
+            stop_reason=stop_reason,
+            warnings=warnings,
+        )
+
+    def _adapter_for(self, adapter_id: str) -> object:
+        try:
+            return self._adapters[adapter_id]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise KeyError(f"Missing adapter: {adapter_id}") from exc
+
+    def _context_payload(
+        self,
+        context: RunContext,
+        loop: LoopDefinition,
+        node: FlowNode,
+        iteration: int,
+    ) -> MutableMapping[str, object]:
+        return {
+            "flow_id": context.flow_id,
+            "run_id": context.run_id,
+            "loop_id": loop.loop_id,
+            "loop_iteration": iteration,
+            "node_id": node.node_id,
+            "adapter_id": node.adapter_id,
+        }
+
+    def _stop_payload(
+        self,
+        reason: str,
+        outcome: BudgetChargeOutcome,
+        context_payload: Mapping[str, object],
+    ) -> MutableMapping[str, object]:
+        payload: MutableMapping[str, object] = {
+            "reason": reason,
+            "scope": outcome.scope.as_dict(),
+            "action": outcome.action,
+            "overages": {metric: str(amount) for metric, amount in outcome.overages.items()},
+            "remaining": {metric: str(amount) for metric, amount in outcome.remaining.items()},
+            "context": {
+                "node_id": context_payload["node_id"],
+                "loop_iteration": context_payload["loop_iteration"],
+            },
+        }
+        return payload

--- a/codex/code/work/runner/trace.py
+++ b/codex/code/work/runner/trace.py
@@ -1,0 +1,58 @@
+"""Trace emission helpers for FlowRunner budget integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Mapping, MutableMapping, Protocol
+
+from .budget_models import BudgetChargeOutcome
+
+
+class TraceWriter(Protocol):
+    """Protocol describing the trace sink used by the runner."""
+
+    def emit(self, event: str, payload: Mapping[str, object]) -> None:  # pragma: no cover - protocol
+        ...
+
+
+@dataclass
+class InMemoryTraceWriter:
+    """Simple TraceWriter used by unit tests."""
+
+    events: List[MutableMapping[str, object]] = field(default_factory=list)
+
+    def emit(self, event: str, payload: Mapping[str, object]) -> None:
+        entry: MutableMapping[str, object] = {"event": event}
+        entry.update(payload)
+        self.events.append(entry)
+
+
+class TraceEventEmitter:
+    """Formats structured events for budget charges and breaches."""
+
+    def __init__(self, writer: TraceWriter):
+        self._writer = writer
+
+    def emit_run_event(self, event: str, *, flow_id: str, run_id: str, **extra: object) -> None:
+        payload = {"flow_id": flow_id, "run_id": run_id}
+        if extra:
+            payload.update(extra)
+        self._writer.emit(event, payload)
+
+    def emit_budget_charge(
+        self,
+        *,
+        outcome: BudgetChargeOutcome,
+        context: Mapping[str, object],
+    ) -> None:
+        payload = {**context, **outcome.to_trace_payload()}
+        self._writer.emit("budget_charge", payload)
+
+    def emit_budget_breach(
+        self,
+        *,
+        outcome: BudgetChargeOutcome,
+        context: Mapping[str, object],
+    ) -> None:
+        payload = {**context, **outcome.to_trace_payload()}
+        self._writer.emit("budget_breach", payload)

--- a/codex/code/work/tests/test_budget_manager.py
+++ b/codex/code/work/tests/test_budget_manager.py
@@ -1,0 +1,104 @@
+import decimal
+import pathlib
+import sys
+from typing import Sequence
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[4]))
+
+import pytest
+
+from codex.code.work.runner.budget_manager import BudgetBreachError, BudgetManager
+from codex.code.work.runner.budget_models import (
+    BudgetScope,
+    BudgetSpec,
+    BudgetChargeOutcome,
+    CostSnapshot,
+)
+
+
+@pytest.fixture
+def run_scope() -> BudgetScope:
+    return BudgetScope.run("run-123")
+
+
+@pytest.fixture
+def node_scope() -> BudgetScope:
+    return BudgetScope.node("node-alpha")
+
+
+@pytest.fixture
+def spec_scope() -> BudgetScope:
+    return BudgetScope.spec("node-alpha", "completion")
+
+
+@pytest.fixture
+def budget_manager(run_scope: BudgetScope, node_scope: BudgetScope, spec_scope: BudgetScope) -> BudgetManager:
+    budgets = {
+        run_scope: BudgetSpec.from_dict({"mode": "hard", "max_usd": "5.00", "max_calls": 10}),
+        node_scope: BudgetSpec.from_dict({"mode": "hard", "max_usd": "3.00", "max_calls": 4}),
+        spec_scope: BudgetSpec.from_dict({"mode": "soft", "max_tokens": 120, "breach_action": "warn"}),
+    }
+    return BudgetManager(budgets=budgets)
+
+
+def collect_metric(outcomes: Sequence[BudgetChargeOutcome], scope: BudgetScope, key: str) -> decimal.Decimal:
+    for outcome in outcomes:
+        if outcome.scope == scope:
+            return outcome.remaining[key]
+    raise AssertionError(f"Scope {scope} not found in outcomes")
+
+
+def test_hard_budget_enforces_stop(budget_manager: BudgetManager, run_scope: BudgetScope, node_scope: BudgetScope) -> None:
+    cost = CostSnapshot.from_costs({"usd": "2.00", "calls": 1})
+    outcomes = budget_manager.charge([run_scope, node_scope], cost)
+    assert not any(outcome.breached for outcome in outcomes)
+    assert collect_metric(outcomes, node_scope, "usd") == decimal.Decimal("1.00")
+
+    # Second charge should breach the node hard limit (3 USD total)
+    with pytest.raises(BudgetBreachError) as exc_info:
+        budget_manager.charge([run_scope, node_scope], cost)
+
+    error = exc_info.value
+    assert error.outcome.scope == node_scope
+    assert error.outcome.breached is True
+    assert error.outcome.action == "error"
+    assert error.outcome.overages["usd"] == decimal.Decimal("1.00")
+
+    # Run scope should still have recorded the spend even after the exception
+    preview = budget_manager.preview([run_scope], CostSnapshot.zero())
+    assert collect_metric(preview, run_scope, "usd") == decimal.Decimal("1.00")
+
+
+def test_soft_budget_warns_and_tracks_overage(
+    budget_manager: BudgetManager,
+    run_scope: BudgetScope,
+    node_scope: BudgetScope,
+    spec_scope: BudgetScope,
+) -> None:
+    big_cost = CostSnapshot.from_costs({"tokens": 140})
+    outcomes = budget_manager.charge([run_scope, node_scope, spec_scope], big_cost)
+    spec_outcome = next(outcome for outcome in outcomes if outcome.scope == spec_scope)
+
+    assert spec_outcome.breached is True
+    assert spec_outcome.action == "warn"
+    assert spec_outcome.overages["tokens"] == decimal.Decimal(20)
+
+    # Additional charge should accumulate overage without raising
+    more_cost = CostSnapshot.from_costs({"tokens": 10})
+    more_outcomes = budget_manager.charge([run_scope, spec_scope], more_cost)
+    spec_outcome = next(outcome for outcome in more_outcomes if outcome.scope == spec_scope)
+    assert spec_outcome.overages["tokens"] == decimal.Decimal(30)
+
+
+def test_preview_does_not_mutate_state(budget_manager: BudgetManager, run_scope: BudgetScope) -> None:
+    preview_cost = CostSnapshot.from_costs({"usd": "1.00"})
+    preview = budget_manager.preview([run_scope], preview_cost)
+    outcome = preview[0]
+    assert outcome.cost.usd == decimal.Decimal("1.00")
+    assert outcome.breached is False
+
+    # After preview, a real charge should see the original limit
+    budget_manager.charge([run_scope], CostSnapshot.from_costs({"usd": "1.00"}))
+    updated = budget_manager.preview([run_scope], CostSnapshot.zero())
+    outcome = updated[0]
+    assert outcome.remaining["usd"] == decimal.Decimal("4.00")

--- a/codex/code/work/tests/test_flow_runner_budget_integration.py
+++ b/codex/code/work/tests/test_flow_runner_budget_integration.py
@@ -1,0 +1,100 @@
+import decimal
+import pathlib
+import sys
+from dataclasses import dataclass
+from typing import Dict, List
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[4]))
+
+import pytest
+
+from codex.code.work.runner.budget_manager import BudgetManager
+from codex.code.work.runner.budget_models import BudgetScope, BudgetSpec, CostSnapshot
+from codex.code.work.runner.flow_runner import FlowDefinition, FlowNode, FlowRunner, LoopDefinition, RunContext
+from codex.code.work.runner.trace import InMemoryTraceWriter, TraceEventEmitter
+
+
+@dataclass
+class CountingAdapter:
+    costs: List[CostSnapshot]
+    executed: int = 0
+
+    def estimate(self, *, node_id: str, iteration: int) -> CostSnapshot:
+        return self.costs[min(iteration, len(self.costs) - 1)]
+
+    def execute(self, *, node_id: str, iteration: int) -> Dict[str, str]:
+        self.executed += 1
+        return {"node_id": node_id, "iteration": str(iteration)}
+
+
+@pytest.fixture
+def adapters() -> Dict[str, CountingAdapter]:
+    costs = [
+        CostSnapshot.from_costs({"usd": "0.40", "tokens": 30, "calls": 1}),
+        CostSnapshot.from_costs({"usd": "0.40", "tokens": 30, "calls": 1}),
+        CostSnapshot.from_costs({"usd": "0.40", "tokens": 30, "calls": 1}),
+    ]
+    return {"completion": CountingAdapter(costs=costs)}
+
+
+@pytest.fixture
+def flow_definition() -> FlowDefinition:
+    run_scope = BudgetScope.run("run-budget")
+    loop_scope = BudgetScope.loop("loop-budget")
+    node_scope = BudgetScope.node("node-alpha")
+    spec_scope = BudgetScope.spec("node-alpha", "completion")
+
+    node = FlowNode(node_id="node-alpha", adapter_id="completion", scopes=[node_scope, spec_scope])
+    loop = LoopDefinition(loop_id="loop-budget", scope=loop_scope, iterations=4, nodes=[node])
+    return FlowDefinition(flow_id="demo-flow", run_scope=run_scope, loop=loop)
+
+
+@pytest.fixture
+def budget_manager(flow_definition: FlowDefinition) -> BudgetManager:
+    run_spec = BudgetSpec.from_dict({"mode": "hard", "max_calls": 6, "max_usd": "3.00"})
+    loop_spec = BudgetSpec.from_dict({"mode": "hard", "max_calls": 2, "breach_action": "stop"})
+    node_spec = BudgetSpec.from_dict({"mode": "hard", "max_calls": 4})
+    spec_soft = BudgetSpec.from_dict({"mode": "soft", "max_tokens": 50, "breach_action": "warn"})
+    budgets = {
+        flow_definition.run_scope: run_spec,
+        flow_definition.loop.scope: loop_spec,
+        flow_definition.loop.nodes[0].scopes[0]: node_spec,
+        flow_definition.loop.nodes[0].scopes[1]: spec_soft,
+    }
+    return BudgetManager(budgets=budgets)
+
+
+def test_runner_stops_on_loop_budget_and_warns_on_spec(
+    adapters: Dict[str, CountingAdapter],
+    flow_definition: FlowDefinition,
+    budget_manager: BudgetManager,
+) -> None:
+    writer = InMemoryTraceWriter()
+    emitter = TraceEventEmitter(writer)
+    runner = FlowRunner(budget_manager=budget_manager, trace_emitter=emitter, adapters=adapters)
+
+    context = RunContext(flow_id="demo-flow", run_id="run-001")
+    result = runner.run(flow_definition, context)
+
+    assert result.status == "stopped"
+    assert result.iterations_executed == 2
+    assert result.stop_reason is not None
+    assert result.stop_reason["scope"]["level"] == "loop"
+    assert result.stop_reason["action"] == "stop"
+
+    warnings = result.warnings
+    assert len(warnings) == 1
+    assert warnings[0]["scope"]["level"] == "spec"
+    assert decimal.Decimal(warnings[0]["overages"]["tokens"]) == decimal.Decimal(10)
+
+    # Trace should contain ordered budget charges and breach events
+    events = writer.events
+    budget_charge_events = [event for event in events if event["event"] == "budget_charge"]
+    budget_breach_events = [event for event in events if event["event"] == "budget_breach"]
+
+    assert any(event["scope"]["level"] == "loop" for event in budget_charge_events)
+    assert any(event["scope"]["level"] == "spec" for event in budget_breach_events)
+    assert any(event["action"] == "stop" for event in budget_breach_events)
+
+    # Adapter should only execute for iterations that completed
+    assert adapters["completion"].executed == 2


### PR DESCRIPTION
## Summary
- add immutable budget domain models with inclusive stop semantics for loop budgets
- implement a BudgetManager that coordinates run, loop, node, and spec scopes while exposing outcomes for tracing
- wire a FlowRunner with trace emission, adapter orchestration, and loop-stop handling plus targeted unit and integration tests

## Testing
- pytest codex/code/work/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8a9dc8530832c914a518a356b62ed