### PR TITLE
Add Phase 3 FlowRunner budget guard staging package

### DIFF
--- a/codex/DOCUMENTATION/P3/phase3_budget_runner_r7h3-20250510-gpt5codex.yaml
+++ b/codex/DOCUMENTATION/P3/phase3_budget_runner_r7h3-20250510-gpt5codex.yaml
@@ -1,0 +1,90 @@
+component:
+  name: phase3_budget_runner_r7h3
+  purpose: >-
+    Provides a canonical staging implementation of budget guards and FlowRunner integration,
+    consolidating normalization, budget orchestration, trace emission, and adapter execution loops.
+  cli_usage: []
+  public_interfaces:
+    - module: codex.code.phase3_budget_runner_r7h3.dsl.costs
+      exports:
+        - name: normalize_cost
+          description: Convert raw adapter estimates into canonical milliseconds/tokens metrics.
+        - name: combine_costs
+          description: Aggregate multiple cost mappings for cumulative arithmetic.
+        - name: subtract_costs
+          description: Compute remaining cost deltas when comparing limits vs. spend.
+    - module: codex.code.phase3_budget_runner_r7h3.dsl.budget
+      exports:
+        - name: BudgetSpec
+          description: Immutable scope budget with normalized limits and breach action.
+        - name: BudgetManager
+          description: Preview/commit orchestration for run/node/loop/spec scopes with immutable diagnostics.
+        - name: BudgetCheck
+          description: Preview outcome capturing allowed flag, dominant action, and per-scope statuses.
+        - name: BudgetChargeOutcome
+          description: Commit outcome reflecting remaining/overage mappings for trace emission.
+        - name: BudgetAction
+          description: Severity enum aligning with warn/stop/error semantics.
+        - name: BudgetBreachError
+          description: Exception raised when stop/error prevents execution.
+    - module: codex.code.phase3_budget_runner_r7h3.dsl.trace
+      exports:
+        - name: TraceWriter
+          description: Minimal emit interface expected by TraceEventEmitter.
+        - name: TraceEventEmitter
+          description: Emits immutable budget_charge/budget_breach/budget_commit payloads.
+    - module: codex.code.phase3_budget_runner_r7h3.dsl.runner
+      exports:
+        - name: FlowRunner
+          description: Executes FlowDefinition nodes via adapters with budget enforcement and trace emission.
+        - name: FlowDefinition
+          description: Immutable description of nodes participating in a run.
+        - name: NodeDefinition
+          description: Declares adapter binding, scope keys, and optional loop configuration for a node.
+        - name: LoopConfig
+          description: Loop metadata (max_iterations + scoped budgets) for iterative nodes.
+        - name: FlowRunResult
+          description: Structured result containing status, stop reason, and per-node outputs.
+        - name: FlowRunStatus
+          description: Enum representing completed/stopped/failed terminal states.
+  extension_hooks:
+    - name: ToolAdapter
+      type: protocol
+      description: Adapters implement estimate/execute to participate in FlowRunner.
+    - name: TraceWriter
+      type: protocol
+      description: Custom trace sinks can be injected by providing emit(event, payload).
+configurables:
+  budget_specs: >-
+    Mapping of scope identifiers to BudgetSpec instances controlling warn/stop/error semantics.
+  flow_scope_keys: >-
+    Default scope chain applied to every node executed by FlowRunner.
+  trace_clock: >-
+    Callable injected into TraceEventEmitter for deterministic timestamps (defaults provided by caller).
+automation_triggers:
+  - trigger: pytest codex/code/phase3_budget_runner_r7h3/tests -q
+    purpose: Validates cost normalization, budget manager semantics, and FlowRunner behaviours.
+error_contracts:
+  - exception: BudgetBreachError
+    raised_when: Preview indicates stop/error and commit is attempted or FlowRunner encounters hard breach.
+    mitigation: Handle exception to surface budget diagnostics and halt run gracefully.
+serialization:
+  trace_events: json-compatible
+  notes: Payloads use mapping proxies but remain JSON-serializable when converted by sinks.
+lifecycle:
+  initialization:
+    - BudgetManager constructed with canonical BudgetSpecs.
+    - FlowRunner created with adapters, BudgetManager, TraceEventEmitter, and flow scope keys.
+  runtime:
+    - FlowRunner previews budgets before each iteration, emits traces, commits allowed charges, and executes adapters.
+    - TraceEventEmitter records charge/breach/commit events per scope for observability pipelines.
+  shutdown:
+    - No persistent state beyond BudgetManager internal spend maps; callers may discard instances.
+typing_notes:
+  - All public dataclasses are frozen to encourage immutability.
+  - Cost mappings are coerced to floats to avoid integer rounding issues.
+security_notes:
+  - No external IO beyond injected TraceWriter; ensure writer sanitises payloads before persistence.
+performance_notes:
+  - Cost arithmetic operates on small dicts per scope; acceptable for synchronous runner usage.
+  - Trace emission duplicates payloads for breach events; sinks should handle lightweight payload copies efficiently.

--- a/codex/TESTS/P3/phase3_budget_runner_r7h3-20250510-gpt5codex.yaml
+++ b/codex/TESTS/P3/phase3_budget_runner_r7h3-20250510-gpt5codex.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_trace_payload_schema_validation
+      rationale: Ensure emitted trace payloads conform to the DSL schema (field names/types) using a validator.
+      source_module: codex/code/phase3_budget_runner_r7h3/dsl/trace.py
+      priority: medium
+    - name: test_flow_runner_policy_trace_interleaving
+      rationale: Validate that policy resolve/validate hooks emit corresponding trace events alongside budget events.
+      source_module: codex/code/phase3_budget_runner_r7h3/dsl/runner.py
+      priority: medium
+    - name: test_budget_manager_partial_metric_limits
+      rationale: Cover scenarios where limits omit metrics present in costs to confirm remaining values are unbounded.
+      source_module: codex/code/phase3_budget_runner_r7h3/dsl/budget.py
+      priority: low

--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.md
@@ -1,0 +1,14 @@
+# Post-Execution Report — 07b_budget_guards_and_runner_integration
+
+## Test Results
+- `pytest codex/code/phase3_budget_runner_r7h3/tests -q`
+  - Status: ✅
+  - Notes: 8 tests executed covering cost normalization, manager semantics, and FlowRunner loop/stop behaviours.
+
+## Coverage & Quality Notes
+- BudgetManager paths for warn/stop/error exercised with immutable snapshot assertions.
+- FlowRunner integration verifies trace emission order and stop reasons but does not yet validate policy trace payloads.
+
+## Follow-ups
+- Add fixtures validating trace payload schema against the DSL contract.
+- Extend normalization helpers for CPU/memory metrics when spec enumerates them.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.md
@@ -1,0 +1,14 @@
+# Phase 3 Preview — 07b_budget_guards_and_runner_integration
+
+## Overview
+- Established canonical staging package `codex.code.phase3_budget_runner_r7h3.dsl` with shared cost normalization, budget orchestration, trace emission, and runner wiring.
+- Budget model aligns with P2 synthesis: immutable `BudgetSpec`, `BudgetCheck`, `BudgetChargeOutcome`, and severity-aware `BudgetAction`.
+- Trace emitter wraps `TraceWriter` to produce deterministic `budget_charge`, `budget_breach`, and `budget_commit` payloads that include immutable mappings.
+
+## Test Strategy
+- Unit suite validates normalization semantics, warnings vs. stops/errors, multi-scope precedence, and immutability guarantees.
+- Integration tests execute FlowRunner through loop and single-shot paths with fake adapters, asserting trace sequencing and stop reasons for warn/stop/error paths.
+
+## Open Risks
+- Policy stack interactions limited to resolve/validate hooks; deeper policy trace coverage deferred.
+- Cost normalization currently handles time/tokens/requests; extending to spec-only metrics will require additional fixtures.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.md
@@ -1,0 +1,13 @@
+# Review Notes — 07b_budget_guards_and_runner_integration
+
+## Checklist
+- [x] Cost normalization converts seconds→milliseconds and preserves unknown metrics.
+- [x] BudgetManager preview/commit enforces warn/stop/error semantics with immutable diagnostics.
+- [x] FlowRunner calls adapters for every executed iteration and halts gracefully on stop/error outcomes.
+- [x] TraceEventEmitter emits `budget_charge`, `budget_breach`, and `budget_commit` with mapping-proxy payloads.
+- [x] Tests cover warn/stop/error, loop halting, multi-scope prioritisation, and trace sequencing.
+
+## Reviewer Notes
+- Policy stack hooks are minimally exercised; future work should assert policy trace outputs once available.
+- Current FlowRunner result payload aggregates node outputs but omits trace sink configuration—acceptable for Phase 3 staging.
+- Missing metrics (e.g., `cost_ms_cpu`) will require extending `normalize_cost` plus fixtures when spec expands.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.yaml
@@ -1,0 +1,62 @@
+summary: "Phase 3 integrates canonical budget manager and FlowRunner wiring with trace emission"
+justification: |
+  Previous phases concluded that we must merge the object-oriented BudgetManager from test-first branches
+  with the adapter-driven FlowRunner while retaining immutable telemetry. The plan consolidates cost
+  normalization, breach semantics, and trace emission so we can validate run/node/loop scopes with
+  deterministic fixtures before filling in the implementation.
+steps:
+  - name: finalise_cost_normalization
+    description: Implement shared helpers to convert adapter estimates into canonical millisecond/token costs.
+  - name: budget_manager_scopes
+    description: Build BudgetManager preview/commit lifecycle with immutable outcomes for run/node/loop/spec scopes.
+  - name: trace_emitter_contract
+    description: Provide TraceEventEmitter that decorates TraceWriter to emit schema-compliant budget events.
+  - name: runner_integration
+    description: Wire FlowRunner to use adapters, BudgetManager, and TraceEventEmitter while respecting policy placeholders.
+modules:
+  - path: codex/code/phase3_budget_runner_r7h3/dsl/costs.py
+    role: Canonical cost normalization utilities shared across manager and runner.
+  - path: codex/code/phase3_budget_runner_r7h3/dsl/budget.py
+    role: Budget dataclasses, BudgetMode enum, BudgetManager orchestration, and outcome objects.
+  - path: codex/code/phase3_budget_runner_r7h3/dsl/trace.py
+    role: TraceWriter protocol and TraceEventEmitter responsible for immutable payload emission.
+  - path: codex/code/phase3_budget_runner_r7h3/dsl/runner.py
+    role: FlowRunner facade coordinating adapters, policy hooks, and budget enforcement with traces.
+tests:
+  - path: codex/code/phase3_budget_runner_r7h3/tests/test_costs_and_manager.py
+    coverage: Validate normalization edge cases, BudgetManager warnings/stops/errors, and immutable outcomes.
+    mocks: Use fake clock/id factories and stub TraceWriter.
+  - path: codex/code/phase3_budget_runner_r7h3/tests/test_flow_runner_budget_integration.py
+    coverage: Exercise FlowRunner across loop iterations, soft/hard breaches, and trace sequencing with fake adapters.
+    mocks: Provide deterministic adapters and policy stack double.
+run_order:
+  - pytest codex/code/phase3_budget_runner_r7h3/tests/test_costs_and_manager.py
+  - pytest codex/code/phase3_budget_runner_r7h3/tests/test_flow_runner_budget_integration.py
+interfaces:
+  - name: TraceWriter
+    contract: emit(event: str, payload: Mapping[str, Any]) -> None returning immediately.
+  - name: ToolAdapter
+    contract: estimate(context) -> Mapping[str, float]; execute(context) -> Dict[str, Any].
+  - name: BudgetManager
+    contract: preview(scope, cost) -> BudgetCheck; commit(scope, cost, metadata) -> BudgetChargeOutcome.
+tdd_coverage_targets:
+  - module: dsl/budget.py
+    threshold: 0.85
+  - module: dsl/runner.py
+    threshold: 0.8
+review_checklist:
+  - Ensure cost normalization enforces milliseconds and immutable payloads.
+  - Verify BudgetManager handles warn/stop/error consistently and exposes diagnostics.
+  - Confirm FlowRunner emits budget_charge and budget_breach events in deterministic order.
+  - Validate adapters are exercised in tests (no mocks bypassing lifecycle).
+outputs:
+  costs_module: codex/code/phase3_budget_runner_r7h3/dsl/costs.py
+  budget_module: codex/code/phase3_budget_runner_r7h3/dsl/budget.py
+  trace_module: codex/code/phase3_budget_runner_r7h3/dsl/trace.py
+  runner_module: codex/code/phase3_budget_runner_r7h3/dsl/runner.py
+  tests_primary: codex/code/phase3_budget_runner_r7h3/tests/
+  documentation_preview: codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.md
+  documentation_review: codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.md
+  documentation_postexecution: codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250510-gpt5codex.md
+  developer_metadata: codex/DOCUMENTATION/P3/phase3_budget_runner_r7h3-20250510-gpt5codex.yaml
+  missing_tests: codex/TESTS/P3/phase3_budget_runner_r7h3-20250510-gpt5codex.yaml

--- a/codex/code/__init__.py
+++ b/codex/code/__init__.py
@@ -1,0 +1,1 @@
+"""Staging packages produced during Codex automation phases."""

--- a/codex/code/phase3_budget_runner_r7h3/dsl/__init__.py
+++ b/codex/code/phase3_budget_runner_r7h3/dsl/__init__.py
@@ -1,0 +1,5 @@
+"""DSL staging package for phase 3 budget runner integration."""
+
+from . import budget, costs, runner, trace  # noqa: F401
+
+__all__ = ["budget", "costs", "runner", "trace"]

--- a/codex/code/phase3_budget_runner_r7h3/dsl/budget.py
+++ b/codex/code/phase3_budget_runner_r7h3/dsl/budget.py
@@ -1,0 +1,180 @@
+"""Budget domain objects and orchestration for FlowRunner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Dict, Mapping, Sequence, Tuple
+
+from . import costs
+
+
+class BudgetBreachError(RuntimeError):
+    """Raised when a budget breach prevents execution."""
+
+    def __init__(self, check: "BudgetCheck", message: str | None = None) -> None:
+        self.check = check
+        super().__init__(message or f"Budget breach: {check.action.value}")
+
+
+class BudgetAction(Enum):
+    """Represents the dominant action to take after a budget evaluation."""
+
+    ALLOW = "allow"
+    WARN = "warn"
+    STOP = "stop"
+    ERROR = "error"
+
+    @classmethod
+    def from_breach_action(cls, breach_action: str) -> "BudgetAction":
+        mapping = {
+            "warn": cls.WARN,
+            "stop": cls.STOP,
+            "error": cls.ERROR,
+        }
+        try:
+            return mapping[breach_action]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(f"Unsupported breach_action: {breach_action}") from exc
+
+
+@dataclass(frozen=True)
+class BudgetSpec:
+    """Immutable definition of a budget for a given scope."""
+
+    scope: str
+    limits: Mapping[str, float]
+    breach_action: str = "error"
+
+    def __post_init__(self) -> None:
+        normalized = costs.normalize_cost(self.limits)
+        object.__setattr__(self, "limits", MappingProxyType(dict(normalized)))
+        if self.breach_action not in {"warn", "stop", "error"}:
+            raise ValueError(f"Unsupported breach_action: {self.breach_action}")
+
+
+@dataclass(frozen=True)
+class ScopeBudgetStatus:
+    """Diagnostic information for a single scope during preview/commit."""
+
+    scope: str
+    breached: bool
+    action: BudgetAction
+    remaining: MappingProxyType[str, float]
+    overages: MappingProxyType[str, float]
+
+
+@dataclass(frozen=True)
+class BudgetCheck:
+    """Result of previewing a cost against one or more budget scopes."""
+
+    allowed: bool
+    action: BudgetAction
+    charge: MappingProxyType[str, float]
+    scope_statuses: Tuple[ScopeBudgetStatus, ...]
+
+
+@dataclass(frozen=True)
+class BudgetChargeOutcome:
+    """Result after successfully committing a cost to the manager."""
+
+    allowed: bool
+    action: BudgetAction
+    charge: MappingProxyType[str, float]
+    remaining: MappingProxyType[str, float]
+    overages: MappingProxyType[str, float]
+    scope_statuses: Tuple[ScopeBudgetStatus, ...]
+
+
+class BudgetManager:
+    """Coordinates budget scopes and exposes preview/commit APIs."""
+
+    def __init__(self, specs: Mapping[str, BudgetSpec]) -> None:
+        self._specs: Dict[str, BudgetSpec] = dict(specs)
+        self._spent: Dict[str, Dict[str, float]] = {scope: {} for scope in self._specs}
+
+    def preview(self, scopes: Sequence[str], cost: Mapping[str, float | int]) -> BudgetCheck:
+        normalized = costs.normalize_cost(cost)
+        charge_proxy = MappingProxyType(dict(normalized))
+        statuses = []
+        dominant_action = BudgetAction.ALLOW
+        severity = {BudgetAction.ALLOW: 0, BudgetAction.WARN: 1, BudgetAction.STOP: 2, BudgetAction.ERROR: 3}
+
+        for scope in scopes:
+            spec = self._specs.get(scope)
+            if spec is None:
+                status = ScopeBudgetStatus(
+                    scope=scope,
+                    breached=False,
+                    action=BudgetAction.ALLOW,
+                    remaining=MappingProxyType({}),
+                    overages=MappingProxyType({}),
+                )
+                statuses.append(status)
+                continue
+
+            spent = self._spent.setdefault(scope, {})
+            new_totals = costs.combine_costs([spent, normalized])
+            remaining: Dict[str, float] = {}
+            overages: Dict[str, float] = {}
+            breached = False
+            for metric, limit in spec.limits.items():
+                value = new_totals.get(metric, 0.0)
+                remaining_value = max(limit - value, 0.0)
+                remaining[metric] = remaining_value
+                overage_value = max(value - limit, 0.0)
+                if overage_value > 0:
+                    breached = True
+                    overages[metric] = overage_value
+            action = BudgetAction.from_breach_action(spec.breach_action) if breached else BudgetAction.ALLOW
+            statuses.append(
+                ScopeBudgetStatus(
+                    scope=scope,
+                    breached=breached,
+                    action=action,
+                    remaining=MappingProxyType(dict(remaining)),
+                    overages=MappingProxyType(dict(overages)),
+                )
+            )
+            if action is not BudgetAction.ALLOW and severity[action] > severity[dominant_action]:
+                dominant_action = action
+
+        ordered_statuses = tuple(sorted(statuses, key=lambda s: (-severity[s.action], s.scope)))
+        allowed = dominant_action in {BudgetAction.ALLOW, BudgetAction.WARN}
+        return BudgetCheck(
+            allowed=allowed,
+            action=dominant_action,
+            charge=charge_proxy,
+            scope_statuses=ordered_statuses,
+        )
+
+    def commit(self, scopes: Sequence[str], cost: Mapping[str, float | int]) -> BudgetChargeOutcome:
+        check = self.preview(scopes, cost)
+        if check.action in {BudgetAction.ERROR, BudgetAction.STOP}:
+            raise BudgetBreachError(check)
+
+        normalized = dict(check.charge)
+        for scope in scopes:
+            spec = self._specs.get(scope)
+            if spec is None:
+                continue
+            spent = self._spent.setdefault(scope, {})
+            for metric, value in normalized.items():
+                spent[metric] = spent.get(metric, 0.0) + value
+
+        dominant_status = check.scope_statuses[0] if check.scope_statuses else ScopeBudgetStatus(
+            scope="run",
+            breached=False,
+            action=BudgetAction.ALLOW,
+            remaining=MappingProxyType({}),
+            overages=MappingProxyType({}),
+        )
+        return BudgetChargeOutcome(
+            allowed=True,
+            action=check.action,
+            charge=check.charge,
+            remaining=dominant_status.remaining,
+            overages=dominant_status.overages,
+            scope_statuses=check.scope_statuses,
+        )

--- a/codex/code/phase3_budget_runner_r7h3/dsl/costs.py
+++ b/codex/code/phase3_budget_runner_r7h3/dsl/costs.py
@@ -1,0 +1,49 @@
+"""Cost normalization utilities for FlowRunner budget enforcement."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping
+
+_SECONDS_KEYS = {"time_s", "seconds", "time_seconds"}
+_MILLISECONDS_KEYS = {"time_ms", "milliseconds", "millis"}
+_CANONICAL_TIME_KEY = "time_ms"
+
+
+def normalize_cost(cost: Mapping[str, float | int]) -> Dict[str, float]:
+    """Normalize a raw cost mapping to canonical metric names and floats.
+
+    * Seconds-based time fields are converted to milliseconds and stored under ``time_ms``.
+    * Millisecond fields are copied verbatim to ``time_ms``.
+    * All numeric values are coerced to ``float`` for deterministic arithmetic.
+    * Unknown keys are preserved to remain forward compatible with the DSL spec.
+    """
+
+    normalized: Dict[str, float] = {}
+    for key, value in cost.items():
+        numeric = float(value)
+        if key in _SECONDS_KEYS:
+            normalized[_CANONICAL_TIME_KEY] = numeric * 1000.0
+        elif key in _MILLISECONDS_KEYS:
+            normalized[_CANONICAL_TIME_KEY] = numeric
+        else:
+            normalized[key] = numeric
+    return normalized
+
+
+def combine_costs(costs: Iterable[Mapping[str, float]]) -> Dict[str, float]:
+    """Aggregate multiple cost mappings into a single dictionary."""
+
+    result: Dict[str, float] = {}
+    for cost in costs:
+        for key, value in cost.items():
+            result[key] = result.get(key, 0.0) + float(value)
+    return result
+
+
+def subtract_costs(minuend: Mapping[str, float], subtrahend: Mapping[str, float]) -> Dict[str, float]:
+    """Subtract one cost mapping from another (``minuend - subtrahend``)."""
+
+    remaining: Dict[str, float] = {}
+    for key, value in minuend.items():
+        remaining[key] = float(value) - float(subtrahend.get(key, 0.0))
+    return remaining

--- a/codex/code/phase3_budget_runner_r7h3/dsl/runner.py
+++ b/codex/code/phase3_budget_runner_r7h3/dsl/runner.py
@@ -1,0 +1,236 @@
+"""FlowRunner orchestration with budget and trace integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Mapping, MutableMapping, Optional, Sequence
+
+from . import budget, costs, trace
+
+
+class ToolAdapter:
+    """Protocol-like base class for adapters used by ``FlowRunner``."""
+
+    def estimate(self, context: Mapping[str, str]) -> Mapping[str, float]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def execute(self, context: Mapping[str, str]) -> Mapping[str, object]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class LoopConfig:
+    max_iterations: int
+    scope_keys: Sequence[str]
+
+
+@dataclass(frozen=True)
+class NodeDefinition:
+    node_id: str
+    adapter_id: str
+    scope_keys: Sequence[str]
+    loop: Optional[LoopConfig] = None
+
+
+@dataclass(frozen=True)
+class FlowDefinition:
+    flow_id: str
+    nodes: Sequence[NodeDefinition]
+
+
+class FlowRunStatus(Enum):
+    COMPLETED = "completed"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
+
+@dataclass
+class FlowRunResult:
+    status: FlowRunStatus
+    stop_reason: Optional[str]
+    node_results: MutableMapping[str, List[Mapping[str, object]]]
+
+
+class NullPolicyStack:
+    """Fallback policy stack used when none is provided."""
+
+    def resolve(self, node_id: str) -> None:  # pragma: no cover - default noop
+        return None
+
+    def validate(self, node_id: str) -> None:  # pragma: no cover - default noop
+        return None
+
+
+class FlowRunner:
+    """Execute nodes using adapters while enforcing budgets and emitting traces."""
+
+    def __init__(
+        self,
+        *,
+        adapters: Mapping[str, ToolAdapter],
+        budget_manager: budget.BudgetManager,
+        trace_emitter: trace.TraceEventEmitter,
+        flow_scope_keys: Sequence[str],
+        policy_stack: Optional[object] = None,
+    ) -> None:
+        self._adapters = dict(adapters)
+        self._budget_manager = budget_manager
+        self._trace_emitter = trace_emitter
+        self._flow_scope_keys = list(flow_scope_keys)
+        self._policy_stack = policy_stack or NullPolicyStack()
+
+    def run(self, flow: FlowDefinition, run_id: str) -> FlowRunResult:
+        node_results: MutableMapping[str, List[Mapping[str, object]]] = {}
+        status = FlowRunStatus.COMPLETED
+        stop_reason: Optional[str] = None
+
+        for node in flow.nodes:
+            adapter = self._adapters[node.adapter_id]
+            scopes = list(dict.fromkeys([*self._flow_scope_keys, *node.scope_keys]))
+
+            if node.loop:
+                loop_status, loop_reason = self._execute_loop(
+                    flow_id=flow.flow_id,
+                    run_id=run_id,
+                    node=node,
+                    adapter=adapter,
+                    scopes=scopes,
+                    node_results=node_results,
+                )
+                if loop_status is not FlowRunStatus.COMPLETED:
+                    status = loop_status
+                    stop_reason = loop_reason
+                    break
+            else:
+                result = self._execute_once(
+                    flow_id=flow.flow_id,
+                    run_id=run_id,
+                    node=node,
+                    adapter=adapter,
+                    scopes=scopes,
+                    iteration=None,
+                )
+                if isinstance(result, FlowRunResult):
+                    status = result.status
+                    stop_reason = result.stop_reason
+                    node_results.update(result.node_results)
+                    break
+                node_results.setdefault(node.node_id, []).append(result)
+
+        return FlowRunResult(status=status, stop_reason=stop_reason, node_results=node_results)
+
+    def _execute_loop(
+        self,
+        *,
+        flow_id: str,
+        run_id: str,
+        node: NodeDefinition,
+        adapter: ToolAdapter,
+        scopes: Sequence[str],
+        node_results: MutableMapping[str, List[Mapping[str, object]]],
+    ) -> tuple[FlowRunStatus, Optional[str]]:
+        loop_scope_keys = list(dict.fromkeys([*scopes, *(node.loop.scope_keys if node.loop else [])]))
+        results = node_results.setdefault(node.node_id, [])
+
+        for iteration in range(node.loop.max_iterations):
+            context = {
+                "flow_id": flow_id,
+                "run_id": run_id,
+                "node_id": node.node_id,
+                "iteration": str(iteration),
+            }
+            estimate_raw = adapter.estimate(context)
+            normalized = costs.normalize_cost(estimate_raw)
+            check = self._budget_manager.preview(loop_scope_keys, normalized)
+            stop_reason = None
+            if check.action is budget.BudgetAction.ERROR:
+                self._trace_emitter.record_budget(
+                    run_id=run_id,
+                    node_id=node.node_id,
+                    loop_iteration=iteration,
+                    check=check,
+                    stop_reason="budget_error",
+                )
+                raise budget.BudgetBreachError(check)
+            if check.action is budget.BudgetAction.STOP:
+                stop_reason = "budget_stop"
+            self._trace_emitter.record_budget(
+                run_id=run_id,
+                node_id=node.node_id,
+                loop_iteration=iteration,
+                check=check,
+                stop_reason=stop_reason,
+            )
+            if check.action is budget.BudgetAction.STOP:
+                return FlowRunStatus.STOPPED, "budget_stop"
+
+            self._policy_stack.resolve(node.node_id)
+            outcome = self._budget_manager.commit(loop_scope_keys, normalized)
+            self._trace_emitter.record_outcome(
+                run_id=run_id,
+                node_id=node.node_id,
+                loop_iteration=iteration,
+                outcome=outcome,
+            )
+            self._policy_stack.validate(node.node_id)
+            result = adapter.execute(context)
+            results.append(result)
+
+        return FlowRunStatus.COMPLETED, None
+
+    def _execute_once(
+        self,
+        *,
+        flow_id: str,
+        run_id: str,
+        node: NodeDefinition,
+        adapter: ToolAdapter,
+        scopes: Sequence[str],
+        iteration: Optional[int],
+    ) -> Mapping[str, object] | FlowRunResult:
+        context = {
+            "flow_id": flow_id,
+            "run_id": run_id,
+            "node_id": node.node_id,
+            "iteration": "0" if iteration is None else str(iteration),
+        }
+        estimate_raw = adapter.estimate(context)
+        normalized = costs.normalize_cost(estimate_raw)
+        check = self._budget_manager.preview(scopes, normalized)
+        stop_reason = None
+        if check.action is budget.BudgetAction.ERROR:
+            self._trace_emitter.record_budget(
+                run_id=run_id,
+                node_id=node.node_id,
+                loop_iteration=iteration,
+                check=check,
+                stop_reason="budget_error",
+            )
+            raise budget.BudgetBreachError(check)
+        if check.action is budget.BudgetAction.STOP:
+            stop_reason = "budget_stop"
+        self._trace_emitter.record_budget(
+            run_id=run_id,
+            node_id=node.node_id,
+            loop_iteration=iteration,
+            check=check,
+            stop_reason=stop_reason,
+        )
+        if check.action is budget.BudgetAction.STOP:
+            return FlowRunResult(
+                status=FlowRunStatus.STOPPED,
+                stop_reason="budget_stop",
+                node_results={node.node_id: []},
+            )
+
+        self._policy_stack.resolve(node.node_id)
+        outcome = self._budget_manager.commit(scopes, normalized)
+        self._trace_emitter.record_outcome(
+            run_id=run_id,
+            node_id=node.node_id,
+            loop_iteration=iteration,
+            outcome=outcome,
+        )
+        self._policy_stack.validate(node.node_id)
+        return adapter.execute(context)

--- a/codex/code/phase3_budget_runner_r7h3/dsl/trace.py
+++ b/codex/code/phase3_budget_runner_r7h3/dsl/trace.py
@@ -1,0 +1,93 @@
+"""Trace emission utilities for FlowRunner budget integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Callable, Dict, Mapping
+
+from . import budget
+
+
+class TraceWriter:
+    """Minimal writer interface expected by :class:`TraceEventEmitter`."""
+
+    def emit(self, event: str, payload: Mapping[str, object]) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class TraceEventEmitter:
+    """Emit immutable budget trace payloads via a ``TraceWriter`` instance."""
+
+    writer: TraceWriter
+    clock: Callable[[], float]
+
+    def _base_payload(
+        self,
+        *,
+        run_id: str,
+        node_id: str,
+        loop_iteration: int | None,
+        charge: Mapping[str, float],
+        status: budget.ScopeBudgetStatus,
+        stop_reason: str | None,
+    ) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "run_id": run_id,
+            "node_id": node_id,
+            "scope": status.scope,
+            "loop_iteration": loop_iteration,
+            "timestamp": self.clock(),
+            "action": status.action.value,
+            "charge": MappingProxyType(dict(charge)),
+            "remaining": status.remaining,
+            "overages": status.overages,
+            "stop_reason": stop_reason,
+        }
+        return payload
+
+    def record_budget(
+        self,
+        *,
+        run_id: str,
+        node_id: str,
+        loop_iteration: int | None,
+        check: budget.BudgetCheck,
+        stop_reason: str | None = None,
+    ) -> None:
+        """Emit ``budget_charge`` for all scopes and ``budget_breach`` for violations."""
+
+        for status in check.scope_statuses:
+            payload = self._base_payload(
+                run_id=run_id,
+                node_id=node_id,
+                loop_iteration=loop_iteration,
+                charge=check.charge,
+                status=status,
+                stop_reason=stop_reason,
+            )
+            self.writer.emit("budget_charge", payload)
+            if status.breached:
+                self.writer.emit("budget_breach", dict(payload))
+
+    def record_outcome(
+        self,
+        *,
+        run_id: str,
+        node_id: str,
+        loop_iteration: int | None,
+        outcome: budget.BudgetChargeOutcome,
+    ) -> None:
+        """Emit outcome information after a successful commit."""
+
+        for status in outcome.scope_statuses:
+            payload = self._base_payload(
+                run_id=run_id,
+                node_id=node_id,
+                loop_iteration=loop_iteration,
+                charge=outcome.charge,
+                status=status,
+                stop_reason=None,
+            )
+            self.writer.emit("budget_commit", payload)

--- a/codex/code/phase3_budget_runner_r7h3/tests/test_costs_and_manager.py
+++ b/codex/code/phase3_budget_runner_r7h3/tests/test_costs_and_manager.py
@@ -1,0 +1,113 @@
+import math
+import pathlib
+import sys
+from types import MappingProxyType
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:  # pragma: no cover - import shim for tests
+    sys.path.insert(0, str(ROOT))
+
+from codex.code.phase3_budget_runner_r7h3.dsl import budget, costs
+
+
+class DummyTraceWriter:
+    def __init__(self):
+        self.events = []
+
+    def emit(self, event: str, payload):
+        self.events.append((event, payload))
+
+
+def test_normalize_cost_converts_seconds_and_validates_keys():
+    normalized = costs.normalize_cost({"time_s": 1.5, "tokens": 12, "requests": 1})
+
+    assert math.isclose(normalized["time_ms"], 1500.0)
+    assert normalized["tokens"] == 12.0
+    assert normalized["requests"] == 1.0
+    # Unknown keys are preserved for forward compatibility.
+    normalized_extra = costs.normalize_cost({"custom": 2})
+    assert normalized_extra["custom"] == 2.0
+
+
+def test_budget_manager_warns_and_returns_immutable_snapshots():
+    manager = budget.BudgetManager(
+        {
+            "run": budget.BudgetSpec(scope="run", limits={"tokens": 100}, breach_action="warn"),
+        }
+    )
+
+    first_charge = manager.commit(["run"], {"tokens": 80})
+    assert first_charge.action is budget.BudgetAction.ALLOW
+    assert first_charge.allowed is True
+    assert isinstance(first_charge.remaining, MappingProxyType)
+
+    preview = manager.preview(["run"], {"tokens": 30})
+    assert preview.allowed is True
+    assert preview.action is budget.BudgetAction.WARN
+    assert preview.scope_statuses[0].breached is True
+    assert isinstance(preview.scope_statuses[0].remaining, MappingProxyType)
+    assert isinstance(preview.scope_statuses[0].overages, MappingProxyType)
+
+    # Mapping proxies should be immutable
+    with pytest.raises(TypeError):
+        preview.scope_statuses[0].remaining["tokens"] = 1
+
+    outcome = manager.commit(["run"], {"tokens": 30})
+    assert outcome.action is budget.BudgetAction.WARN
+    assert outcome.allowed is True
+    assert outcome.overages["tokens"] == pytest.approx(10.0)
+
+
+def test_budget_manager_stop_blocks_commit_and_reports_scope():
+    manager = budget.BudgetManager(
+        {
+            "node:alpha": budget.BudgetSpec(scope="node", limits={"time_ms": 5}, breach_action="stop"),
+        }
+    )
+
+    preview = manager.preview(["node:alpha"], {"time_ms": 6})
+    assert preview.allowed is False
+    assert preview.action is budget.BudgetAction.STOP
+    assert preview.scope_statuses[0].scope == "node:alpha"
+
+    with pytest.raises(budget.BudgetBreachError):
+        manager.commit(["node:alpha"], {"time_ms": 6})
+
+
+def test_budget_manager_hard_breach_raises_immediately():
+    manager = budget.BudgetManager(
+        {
+            "run": budget.BudgetSpec(scope="run", limits={"tokens": 10}, breach_action="error"),
+            "node:beta": budget.BudgetSpec(scope="node", limits={"tokens": 5}, breach_action="warn"),
+        }
+    )
+
+    preview = manager.preview(["run", "node:beta"], {"tokens": 12})
+    assert preview.allowed is False
+    assert preview.action is budget.BudgetAction.ERROR
+    dominant = preview.scope_statuses[0]
+    assert dominant.scope == "run"
+    assert dominant.breached is True
+
+    with pytest.raises(budget.BudgetBreachError):
+        manager.commit(["run", "node:beta"], {"tokens": 12})
+
+
+def test_budget_manager_combines_multiple_scopes():
+    manager = budget.BudgetManager(
+        {
+            "run": budget.BudgetSpec(scope="run", limits={"tokens": 200}, breach_action="warn"),
+            "node:gamma": budget.BudgetSpec(scope="node", limits={"tokens": 50}, breach_action="stop"),
+        }
+    )
+
+    manager.commit(["run", "node:gamma"], {"tokens": 30})
+    preview = manager.preview(["run", "node:gamma"], {"tokens": 25})
+
+    assert preview.allowed is False
+    assert preview.action is budget.BudgetAction.STOP
+    statuses = {status.scope: status for status in preview.scope_statuses}
+    assert statuses["node:gamma"].breached is True
+    assert statuses["run"].breached is False

--- a/codex/code/phase3_budget_runner_r7h3/tests/test_flow_runner_budget_integration.py
+++ b/codex/code/phase3_budget_runner_r7h3/tests/test_flow_runner_budget_integration.py
@@ -1,0 +1,189 @@
+from dataclasses import dataclass
+from typing import Dict, List
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:  # pragma: no cover - import shim for tests
+    sys.path.insert(0, str(ROOT))
+
+from codex.code.phase3_budget_runner_r7h3.dsl import budget, costs, runner, trace
+
+
+class FakeAdapter:
+    def __init__(self, estimates: List[Dict[str, float]], results: List[Dict[str, str]]):
+        self._estimates = estimates
+        self._results = results
+        self.executed = []
+
+    def estimate(self, context: Dict[str, str]) -> Dict[str, float]:
+        return self._estimates[len(self.executed)]
+
+    def execute(self, context: Dict[str, str]) -> Dict[str, str]:
+        result = self._results[len(self.executed)]
+        self.executed.append({"context": context, "result": result})
+        return result
+
+
+class RecordingTraceWriter(trace.TraceWriter):
+    def __init__(self):
+        self.events: List[Dict[str, object]] = []
+
+    def emit(self, event: str, payload: Dict[str, object]) -> None:
+        self.events.append({"event": event, **payload})
+
+
+@dataclass
+class DummyPolicyStack:
+    resolved: List[str]
+
+    def resolve(self, node_id: str) -> None:
+        self.resolved.append(node_id)
+
+    def validate(self, node_id: str) -> None:
+        return None
+
+
+@pytest.fixture
+def run_manager():
+    specs = {
+        "run": budget.BudgetSpec(scope="run", limits={"tokens": 15}, breach_action="warn"),
+        "node:loop": budget.BudgetSpec(scope="node", limits={"tokens": 6}, breach_action="stop"),
+        "loop:loop": budget.BudgetSpec(scope="loop", limits={"tokens": 6}, breach_action="stop"),
+    }
+    return budget.BudgetManager(specs)
+
+
+def test_flow_runner_stops_loop_on_budget_stop(run_manager):
+    adapter = FakeAdapter(
+        estimates=[{"tokens": 2}, {"tokens": 2}, {"tokens": 3}],
+        results=[{"value": "ok1"}, {"value": "ok2"}, {"value": "ok3"}],
+    )
+    writer = RecordingTraceWriter()
+    emitter = trace.TraceEventEmitter(writer, clock=lambda: 123.0)
+    policy = DummyPolicyStack([])
+
+    flow = runner.FlowDefinition(
+        flow_id="flow",
+        nodes=[
+            runner.NodeDefinition(
+                node_id="loop",
+                adapter_id="loop_adapter",
+                loop=runner.LoopConfig(max_iterations=5, scope_keys=["loop:loop"]),
+                scope_keys=["run", "node:loop"],
+            )
+        ],
+    )
+
+    flow_runner = runner.FlowRunner(
+        adapters={"loop_adapter": adapter},
+        budget_manager=run_manager,
+        trace_emitter=emitter,
+        policy_stack=policy,
+        flow_scope_keys=["run"],
+    )
+
+    result = flow_runner.run(flow, run_id="run-1")
+
+    assert result.status == runner.FlowRunStatus.STOPPED
+    assert result.stop_reason == "budget_stop"
+    assert len(adapter.executed) == 2
+    assert policy.resolved == ["loop", "loop"]
+
+    breach_events = [event for event in writer.events if event["event"] == "budget_breach"]
+    assert breach_events, "expected at least one breach event"
+    last_breach = breach_events[-1]
+    assert last_breach["action"] == "stop"
+    assert last_breach["scope"] == "node:loop"
+
+
+def test_flow_runner_raises_on_hard_breach():
+    manager = budget.BudgetManager(
+        {
+            "run": budget.BudgetSpec(scope="run", limits={"tokens": 2}, breach_action="error"),
+        }
+    )
+    adapter = FakeAdapter(
+        estimates=[{"tokens": 5}],
+        results=[{"value": "too much"}],
+    )
+    writer = RecordingTraceWriter()
+    emitter = trace.TraceEventEmitter(writer, clock=lambda: 999.0)
+
+    flow = runner.FlowDefinition(
+        flow_id="flow",
+        nodes=[
+            runner.NodeDefinition(
+                node_id="n1",
+                adapter_id="a1",
+                loop=None,
+                scope_keys=["run"],
+            )
+        ],
+    )
+    flow_runner = runner.FlowRunner(
+        adapters={"a1": adapter},
+        budget_manager=manager,
+        trace_emitter=emitter,
+        flow_scope_keys=["run"],
+    )
+
+    with pytest.raises(budget.BudgetBreachError):
+        flow_runner.run(flow, run_id="run-hard")
+
+    breach_events = [event for event in writer.events if event["event"] == "budget_breach"]
+    assert breach_events[0]["action"] == "error"
+
+
+def test_flow_runner_emits_warn_and_continues():
+    manager = budget.BudgetManager(
+        {
+            "run": budget.BudgetSpec(scope="run", limits={"tokens": 5}, breach_action="warn"),
+            "node:n1": budget.BudgetSpec(scope="node", limits={"tokens": 10}, breach_action="warn"),
+            "node:n2": budget.BudgetSpec(scope="node", limits={"tokens": 10}, breach_action="warn"),
+        }
+    )
+    adapter1 = FakeAdapter(
+        estimates=[{"tokens": 3}],
+        results=[{"value": "first"}],
+    )
+    adapter2 = FakeAdapter(
+        estimates=[{"tokens": 4}],
+        results=[{"value": "second"}],
+    )
+    writer = RecordingTraceWriter()
+    emitter = trace.TraceEventEmitter(writer, clock=lambda: 42.0)
+
+    flow = runner.FlowDefinition(
+        flow_id="flow",
+        nodes=[
+            runner.NodeDefinition(
+                node_id="n1",
+                adapter_id="a1",
+                loop=None,
+                scope_keys=["run", "node:n1"],
+            ),
+            runner.NodeDefinition(
+                node_id="n2",
+                adapter_id="a2",
+                loop=None,
+                scope_keys=["run", "node:n2"],
+            ),
+        ],
+    )
+    flow_runner = runner.FlowRunner(
+        adapters={"a1": adapter1, "a2": adapter2},
+        budget_manager=manager,
+        trace_emitter=emitter,
+        flow_scope_keys=["run"],
+    )
+
+    result = flow_runner.run(flow, run_id="run-soft")
+
+    assert result.status == runner.FlowRunStatus.COMPLETED
+    warn_events = [event for event in writer.events if event["event"] == "budget_breach" and event["action"] == "warn"]
+    assert warn_events, "expected warn breach events"
+    assert warn_events[-1]["scope"] == "run"
+    assert result.stop_reason is None


### PR DESCRIPTION
## Summary
- stage cost normalization, budget manager, trace emitter, and FlowRunner modules under codex.code.phase3_budget_runner_r7h3
- add unit and integration tests covering warn/stop/error semantics, loop halting, and trace emission
- document phase artefacts plus missing-test recommendations for downstream automation

## Testing
- pytest codex/code/phase3_budget_runner_r7h3/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8bdef46f0832cb681466563bffb89