### PR TITLE
Phase 3: integrate loop budgets and policy traces

### DIFF
--- a/codex/DOCUMENTATION/P3/work-20250509-gpt5codex.yaml
+++ b/codex/DOCUMENTATION/P3/work-20250509-gpt5codex.yaml
@@ -1,0 +1,64 @@
+component: budget_guard_runner_phase3
+purpose: |
+  Extend the Phase 3 runner integration with loop-aware budgeting and shared policy trace emission.
+  FlowRunner now previews budgets across run/node/loop scopes before committing spend, breaks loops
+  on stop-configured breaches, and emits loop summaries plus policy trace events through a unified emitter.
+cli_usage:
+  description: Execute branch-scoped regression tests for loop and policy integrations.
+  command: pytest codex/code/work/tests -q
+public_interfaces:
+  - name: codex.code.work.dsl.policy_bridge.PolicyTraceBridge
+    description: Forwards PolicyStack trace events into the shared TraceEventEmitter while preserving downstream sinks.
+  - name: codex.code.work.dsl.flow_runner.FlowRunner.run
+    description: Executes nodes with optional run-level policy frame, loop orchestration, and scope-aware budget enforcement.
+  - name: codex.code.work.dsl.flow_runner._execute_loop
+    description: Internal helper that iterates loop bodies, applies loop budgets, and emits loop_summary traces.
+  - name: codex.code.work.dsl.budget_manager.BudgetBreachError.decision
+    description: Exposed attribute referencing the BudgetDecision that triggered the breach for diagnostics.
+extension_hooks:
+  - hook: PolicyTraceBridge
+    extension: Wrap with additional sinks (e.g., OTEL) to fan out policy trace events.
+  - hook: FlowRunner._normalise_body
+    extension: Override in subclasses to support richer loop body descriptors.
+  - hook: FlowRunner._commit_scope
+    extension: Decorate to add telemetry or retries around budget commit operations.
+configurable_options:
+  - name: run_policy
+    values: Mapping[str, Iterable[str]] | None
+    default: null
+  - name: loop.stop.max_iterations
+    values: integer >= 0
+    default: null (loop runs until other stop conditions)
+  - name: BudgetSpec.mode
+    values: [hard, soft]
+    default: hard
+automation_triggers:
+  - trigger: PolicyStack.push/pop via FlowRunner
+    outcome: Ensures policies remain balanced even when exceptions occur.
+  - trigger: BudgetManager.preview_charge for loop scopes
+    outcome: Records breach telemetry before deciding whether to execute an iteration.
+error_contracts:
+  - name: BudgetBreachError
+    raised_when: Preview/commit detects a stop-configured breach at run/node/loop scopes.
+    payload: scope metadata, blocking BudgetChargeOutcome, and attached BudgetDecision.
+  - name: PolicyViolationError
+    raised_when: PolicyStack denies a tool; FlowRunner emits policy_violation and aborts execution.
+serialization:
+  trace_payloads:
+    loop_summary: {loop_id, iterations, stop_reason, breach?}
+    policy_events: Forwarded PolicyTraceEvent payloads (policy_push/pop/resolved/violation).
+    budget_events: MappingProxyType containing cost, totals, remaining, and overage metrics.
+  cost_snapshot: {time_ms: float, tokens: int}
+lifecycle:
+  - FlowRunner.run: enter run scope -> optional run policy push -> iterate nodes/loops -> emit run_complete -> pop policy -> exit scope.
+  - Loop execution: enter loop scope -> optional policy push -> per-iteration budget previews -> commit or halt -> emit loop_summary -> exit scope.
+  - Budget breach: preview_charge -> record_breach -> commit_charge raises BudgetBreachError with attached decision.
+typing:
+  language: Python 3.12
+  typing: dataclasses, Protocol for adapters, explicit Mapping types for node definitions.
+security:
+  - FlowRunner trusts adapters and policies; ensure upstream configuration sanitises inputs.
+  - Policy trace emission may include policy definitions; route to trusted sinks.
+performance:
+  - Preview before commit avoids unnecessary state updates when loops halt early.
+  - Trace emission is synchronous; consider attaching asynchronous sinks for high-volume policies/loops.

--- a/codex/TESTS/P3/work-20250509-gpt5codex.yaml
+++ b/codex/TESTS/P3/work-20250509-gpt5codex.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_loop_budget_warns_and_continues_multiple_iterations
+      rationale: Cover loop scopes configured with breach_action "warn" to ensure warnings emit without halting iterations.
+      source_module: codex/code/work/dsl/flow_runner.py
+      priority: medium
+    - name: test_policy_bridge_with_existing_sink
+      rationale: Validate that PolicyTraceBridge correctly forwards events when PolicyStack already has a sink attached.
+      source_module: codex/code/work/dsl/policy_bridge.py
+      priority: low
+    - name: property_test_budget_decision_carries_through_exception
+      rationale: Property-based check that any stop decision propagated via BudgetBreachError retains the originating decision payload.
+      source_module: codex/code/work/dsl/budget_manager.py
+      priority: medium

--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
@@ -1,0 +1,14 @@
+# Phase 3 Post-Execution – Budget guards integrated with FlowRunner
+
+## Test Execution
+- `pytest codex/code/work/tests/work -q`
+- `pytest codex/code/work/tests -q`
+
+## Outcomes
+- Loop stop scenario halts only the loop scope; run continues and emits `loop_summary` with breach payload.
+- Policy trace bridge emits `policy_push`, `policy_resolved`, `policy_pop`, and `policy_violation` events via the shared emitter.
+- Budget manager now exposes `decision` metadata on raised breaches, enabling richer diagnostics and assertions.
+
+## Follow-up Recommendations
+- Add property-based tests around loop iteration accounting (budget stop vs. warn) once more loop stop triggers are implemented.
+- Consider integration coverage that exercises simultaneous policy violation and loop budget stop to validate ordering semantics.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
@@ -1,0 +1,16 @@
+# Phase 3 Preview – Budget guards integrated with FlowRunner
+
+## Scope
+- Add a reusable `PolicyTraceBridge` so PolicyStack trace events flow through the shared `TraceEventEmitter`.
+- Extend `FlowRunner` with loop orchestration, loop-aware budget charging, and loop summary trace emission.
+- Preserve adapter-driven execution while layering run/node policy push/pop and policy resolution traces.
+- Attach preview `BudgetDecision` metadata to `BudgetBreachError` for downstream diagnostics.
+
+## Test Strategy
+- New branch-scoped tests under `codex/code/work/tests/work/` cover loop budget stops and policy trace propagation.
+- Existing budget manager and integration tests gain assertions around attached decisions and remain deterministic.
+- All tests will be executed with `pytest codex/code/work/tests -q` during implementation.
+
+## Open Questions / Risks
+- Loop termination currently relies on `max_iterations` or budget stops; additional stop criteria (LLM feedback) remain future work.
+- Policy trace bridging assumes ownership of `PolicyStack._event_sink`; callers supplying custom sinks should continue working via downstream forwarding, but additional validation in integration environments is recommended.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
@@ -1,0 +1,14 @@
+# Phase 3 Review – Budget guards integrated with FlowRunner
+
+## Checklist
+- [x] Policy trace bridge preserves downstream sinks and emits immutable payloads.
+- [x] FlowRunner loop execution halts only loop scopes on stop decisions and surfaces `loop_summary` payloads.
+- [x] Run/node policy push/pop balanced under success and exception paths.
+- [x] Budget breach exceptions expose `decision` metadata for diagnostics and testing.
+- [x] Branch-scoped tests cover loop stop, policy traces, and regression suites remain deterministic.
+
+## Notes for Reviewers
+- `PolicyTraceBridge` forwards to any pre-existing `PolicyStack` sink to avoid breaking external telemetry wiring.
+- Loop handling commits run/node budgets only after loop preview indicates execution will proceed, preventing phantom spend.
+- `loop_summary` events include the blocking outcome payload when applicable; see tests for expectations.
+- Consider future follow-up to support additional loop termination criteria (e.g., until LLM response) if required by spec.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.yaml
@@ -1,0 +1,90 @@
+summary: Extend FlowRunner with loop-aware budget enforcement and shared policy tracing
+justification: |
+  Phase 2 established immutable budget models, a scope-aware BudgetManager, and adapter-backed
+  FlowRunner skeleton. Review notes highlighted missing loop stop semantics and lack of shared
+  policy traces. This plan adds loop orchestration, ensures budget breaches halt loops without
+  aborting the entire run, and bridges PolicyStack events into the TraceEventEmitter so policy
+  and budget telemetry share a contract. Tests will codify stop/warn behaviour and trace payloads
+  before implementation.
+steps:
+  - name: policy_bridge
+    description: Provide a reusable bridge that forwards PolicyStack trace events into the shared TraceEventEmitter.
+  - name: flow_runner_loops
+    description: Teach FlowRunner to execute loop nodes, apply loop budgets, and emit loop summaries while preserving adapter integration.
+  - name: flow_runner_policy_traces
+    description: Push/pop run and node policies, emit policy_resolved traces, and surface violations through the shared emitter.
+  - name: budget_manager_stop_metadata
+    description: Attach preview decisions to raised BudgetBreachError so loop handlers can produce diagnostics without mutating manager internals.
+modules:
+  - path: codex/code/work/dsl/policy_bridge.py
+    role: Adapt PolicyStack trace events to the TraceEventEmitter, preserving immutable payloads.
+  - path: codex/code/work/dsl/flow_runner.py
+    role: Execute tool and loop nodes with budget+policy enforcement and deterministic trace emission.
+  - path: codex/code/work/dsl/budget_manager.py
+    role: Surface BudgetDecision metadata when raising BudgetBreachError for downstream diagnostics.
+  - path: codex/code/work/dsl/__init__.py
+    role: Export new bridge utilities for downstream imports.
+  - path: codex/code/work/tests/work/__init__.py
+    role: Namespace package for branch-scoped tests.
+  - path: codex/code/work/tests/work/test_flow_runner_loop_budget_stop.py
+    role: Validate loop budget stop semantics, summary traces, and continued run execution.
+  - path: codex/code/work/tests/work/test_flow_runner_policy_traces.py
+    role: Assert shared policy trace emission, policy push/pop ordering, and violation recording.
+  - path: codex/code/work/tests/conftest.py
+    role: Ensure Python path wiring covers new branch-scoped tests.
+  - path: codex/code/work/tests/test_flow_runner_budget_integration.py
+    role: Align legacy integration fixture helpers with new bridge utilities when necessary.
+  - path: codex/code/work/tests/__init__.py
+    role: Document branch test layout.
+  - path: codex/code/work/dsl/trace.py
+    role: Support policy bridge payload immutability helpers if adjustments needed.
+  - path: codex/code/work/dsl/budget_models.py
+    role: Provide helper types reused by loop summaries (e.g., ScopeKey aliasing).
+  - path: codex/code/work/tests/test_budget_manager.py
+    role: Extend assertions for attached decision metadata.
+  - path: codex/code/work/tests/test_flow_runner_budget_integration.py
+    role: Update fixtures to leverage new bridge if required.
+  - path: codex/code/work/tests/test_budget_models.py
+    role: Ensure compatibility with new summary helpers if added.
+tests:
+  - path: codex/code/work/tests/work/test_flow_runner_loop_budget_stop.py
+    coverage: loop scope entry/exit, soft vs stop semantics, loop_summary trace payloads, continuation behaviour.
+    mocks: Deterministic fake adapter with per-node counters.
+  - path: codex/code/work/tests/work/test_flow_runner_policy_traces.py
+    coverage: run/node policy push/pop, policy_resolved emission, violation propagation.
+    mocks: Fake adapter, preconfigured PolicyStack fixtures.
+  - path: codex/code/work/tests/test_budget_manager.py
+    coverage: confirm raised BudgetBreachError now carries decision metadata for diagnostics.
+    mocks: Trace emitter fixture.
+run_order:
+  - pytest codex/code/work/tests/work/test_flow_runner_policy_traces.py
+  - pytest codex/code/work/tests/work/test_flow_runner_loop_budget_stop.py
+  - pytest codex/code/work/tests/test_budget_manager.py
+  - pytest codex/code/work/tests/test_flow_runner_budget_integration.py
+interfaces:
+  policy_bridge: [PolicyTraceBridge.__call__]
+  flow_runner: [FlowRunner.run, FlowRunner._execute_node, FlowRunner._execute_loop]
+  budget_manager: [BudgetManager.commit_charge, BudgetBreachError.outcome, BudgetBreachError.decision]
+  trace: [TraceEventEmitter.emit]
+  policy_stack: [PolicyStack.push, PolicyStack.pop, PolicyStack.effective_allowlist, PolicyStack.enforce]
+tdd_coverage_targets:
+  codex/code/work/dsl/flow_runner.py: 90
+  codex/code/work/dsl/policy_bridge.py: 95
+  codex/code/work/dsl/budget_manager.py: 85
+review_checklist:
+  - Verify PolicyTraceBridge preserves downstream sinks and emits immutable payloads.
+  - Ensure FlowRunner loop execution catches loop-specific budget stops without masking run/node breaches.
+  - Confirm loop_summary payload includes stop_reason and breached spec metadata when applicable.
+  - Check policy push/pop ordering is balanced even on exceptions.
+  - Validate new tests cover both success and failure paths deterministically.
+outputs:
+  plan: codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.yaml
+  tests: codex/code/work/tests/work
+  implementation: codex/code/work/dsl
+  documentation:
+    preview: codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+    review: codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+    postexecution: codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex.md
+    metadata: codex/DOCUMENTATION/P3/work-20250509-gpt5codex.yaml
+  missing_tests: codex/TESTS/P3/work-20250509-gpt5codex.yaml
+  optional_runner: codex/code/work/phase3_runner.py

--- a/codex/code/work/dsl/__init__.py
+++ b/codex/code/work/dsl/__init__.py
@@ -1,5 +1,6 @@
 """DSL helpers for Phase 3 work branch."""
 
 from . import budget_models
+from .policy_bridge import PolicyTraceBridge
 
-__all__ = ["budget_models"]
+__all__ = ["budget_models", "PolicyTraceBridge"]

--- a/codex/code/work/dsl/budget_manager.py
+++ b/codex/code/work/dsl/budget_manager.py
@@ -94,7 +94,9 @@ class BudgetManager:
             blocking = decision.blocking
             if blocking is None:  # pragma: no cover - defensive guard
                 raise BudgetError("blocking outcome missing for stop decision")
-            raise BudgetBreachError(decision.scope, blocking)
+            error = BudgetBreachError(decision.scope, blocking)
+            setattr(error, "decision", decision)
+            raise error
         for outcome in decision.outcomes:
             state.spent[outcome.spec.name] = outcome.charge.new_total
             self._trace.emit(

--- a/codex/code/work/dsl/flow_runner.py
+++ b/codex/code/work/dsl/flow_runner.py
@@ -1,15 +1,14 @@
-"""Adapter-backed FlowRunner integrating budgets and policies."""
-
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from pkgs.dsl.policy import PolicyStack, PolicyViolationError
 
 from . import budget_models as bm
-from .budget_manager import BudgetBreachError, BudgetError, BudgetManager
+from .budget_manager import BudgetBreachError, BudgetManager
+from .policy_bridge import PolicyTraceBridge
 from .trace import TraceEventEmitter
 
 __all__ = ["ToolAdapter", "NodeExecution", "FlowRunner"]
@@ -35,6 +34,11 @@ class NodeExecution:
     result: object
 
 
+@dataclass(frozen=True, slots=True)
+class _LoopHalt:
+    decision: bm.BudgetDecision
+
+
 class FlowRunner:
     """Execute flow nodes with policy enforcement and budget guards."""
 
@@ -50,6 +54,9 @@ class FlowRunner:
         self._budgets = budget_manager
         self._policies = policy_stack
         self._trace = trace or budget_manager.trace
+        downstream = getattr(policy_stack, "_event_sink", None)
+        self._policy_bridge = PolicyTraceBridge(self._trace, downstream)
+        policy_stack._event_sink = self._policy_bridge
 
     def run(
         self,
@@ -57,56 +64,31 @@ class FlowRunner:
         flow_id: str,
         run_id: str,
         nodes: Iterable[Mapping[str, object]],
+        run_policy: Mapping[str, Iterable[str]] | None = None,
     ) -> list[NodeExecution]:
         run_scope = bm.ScopeKey(scope_type="run", scope_id=run_id)
         self._budgets.enter_scope(run_scope)
-        self._trace.emit(
-            "run_start",
-            scope_type="run",
-            scope_id=run_id,
-            payload={"flow_id": flow_id},
-        )
+        run_policy_scope = f"run:{run_id}"
+        run_policy_active = False
         executions: list[NodeExecution] = []
         try:
+            if run_policy is not None:
+                self._policies.push(run_policy, scope=run_policy_scope, source=flow_id)
+                run_policy_active = True
+            self._trace.emit(
+                "run_start",
+                scope_type="run",
+                scope_id=run_id,
+                payload={"flow_id": flow_id},
+            )
             for raw_node in nodes:
-                node_id = str(raw_node["id"])
-                tool = str(raw_node["tool"])
-                adapter = self._adapters.get(tool)
-                if adapter is None:
-                    raise KeyError(f"unknown adapter for tool '{tool}'")
-                node_scope = bm.ScopeKey(scope_type="node", scope_id=node_id)
-                self._budgets.enter_scope(node_scope)
-                self._trace.emit(
-                    "node_start",
-                    scope_type="node",
-                    scope_id=node_id,
-                    payload={"tool": tool},
-                )
-                try:
-                    self._policies.enforce(tool)
-                    cost_snapshot = bm.CostSnapshot.from_raw(adapter.estimate_cost(raw_node))
-                    self._apply_budget(run_scope, cost_snapshot)
-                    self._apply_budget(node_scope, cost_snapshot)
-                    result = adapter.execute(raw_node)
-                    executions.append(
-                        NodeExecution(node_id=node_id, tool=tool, result=result)
-                    )
-                    self._trace.emit(
-                        "node_complete",
-                        scope_type="node",
-                        scope_id=node_id,
-                        payload={"tool": tool},
-                    )
-                except PolicyViolationError as exc:
-                    self._trace.emit(
-                        "policy_violation",
-                        scope_type="node",
-                        scope_id=node_id,
-                        payload={"tool": tool, "error": str(exc)},
-                    )
-                    raise
-                finally:
-                    self._budgets.exit_scope(node_scope)
+                node_type = str(raw_node.get("type", "tool"))
+                if node_type == "loop":
+                    executions.extend(self._execute_loop(run_scope, raw_node))
+                    continue
+                execution, _ = self._execute_tool_node(run_scope, raw_node, loop_scope=None)
+                if execution is not None:
+                    executions.append(execution)
             self._trace.emit(
                 "run_complete",
                 scope_type="run",
@@ -115,18 +97,214 @@ class FlowRunner:
             )
             return executions
         finally:
+            if run_policy_active:
+                self._policies.pop(run_policy_scope)
             self._budgets.exit_scope(run_scope)
 
     # ------------------------------------------------------------------
-    # Internal helpers
+    # Loop orchestration
     # ------------------------------------------------------------------
-    def _apply_budget(self, scope: bm.ScopeKey, cost: bm.CostSnapshot) -> None:
+    def _execute_loop(
+        self,
+        run_scope: bm.ScopeKey,
+        node: Mapping[str, object],
+    ) -> list[NodeExecution]:
+        loop_id = str(node["id"])
+        body_nodes = self._normalise_body(node.get("body"))
+        max_iterations = self._loop_max_iterations(node)
+        loop_scope = bm.ScopeKey(scope_type="loop", scope_id=loop_id)
+        self._budgets.enter_scope(loop_scope)
+
+        loop_policy = node.get("policy")
+        policy_scope = f"loop:{loop_id}"
+        policy_active = False
+        iterations = 0
+        stop_reason = "completed"
+        blocking: bm.BudgetChargeOutcome | None = None
+        executions: list[NodeExecution] = []
+
+        try:
+            if loop_policy is not None:
+                self._policies.push(loop_policy, scope=policy_scope, source=loop_id)
+                policy_active = True
+
+            while True:
+                if max_iterations is not None and iterations >= max_iterations:
+                    stop_reason = "max_iterations"
+                    break
+
+                if not body_nodes:
+                    break
+
+                iteration_records: list[NodeExecution] = []
+                for body in body_nodes:
+                    execution, halt = self._execute_tool_node(
+                        run_scope,
+                        body,
+                        loop_scope=loop_scope,
+                    )
+                    if execution is not None:
+                        iteration_records.append(execution)
+                    if halt is not None:
+                        blocking = halt.decision.blocking
+                        stop_reason = "budget_stop"
+                        break
+
+                if iteration_records:
+                    executions.extend(iteration_records)
+                    iterations += 1
+
+                if blocking is not None:
+                    break
+
+        finally:
+            payload = {
+                "loop_id": loop_id,
+                "iterations": iterations,
+                "stop_reason": stop_reason,
+            }
+            if blocking is not None:
+                payload["breach"] = blocking.to_trace_payload(
+                    scope_type="loop",
+                    scope_id=loop_id,
+                )
+            self._trace.emit(
+                "loop_summary",
+                scope_type="loop",
+                scope_id=loop_id,
+                payload=payload,
+            )
+            if policy_active:
+                self._policies.pop(policy_scope)
+            self._budgets.exit_scope(loop_scope)
+
+        return executions
+
+    def _normalise_body(
+        self, body: object | None
+    ) -> Sequence[Mapping[str, object]]:
+        if body is None:
+            return ()
+        if isinstance(body, Mapping):
+            return (body,)  # pragma: no cover - defensive convenience
+        try:
+            normalised: list[Mapping[str, object]] = []
+            for entry in body:  # type: ignore[arg-type]
+                if not isinstance(entry, Mapping):
+                    raise TypeError("loop body entries must be mappings")
+                normalised.append(entry)
+            return tuple(normalised)
+        except TypeError as exc:  # pragma: no cover - defensive guard
+            raise TypeError("loop body must be iterable of mappings") from exc
+
+    def _loop_max_iterations(self, node: Mapping[str, object]) -> int | None:
+        raw_stop = node.get("stop")
+        max_iterations = node.get("max_iterations")
+        if max_iterations is None and isinstance(raw_stop, Mapping):
+            max_iterations = raw_stop.get("max_iterations")
+        if max_iterations is None:
+            return None
+        value = int(max_iterations)
+        if value < 0:
+            raise ValueError("max_iterations must be >= 0")
+        return value
+
+    # ------------------------------------------------------------------
+    # Node execution
+    # ------------------------------------------------------------------
+    def _execute_tool_node(
+        self,
+        run_scope: bm.ScopeKey,
+        node: Mapping[str, object],
+        *,
+        loop_scope: bm.ScopeKey | None,
+    ) -> tuple[NodeExecution | None, _LoopHalt | None]:
+        node_id = str(node["id"])
+        tool = str(node["tool"])
+        adapter = self._adapters.get(tool)
+        if adapter is None:
+            raise KeyError(f"unknown adapter for tool '{tool}'")
+
+        node_scope = bm.ScopeKey(scope_type="node", scope_id=node_id)
+        self._budgets.enter_scope(node_scope)
+        self._trace.emit(
+            "node_start",
+            scope_type="node",
+            scope_id=node_id,
+            payload={"tool": tool},
+        )
+
+        node_policy = node.get("policy")
+        policy_scope = f"node:{node_id}"
+        policy_active = False
+
+        try:
+            if node_policy is not None:
+                self._policies.push(node_policy, scope=policy_scope, source=node_id)
+                policy_active = True
+
+            self._policies.effective_allowlist([tool])
+            self._policies.enforce(tool)
+
+            cost_snapshot = bm.CostSnapshot.from_raw(adapter.estimate_cost(node))
+
+            run_decision = self._preview_scope(run_scope, cost_snapshot)
+            if run_decision.should_stop:
+                self._commit_scope(run_decision)
+            node_decision = self._preview_scope(node_scope, cost_snapshot)
+            if node_decision.should_stop:
+                self._commit_scope(node_decision)
+
+            loop_decision: bm.BudgetDecision | None = None
+            if loop_scope is not None:
+                loop_decision = self._preview_scope(loop_scope, cost_snapshot)
+                if loop_decision.should_stop:
+                    return None, _LoopHalt(decision=loop_decision)
+
+            self._commit_scope(run_decision)
+            self._commit_scope(node_decision)
+            if loop_decision is not None:
+                self._commit_scope(loop_decision)
+
+            result = adapter.execute(node)
+            execution = NodeExecution(node_id=node_id, tool=tool, result=result)
+            self._trace.emit(
+                "node_complete",
+                scope_type="node",
+                scope_id=node_id,
+                payload={"tool": tool},
+            )
+            return execution, None
+        except BudgetBreachError:
+            raise
+        except PolicyViolationError as exc:
+            self._trace.emit(
+                "policy_violation",
+                scope_type="node",
+                scope_id=node_id,
+                payload={"tool": tool, "error": str(exc)},
+            )
+            raise
+        finally:
+            if policy_active:
+                self._policies.pop(policy_scope)
+            self._budgets.exit_scope(node_scope)
+
+    # ------------------------------------------------------------------
+    # Budget helpers
+    # ------------------------------------------------------------------
+    def _preview_scope(
+        self, scope: bm.ScopeKey, cost: bm.CostSnapshot
+    ) -> bm.BudgetDecision:
         decision = self._budgets.preview_charge(scope, cost)
         if decision.breached:
             self._budgets.record_breach(decision)
-        if decision.should_stop:
-            blocking = decision.blocking
-            if blocking is None:  # pragma: no cover - defensive guard
-                raise BudgetError("blocking outcome missing for stop decision")
-            raise BudgetBreachError(scope, blocking)
-        self._budgets.commit_charge(decision)
+        return decision
+
+    def _commit_scope(self, decision: bm.BudgetDecision) -> None:
+        try:
+            self._budgets.commit_charge(decision)
+        except BudgetBreachError as exc:
+            if not hasattr(exc, "decision"):
+                setattr(exc, "decision", decision)
+            raise

--- a/codex/code/work/dsl/policy_bridge.py
+++ b/codex/code/work/dsl/policy_bridge.py
@@ -1,0 +1,38 @@
+"""Utilities to bridge policy trace events into the shared trace emitter."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from pkgs.dsl.policy import PolicyTraceEvent
+
+from .trace import TraceEventEmitter
+
+__all__ = ["PolicyTraceBridge"]
+
+
+class PolicyTraceBridge:
+    """Forward :class:`PolicyTraceEvent` instances to a :class:`TraceEventEmitter`."""
+
+    def __init__(
+        self,
+        emitter: TraceEventEmitter,
+        downstream: Callable[[PolicyTraceEvent], None] | None = None,
+        *,
+        scope_type: str = "policy",
+    ) -> None:
+        self._emitter = emitter
+        self._downstream = downstream
+        self._scope_type = scope_type
+
+    def __call__(self, event: PolicyTraceEvent) -> None:
+        payload: dict[str, Any] = dict(event.data)
+        self._emitter.emit(
+            event.event,
+            scope_type=self._scope_type,
+            scope_id=event.scope,
+            payload=payload,
+        )
+        if self._downstream is not None:
+            self._downstream(event)

--- a/codex/code/work/phase3_runner.py
+++ b/codex/code/work/phase3_runner.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Run Phase 3 test suite and capture output for auditing."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+LOG_PATH = Path("codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250509-gpt5codex-runlog.txt")
+
+
+def main() -> int:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_PATH.open("w", encoding="utf-8") as stream:
+        process = subprocess.run(
+            ["pytest", "codex/code/work/tests", "-q"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+        stream.write(process.stdout)
+    return process.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/code/work/tests/test_budget_manager.py
+++ b/codex/code/work/tests/test_budget_manager.py
@@ -54,8 +54,9 @@ class TestBudgetManager:
         decision = manager.preview_charge(scope, bm.CostSnapshot.from_raw({"time_ms": 20}))
         assert decision.should_stop is True
         manager.record_breach(decision)
-        with pytest.raises(BudgetBreachError):
+        with pytest.raises(BudgetBreachError) as excinfo:
             manager.commit_charge(decision)
+        assert getattr(excinfo.value, "decision", None) is decision
         events = trace_emitter.events
         assert any(evt.event == "budget_breach" and evt.payload["spec_name"] == "run-hard" for evt in events)
 

--- a/codex/code/work/tests/work/__init__.py
+++ b/codex/code/work/tests/work/__init__.py
@@ -1,0 +1,1 @@
+"""Branch-scoped tests for the work feature branch."""

--- a/codex/code/work/tests/work/test_flow_runner_loop_budget_stop.py
+++ b/codex/code/work/tests/work/test_flow_runner_loop_budget_stop.py
@@ -1,0 +1,134 @@
+import pytest
+
+from codex.code.work.dsl import budget_models as bm
+from codex.code.work.dsl.budget_manager import BudgetManager
+from codex.code.work.dsl.flow_runner import FlowRunner, ToolAdapter
+from codex.code.work.dsl.trace import TraceEventEmitter
+from pkgs.dsl.policy import PolicyStack
+
+
+class LoopingAdapter(ToolAdapter):
+    """Deterministic adapter that returns pre-seeded results per node id."""
+
+    def __init__(
+        self,
+        cost_by_node: dict[str, dict[str, float]],
+        results_by_node: dict[str, list[object]],
+    ) -> None:
+        self._cost = cost_by_node
+        self._results = {key: list(values) for key, values in results_by_node.items()}
+        self._cursors: dict[str, int] = {key: 0 for key in results_by_node}
+        self.executed: list[str] = []
+
+    def estimate_cost(self, node: dict[str, object]) -> dict[str, float]:  # type: ignore[override]
+        return self._cost[node["id"]]
+
+    def execute(self, node: dict[str, object]) -> object:  # type: ignore[override]
+        node_id = node["id"]
+        cursor = self._cursors[node_id]
+        if cursor >= len(self._results[node_id]):
+            raise RuntimeError(f"no result remaining for node {node_id}")
+        self._cursors[node_id] = cursor + 1
+        self.executed.append(node_id)
+        return self._results[node_id][cursor]
+
+
+@pytest.fixture()
+def trace_emitter() -> TraceEventEmitter:
+    return TraceEventEmitter()
+
+
+@pytest.fixture()
+def policy_stack() -> PolicyStack:
+    tools = {"echo": {"tags": []}}
+    return PolicyStack(tools=tools, trace=None, event_sink=None)
+
+
+@pytest.fixture()
+def budget_manager(trace_emitter: TraceEventEmitter) -> BudgetManager:
+    specs = [
+        bm.BudgetSpec(
+            name="run-soft",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 500}),
+            mode="soft",
+            breach_action="warn",
+        ),
+        bm.BudgetSpec(
+            name="loop-stop",
+            scope_type="loop",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 120}),
+            mode="soft",
+            breach_action="stop",
+        ),
+        bm.BudgetSpec(
+            name="node-hard",
+            scope_type="node",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 200}),
+            mode="hard",
+            breach_action="stop",
+        ),
+    ]
+    return BudgetManager(specs=specs, trace=trace_emitter)
+
+
+def test_loop_budget_stop_emits_summary_and_continues_run(
+    budget_manager: BudgetManager,
+    policy_stack: PolicyStack,
+    trace_emitter: TraceEventEmitter,
+) -> None:
+    adapter = LoopingAdapter(
+        cost_by_node={
+            "inner": {"time_ms": 70.0},
+            "after": {"time_ms": 10.0},
+        },
+        results_by_node={
+            "inner": ["loop-1" for _ in range(3)],
+            "after": ["done"],
+        },
+    )
+    runner = FlowRunner(
+        adapters={"echo": adapter},
+        budget_manager=budget_manager,
+        policy_stack=policy_stack,
+        trace=trace_emitter,
+    )
+    nodes = [
+        {
+            "id": "loop-1",
+            "type": "loop",
+            "body": [
+                {"id": "inner", "tool": "echo", "params": {}},
+            ],
+        },
+        {"id": "after", "tool": "echo", "params": {}},
+    ]
+
+    executions = runner.run(
+        flow_id="flow-loop",
+        run_id="run-loop",
+        nodes=nodes,
+        run_policy={"allow_tools": ["echo"]},
+    )
+
+    executed_ids = [record.node_id for record in executions]
+    assert executed_ids == ["inner", "after"]
+    assert adapter.executed == ["inner", "after"]
+
+    loop_events = [evt for evt in trace_emitter.events if evt.event == "loop_summary"]
+    assert len(loop_events) == 1
+    summary = loop_events[0]
+    assert summary.scope_type == "loop"
+    assert summary.scope_id == "loop-1"
+    assert summary.payload["iterations"] == 1
+    assert summary.payload["stop_reason"] == "budget_stop"
+    breach = summary.payload.get("breach")
+    assert breach is not None
+    assert breach["spec_name"] == "loop-stop"
+
+    breach_events = [evt for evt in trace_emitter.events if evt.event == "budget_breach"]
+    assert any(evt.scope_type == "loop" and evt.scope_id == "loop-1" for evt in breach_events)
+
+    run_complete = [evt for evt in trace_emitter.events if evt.event == "run_complete"]
+    assert len(run_complete) == 1
+    assert run_complete[0].payload["flow_id"] == "flow-loop"

--- a/codex/code/work/tests/work/test_flow_runner_policy_traces.py
+++ b/codex/code/work/tests/work/test_flow_runner_policy_traces.py
@@ -1,0 +1,117 @@
+import pytest
+
+from codex.code.work.dsl import budget_models as bm
+from codex.code.work.dsl.budget_manager import BudgetManager
+from codex.code.work.dsl.flow_runner import FlowRunner, ToolAdapter
+from codex.code.work.dsl.trace import TraceEventEmitter
+from pkgs.dsl.policy import PolicyStack, PolicyViolationError
+
+
+class PolicyAwareAdapter(ToolAdapter):
+    def __init__(self, *, cost: dict[str, dict[str, float]], results: dict[str, list[object]]) -> None:
+        self._cost = {key: dict(value) for key, value in cost.items()}
+        self._results = {key: list(values) for key, values in results.items()}
+        self._cursors = {key: 0 for key in results}
+
+    def estimate_cost(self, node: dict[str, object]) -> dict[str, float]:  # type: ignore[override]
+        return self._cost[node["id"]]
+
+    def execute(self, node: dict[str, object]) -> object:  # type: ignore[override]
+        node_id = node["id"]
+        cursor = self._cursors[node_id]
+        self._cursors[node_id] = cursor + 1
+        return self._results[node_id][cursor]
+
+
+@pytest.fixture()
+def trace_emitter() -> TraceEventEmitter:
+    return TraceEventEmitter()
+
+
+@pytest.fixture()
+def budget_manager(trace_emitter: TraceEventEmitter) -> BudgetManager:
+    specs = [
+        bm.BudgetSpec(
+            name="run-soft",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 200}),
+            mode="soft",
+            breach_action="warn",
+        ),
+        bm.BudgetSpec(
+            name="node-soft",
+            scope_type="node",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 150}),
+            mode="soft",
+            breach_action="warn",
+        ),
+    ]
+    return BudgetManager(specs=specs, trace=trace_emitter)
+
+
+@pytest.fixture()
+def policy_stack() -> PolicyStack:
+    return PolicyStack(tools={"echo": {"tags": []}}, trace=None, event_sink=None)
+
+
+def test_policy_events_bridge_and_violation(
+    budget_manager: BudgetManager,
+    policy_stack: PolicyStack,
+    trace_emitter: TraceEventEmitter,
+) -> None:
+    adapter = PolicyAwareAdapter(
+        cost={
+            "allow": {"time_ms": 20.0},
+            "deny": {"time_ms": 20.0},
+        },
+        results={
+            "allow": ["ok"],
+            "deny": ["no"],
+        },
+    )
+    runner = FlowRunner(
+        adapters={"echo": adapter},
+        budget_manager=budget_manager,
+        policy_stack=policy_stack,
+        trace=trace_emitter,
+    )
+    nodes = [
+        {"id": "allow", "tool": "echo", "params": {}, "policy": {"allow_tools": ["echo"]}},
+        {"id": "deny", "tool": "echo", "params": {}, "policy": {"deny_tools": ["echo"]}},
+    ]
+
+    with pytest.raises(PolicyViolationError):
+        runner.run(
+            flow_id="flow-policy",
+            run_id="run-policy",
+            nodes=nodes,
+            run_policy={"allow_tools": ["echo"]},
+        )
+
+    events = trace_emitter.events
+    policy_events = [evt for evt in events if evt.event.startswith("policy_")]
+    emitted_names = [evt.event for evt in policy_events]
+    assert emitted_names.count("policy_push") >= 2
+    assert "policy_pop" in emitted_names
+    assert "policy_resolved" in emitted_names
+    assert "policy_violation" in emitted_names
+
+    run_push = next(
+        evt for evt in policy_events if evt.event == "policy_push" and evt.scope_id == "run:run-policy"
+    )
+    assert run_push.payload["stack_depth"] == 1
+
+    node_push = next(
+        evt for evt in policy_events if evt.event == "policy_push" and evt.scope_id == "node:allow"
+    )
+    assert node_push.payload["stack_depth"] == 2
+
+    violation = next(evt for evt in policy_events if evt.event == "policy_violation")
+    assert violation.payload["tool"] == "echo"
+    assert violation.payload["reasons"]
+
+    pops = [evt for evt in policy_events if evt.event == "policy_pop" and evt.scope_id == "run:run-policy"]
+    assert len(pops) == 1
+
+    run_scope_events = [evt for evt in events if evt.scope_type == "run" and evt.event == "run_complete"]
+    assert not run_scope_events


### PR DESCRIPTION
## Summary
- add a PolicyTraceBridge helper and update FlowRunner to push run/node policies, execute loop nodes, and emit loop summaries through the shared trace emitter
- attach preview BudgetDecision metadata to BudgetBreachError for downstream diagnostics and provide a phase3_runner helper script
- document the plan/results and add branch-scoped tests covering loop budget stops, policy trace propagation, and existing budget manager behaviour

## Testing
- pytest codex/code/work/tests/work -q
- pytest codex/code/work/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8bd190604832c8a801d9c0aee7a68