### PR TITLE
Add loop scope budgeting and trace validation to FlowRunner

### DIFF
--- a/codex/DOCUMENTATION/P3/work-20250513-gpt5codex.yaml
+++ b/codex/DOCUMENTATION/P3/work-20250513-gpt5codex.yaml
@@ -1,0 +1,52 @@
+component: budget_guard_runner_phase3_loop_extension
+purpose: |
+  Extend the Phase 3 budget guard integration with loop-aware FlowRunner execution, validator-backed trace
+  emission, and hardened policy/budget interactions so soft stop semantics and schema compliance are enforced.
+cli_usage:
+  description: Run deterministic validation for loop, policy, and trace integrations.
+  command: pytest codex/code/work/tests -q
+public_interfaces:
+  - name: codex.code.work.dsl.trace.TraceEventEmitter.attach_validator
+    description: Registers a callable that validates each emitted event before it is stored or forwarded.
+  - name: codex.code.work.dsl.flow_runner.FlowRunner.run
+    description: Executes nodes (including loop bodies) via adapters with policy and budget enforcement plus trace emission.
+  - name: codex.code.work.dsl.flow_runner.NodeExecution
+    description: Immutable execution record capturing node id, tool, result, and optional loop iteration metadata.
+extension_hooks:
+  - hook: TraceEventEmitter.attach_sink
+    extension: Forward validated events to structured logging or telemetry systems.
+  - hook: FlowRunner._run_loop
+    extension: Override loop scheduling or tracing behaviour for advanced DSL constructs.
+configurable_options:
+  - name: BudgetSpec.breach_action
+    values: [stop, warn]
+    default: stop
+  - name: Loop node stop.max_iterations
+    values: integer >= 0 (0 interpreted as no iterations)
+    default: 0
+automation_triggers:
+  - trigger: PolicyStack.enforce
+    outcome: Prevents adapter execution when policies deny the tool, leaving budgets untouched.
+  - trigger: BudgetManager.record_breach
+    outcome: Emits immutable breach payloads prior to stop decisions.
+error_contracts:
+  - name: BudgetBreachError
+    raised_when: A budget preview detects a blocking outcome (run/node/loop scope) that requires halting execution.
+    payload: Includes the scope metadata and immutable BudgetChargeOutcome snapshot.
+  - name: PolicyViolationError
+    raised_when: PolicyStack denies a tool before execution; FlowRunner emits `policy_violation` traces and re-raises.
+serialization:
+  trace_payloads: MappingProxy-based payloads with cost, remaining, overage, loop identifiers, and iteration counters.
+  node_execution: Dataclass serialisable to dict for debugging or history persistence.
+lifecycle:
+  - run_scope.enter -> (loop_start?)* -> node_start -> budget preview -> optional breach -> commit -> adapter.execute -> node_complete -> loop_complete -> run_complete
+  - BudgetManager history retains last spent snapshot per scope for inspection after exit.
+typing:
+  language: Python 3.12
+  typing: Protocol for adapters, dataclasses for DTOs, explicit Optional typing for loop context.
+security:
+  - Policy enforcement occurs before adapter execution; adapters themselves must remain trusted.
+  - Trace validators can enforce schema constraints to prevent leaking malformed payloads to sinks.
+performance:
+  - Loop orchestration reuses synchronous previews/commits; overhead is linear in executed nodes.
+  - Validator hook introduces negligible cost unless the callable performs heavy schema validation.

--- a/codex/TESTS/P3/work-20250513-gpt5codex.yaml
+++ b/codex/TESTS/P3/work-20250513-gpt5codex.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_nested_loop_budget_stop_propagation
+      rationale: Exercise nested loop scopes to ensure inner loop breaches emit stop events without leaking scopes in the outer loop.
+      source_module: codex/code/work/dsl/flow_runner.py
+      priority: high
+    - name: test_loop_soft_warn_allows_iteration_progress
+      rationale: Validate that soft loop budgets with `breach_action: warn` emit breaches yet continue executing subsequent iterations.
+      source_module: codex/code/work/dsl/flow_runner.py
+      priority: medium
+    - name: test_trace_validator_error_context
+      rationale: Assert that validator exceptions can annotate failures with event metadata for downstream logging.
+      source_module: codex/code/work/dsl/trace.py
+      priority: low

--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
@@ -1,0 +1,14 @@
+# Phase 3 Post-Execution – Budget guards and runner integration
+
+## Test Results
+- `pytest codex/code/work/tests -q`
+  - Loop, policy, and trace validation suites all pass (16 tests).
+
+## Coverage & Behaviour Notes
+- Loop budget stops emit `loop_stop` traces and preserve run history with no extra spend committed.
+- Policy denials exit node scopes while run scopes remain inspectable with zero spend snapshots.
+- Trace validators block invalid payloads before they are stored or forwarded to sinks.
+
+## Follow-ups
+- Extend loop coverage to nested loops and decision nodes once those constructs are implemented.
+- Consider optional policy push/pop around loop bodies when DSL policies differ per iteration.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
@@ -1,0 +1,11 @@
+# Phase 3 Preview – Budget guards and runner integration
+
+## Key Enhancements
+- Loop-aware FlowRunner execution that enters loop scopes, emits iteration traces, and halts gracefully on budget stop outcomes.
+- Validator-backed `TraceEventEmitter` so schema requirements can be enforced in tests before events are persisted.
+- Hardened policy/budget interplay ensuring policy denials raise before any budget charge is committed.
+
+## Planned Validation
+- Unit tests verifying trace validator success/failure paths.
+- Loop scope regression covering stop-on-breach behaviour, iteration metadata, and trace ordering.
+- Policy violation regression ensuring run/node budgets remain uncharged and traces capture the violation event.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
@@ -1,0 +1,17 @@
+# Phase 3 Review Checklist – Budget guards and runner integration
+
+## Functional Verification
+- [ ] Loop scopes are entered/exited once and emit `loop_start`, iteration, and stop/complete events in deterministic order.
+- [ ] Loop budget breaches surface as `loop_stop` traces without aborting the surrounding run.
+- [ ] Policy violations raise `PolicyViolationError` before any budget commit and leave manager history at zero.
+- [ ] `TraceEventEmitter.attach_validator` rejects malformed events prior to persistence and sink forwarding.
+
+## Test Coverage
+- [ ] `test_trace_emitter_validation.py` exercises validator success/failure paths.
+- [ ] `test_flow_runner_loop_policy.py` covers loop stop semantics and policy/budget interplay.
+- [ ] Existing integration tests continue to pass with iteration metadata added to `NodeExecution`.
+
+## Code Quality
+- [ ] `_run_unit_node` previews budgets before committing to avoid partial spend on loop stops.
+- [ ] Trace payloads include iteration and loop identifiers when available.
+- [ ] New helpers remain synchronous and deterministic for reproducible tests.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.yaml
@@ -1,0 +1,97 @@
+summary: Extend FlowRunner budgets to cover loop scopes and trace validation
+justification: |
+  Phase 2 synthesis and prior reviews flagged missing coverage for loop budget stop behaviour,
+  simultaneous policy and budget violations, and schema validation of emitted trace payloads.
+  This phase introduces targeted enhancements—loop-aware execution paths, validator-backed
+  trace emission, and regression tests—to close those gaps while preserving the immutable data
+  model and adapter-driven runner established earlier.
+steps:
+  - name: loop_scope_support
+    description: Add loop scope orchestration in FlowRunner with deterministic trace emission
+      and graceful handling of stop-on-breach outcomes.
+  - name: trace_validation
+    description: Allow TraceEventEmitter to register validators so budget/policy payloads can
+      be checked against DSL expectations during tests.
+  - name: policy_budget_interplay
+    description: Harden FlowRunner around policy denials so budget scopes unwind cleanly when
+      enforcement blocks execution prior to charging costs.
+modules:
+  - path: codex/code/work/dsl/budget_manager.py
+    role: Scope lifecycle and charging logic; updated for non-raising decision returns when
+      used by loop orchestration.
+  - path: codex/code/work/dsl/flow_runner.py
+    role: Adapter-backed runner extended with loop execution, stop handling, and enriched
+      trace emission.
+  - path: codex/code/work/dsl/trace.py
+    role: Trace emitter augmented with validator attachment for schema enforcement.
+  - path: codex/code/work/tests/test_flow_runner_budget_integration.py
+    role: Existing integration regression suite updated for new behaviours.
+  - path: codex/code/work/tests/test_flow_runner_loop_policy.py
+    role: New unit/integration coverage for loop stop semantics and policy/budget interplay.
+  - path: codex/code/work/tests/test_trace_emitter_validation.py
+    role: Unit coverage for validator-backed trace emission contract.
+  - path: codex/code/work/tests/conftest.py
+    role: Shared fixtures extended for new tests (loop-aware adapters, validators).
+  - path: codex/code/work/tests/__init__.py
+    role: Package marker (unchanged but included for completeness).
+tests:
+  - path: codex/code/work/tests/test_flow_runner_loop_policy.py
+    coverage: loop scope entry/exit, stop-on-breach handling, policy denial without cost charges.
+    mocks: FakeAdapter, TestPolicyStack fixtures, TraceEventEmitter validator doubles.
+  - path: codex/code/work/tests/test_trace_emitter_validation.py
+    coverage: validator success/failure paths, immutability preservation on rejection.
+    mocks: inline validator callables.
+  - path: codex/code/work/tests/test_flow_runner_budget_integration.py
+    coverage: update expectations for new trace events and decision returns.
+    mocks: FakeAdapter already present; extended to expose iteration metadata.
+run_order:
+  - pytest codex/code/work/tests/test_trace_emitter_validation.py
+  - pytest codex/code/work/tests/test_flow_runner_loop_policy.py
+  - pytest codex/code/work/tests/test_flow_runner_budget_integration.py
+interfaces:
+  budget_manager:
+    - BudgetManager.enter_scope
+    - BudgetManager.exit_scope
+    - BudgetManager.preview_charge
+    - BudgetManager.commit_charge
+    - BudgetManager.record_breach
+  flow_runner:
+    - FlowRunner.run
+    - FlowRunner._run_loop
+    - FlowRunner._run_unit_node
+  trace:
+    - TraceEventEmitter.emit
+    - TraceEventEmitter.attach_sink
+    - TraceEventEmitter.attach_validator
+  policy:
+    - PolicyStack.enforce
+    - PolicyStack.push
+    - PolicyStack.pop
+tdd_coverage_targets:
+  codex/code/work/dsl/flow_runner.py: 90
+  codex/code/work/dsl/budget_manager.py: 90
+  codex/code/work/dsl/trace.py: 95
+review_checklist:
+  - Verify loop scopes are entered/exited exactly once per run even on early stop.
+  - Ensure BudgetBreachError raised for loop scopes is intercepted and emits loop_stop traces
+    without aborting the run.
+  - Confirm policy violations leave run/node budgets uncharged and traces emitted.
+  - Validate TraceEventEmitter rejects invalid events before persisting them.
+  - Check new tests cover warn vs stop combinations and validator failure cases.
+outputs:
+  plan: codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.yaml
+  tests:
+    - codex/code/work/tests/test_flow_runner_loop_policy.py
+    - codex/code/work/tests/test_trace_emitter_validation.py
+    - codex/code/work/tests/test_flow_runner_budget_integration.py
+  implementation:
+    - codex/code/work/dsl/flow_runner.py
+    - codex/code/work/dsl/budget_manager.py
+    - codex/code/work/dsl/trace.py
+  documentation:
+    preview: codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+    review: codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+    postexecution: codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250513-gpt5codex.md
+    metadata: codex/DOCUMENTATION/P3/work-20250513-gpt5codex.yaml
+  missing_tests: codex/TESTS/P3/work-20250513-gpt5codex.yaml
+  optional_runner: codex/code/work/phase3_runner.py

--- a/codex/code/work/dsl/flow_runner.py
+++ b/codex/code/work/dsl/flow_runner.py
@@ -33,6 +33,8 @@ class NodeExecution:
     node_id: str
     tool: str
     result: object
+    iteration: int | None = None
+    loop_id: str | None = None
 
 
 class FlowRunner:
@@ -69,44 +71,18 @@ class FlowRunner:
         executions: list[NodeExecution] = []
         try:
             for raw_node in nodes:
-                node_id = str(raw_node["id"])
-                tool = str(raw_node["tool"])
-                adapter = self._adapters.get(tool)
-                if adapter is None:
-                    raise KeyError(f"unknown adapter for tool '{tool}'")
-                node_scope = bm.ScopeKey(scope_type="node", scope_id=node_id)
-                self._budgets.enter_scope(node_scope)
-                self._trace.emit(
-                    "node_start",
-                    scope_type="node",
-                    scope_id=node_id,
-                    payload={"tool": tool},
+                kind = str(raw_node.get("kind", "unit"))
+                if kind == "loop":
+                    self._run_loop(run_scope, raw_node, executions)
+                    continue
+                execution = self._run_unit_node(
+                    run_scope=run_scope,
+                    raw_node=raw_node,
+                    loop_scope=None,
+                    loop_id=None,
+                    iteration=None,
                 )
-                try:
-                    self._policies.enforce(tool)
-                    cost_snapshot = bm.CostSnapshot.from_raw(adapter.estimate_cost(raw_node))
-                    self._apply_budget(run_scope, cost_snapshot)
-                    self._apply_budget(node_scope, cost_snapshot)
-                    result = adapter.execute(raw_node)
-                    executions.append(
-                        NodeExecution(node_id=node_id, tool=tool, result=result)
-                    )
-                    self._trace.emit(
-                        "node_complete",
-                        scope_type="node",
-                        scope_id=node_id,
-                        payload={"tool": tool},
-                    )
-                except PolicyViolationError as exc:
-                    self._trace.emit(
-                        "policy_violation",
-                        scope_type="node",
-                        scope_id=node_id,
-                        payload={"tool": tool, "error": str(exc)},
-                    )
-                    raise
-                finally:
-                    self._budgets.exit_scope(node_scope)
+                executions.append(execution)
             self._trace.emit(
                 "run_complete",
                 scope_type="run",
@@ -120,7 +96,186 @@ class FlowRunner:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-    def _apply_budget(self, scope: bm.ScopeKey, cost: bm.CostSnapshot) -> None:
+    def _run_loop(
+        self,
+        run_scope: bm.ScopeKey,
+        raw_loop: Mapping[str, object],
+        executions: list[NodeExecution],
+    ) -> None:
+        loop_id = str(raw_loop["id"])
+        body = list(raw_loop.get("body", []))
+        stop_cfg = raw_loop.get("stop")
+        max_iterations_value: int | None = None
+        if isinstance(stop_cfg, Mapping):
+            raw_limit = stop_cfg.get("max_iterations")
+            if raw_limit is not None:
+                max_iterations_value = int(raw_limit)
+        if max_iterations_value is None and "max_iterations" in raw_loop:
+            max_iterations_value = int(raw_loop.get("max_iterations", 0))
+        loop_scope = bm.ScopeKey(scope_type="loop", scope_id=loop_id)
+        self._budgets.enter_scope(loop_scope)
+        unlimited = max_iterations_value is None
+        self._trace.emit(
+            "loop_start",
+            scope_type="loop",
+            scope_id=loop_id,
+            payload={"max_iterations": max_iterations_value},
+        )
+        try:
+            if not body:
+                self._trace.emit(
+                    "loop_complete",
+                    scope_type="loop",
+                    scope_id=loop_id,
+                    payload={"iterations": 0},
+                )
+                return
+            if max_iterations_value is not None and max_iterations_value <= 0:
+                self._trace.emit(
+                    "loop_complete",
+                    scope_type="loop",
+                    scope_id=loop_id,
+                    payload={"iterations": 0},
+                )
+                return
+            iteration = 1
+            executed = 0
+            while unlimited or iteration <= (max_iterations_value or 0):
+                self._trace.emit(
+                    "loop_iteration_start",
+                    scope_type="loop",
+                    scope_id=loop_id,
+                    payload={"iteration": iteration},
+                )
+                for node in body:
+                    try:
+                        execution = self._run_unit_node(
+                            run_scope=run_scope,
+                            raw_node=node,
+                            loop_scope=loop_scope,
+                            loop_id=loop_id,
+                            iteration=iteration,
+                        )
+                        executions.append(execution)
+                    except BudgetBreachError as exc:
+                        if exc.scope == loop_scope:
+                            self._trace.emit(
+                                "loop_stop",
+                                scope_type="loop",
+                                scope_id=loop_id,
+                                payload={
+                                    "reason": "budget_stop",
+                                    "spec_name": exc.outcome.spec.name,
+                                    "iteration": iteration,
+                                },
+                            )
+                            return
+                        raise
+                executed = iteration
+                self._trace.emit(
+                    "loop_iteration_complete",
+                    scope_type="loop",
+                    scope_id=loop_id,
+                    payload={"iteration": iteration},
+                )
+                iteration += 1
+                if not unlimited and iteration > (max_iterations_value or 0):
+                    break
+            self._trace.emit(
+                "loop_complete",
+                scope_type="loop",
+                scope_id=loop_id,
+                payload={"iterations": executed},
+            )
+        finally:
+            self._budgets.exit_scope(loop_scope)
+
+    def _run_unit_node(
+        self,
+        *,
+        run_scope: bm.ScopeKey,
+        raw_node: Mapping[str, object],
+        loop_scope: bm.ScopeKey | None,
+        loop_id: str | None,
+        iteration: int | None,
+    ) -> NodeExecution:
+        node_id = str(raw_node["id"])
+        tool = str(raw_node["tool"])
+        adapter = self._adapters.get(tool)
+        if adapter is None:
+            raise KeyError(f"unknown adapter for tool '{tool}'")
+        scope_id = f"{node_id}@{iteration}" if iteration is not None else node_id
+        node_scope = bm.ScopeKey(scope_type="node", scope_id=scope_id)
+        self._budgets.enter_scope(node_scope)
+        payload = {"tool": tool}
+        if iteration is not None:
+            payload["iteration"] = iteration
+        if loop_id is not None:
+            payload["loop_id"] = loop_id
+        self._trace.emit(
+            "node_start",
+            scope_type="node",
+            scope_id=scope_id,
+            payload=payload,
+        )
+        node_payload = dict(raw_node)
+        if iteration is not None:
+            node_payload.setdefault("iteration", iteration)
+        if loop_id is not None:
+            node_payload.setdefault("loop_id", loop_id)
+        try:
+            self._policies.enforce(tool)
+            cost_snapshot = bm.CostSnapshot.from_raw(
+                adapter.estimate_cost(node_payload)
+            )
+            run_decision = self._apply_budget(
+                run_scope, cost_snapshot, commit=False
+            )
+            loop_decision: bm.BudgetDecision | None = None
+            if loop_scope is not None:
+                loop_decision = self._apply_budget(
+                    loop_scope, cost_snapshot, commit=False
+                )
+            node_decision = self._apply_budget(
+                node_scope, cost_snapshot, commit=False
+            )
+            self._budgets.commit_charge(run_decision)
+            if loop_decision is not None:
+                self._budgets.commit_charge(loop_decision)
+            self._budgets.commit_charge(node_decision)
+            result = adapter.execute(node_payload)
+            record = NodeExecution(
+                node_id=node_id,
+                tool=tool,
+                result=result,
+                iteration=iteration,
+                loop_id=loop_id,
+            )
+            self._trace.emit(
+                "node_complete",
+                scope_type="node",
+                scope_id=scope_id,
+                payload=payload,
+            )
+            return record
+        except PolicyViolationError as exc:
+            self._trace.emit(
+                "policy_violation",
+                scope_type="node",
+                scope_id=scope_id,
+                payload={"tool": tool, "error": str(exc)},
+            )
+            raise
+        finally:
+            self._budgets.exit_scope(node_scope)
+
+    def _apply_budget(
+        self,
+        scope: bm.ScopeKey,
+        cost: bm.CostSnapshot,
+        *,
+        commit: bool = True,
+    ) -> bm.BudgetDecision:
         decision = self._budgets.preview_charge(scope, cost)
         if decision.breached:
             self._budgets.record_breach(decision)
@@ -129,4 +284,6 @@ class FlowRunner:
             if blocking is None:  # pragma: no cover - defensive guard
                 raise BudgetError("blocking outcome missing for stop decision")
             raise BudgetBreachError(scope, blocking)
-        self._budgets.commit_charge(decision)
+        if commit:
+            self._budgets.commit_charge(decision)
+        return decision

--- a/codex/code/work/dsl/trace.py
+++ b/codex/code/work/dsl/trace.py
@@ -27,11 +27,19 @@ class TraceEventEmitter:
     def __init__(self) -> None:
         self._events: list[TraceEvent] = []
         self._sink: Callable[[TraceEvent], None] | None = None
+        self._validator: Callable[[TraceEvent], None] | None = None
 
     def attach_sink(self, sink: Callable[[TraceEvent], None] | None) -> None:
         """Attach or clear an external sink that receives emitted events."""
 
         self._sink = sink
+
+    def attach_validator(
+        self, validator: Callable[[TraceEvent], None] | None
+    ) -> None:
+        """Register a validator invoked for every emitted event."""
+
+        self._validator = validator
 
     def emit(
         self,
@@ -48,6 +56,8 @@ class TraceEventEmitter:
             scope_id=scope_id,
             payload=MappingProxyType(data),
         )
+        if self._validator is not None:
+            self._validator(record)
         self._events.append(record)
         if self._sink is not None:
             self._sink(record)

--- a/codex/code/work/tests/test_flow_runner_loop_policy.py
+++ b/codex/code/work/tests/test_flow_runner_loop_policy.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+
+from codex.code.work.dsl import budget_models as bm
+from codex.code.work.dsl.budget_manager import BudgetManager
+from codex.code.work.dsl.flow_runner import FlowRunner, ToolAdapter
+from codex.code.work.dsl.trace import TraceEventEmitter
+from pkgs.dsl.policy import PolicyStack, PolicyViolationError
+
+
+class LoopAwareAdapter(ToolAdapter):
+    """Adapter that records iteration-aware executions."""
+
+    def __init__(
+        self,
+        *,
+        cost_ms: float,
+        result_factory: Callable[[dict[str, object]], object] | None = None,
+    ) -> None:  # type: ignore[override]
+        self._cost_snapshot = {"time_ms": cost_ms}
+        self._result_factory = result_factory or (lambda node: node["id"])
+        self.executed: list[str] = []
+
+    def estimate_cost(self, node: dict[str, object]) -> dict[str, float]:  # type: ignore[override]
+        return dict(self._cost_snapshot)
+
+    def execute(self, node: dict[str, object]) -> object:  # type: ignore[override]
+        iteration = node.get("iteration")
+        token = f"{node['id']}@{iteration}" if iteration is not None else str(node["id"])
+        self.executed.append(token)
+        return self._result_factory(node)
+
+
+@pytest.fixture()
+def trace_emitter() -> TraceEventEmitter:
+    return TraceEventEmitter()
+
+
+@pytest.fixture()
+def policy_stack() -> PolicyStack:
+    tools = {"echo": {"tags": []}}
+    return PolicyStack(tools=tools, trace=None, event_sink=None)
+
+
+def _loop_specs(trace: TraceEventEmitter) -> BudgetManager:
+    specs = [
+        bm.BudgetSpec(
+            name="run-soft",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 500}),
+            mode="soft",
+            breach_action="warn",
+        ),
+        bm.BudgetSpec(
+            name="loop-stop",
+            scope_type="loop",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 80}),
+            mode="soft",
+            breach_action="stop",
+        ),
+        bm.BudgetSpec(
+            name="node-hard",
+            scope_type="node",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 200}),
+            mode="hard",
+            breach_action="stop",
+        ),
+    ]
+    return BudgetManager(specs=specs, trace=trace)
+
+
+def test_loop_scope_stop_emits_trace_and_breaks_iterations(
+    trace_emitter: TraceEventEmitter,
+    policy_stack: PolicyStack,
+) -> None:
+    manager = _loop_specs(trace_emitter)
+    adapter = LoopAwareAdapter(cost_ms=40.0)
+    runner = FlowRunner(
+        adapters={"echo": adapter},
+        budget_manager=manager,
+        policy_stack=policy_stack,
+        trace=trace_emitter,
+    )
+
+    loop_node = {
+        "id": "loop-1",
+        "kind": "loop",
+        "body": [
+            {"id": "node-a", "tool": "echo", "params": {}},
+        ],
+        "max_iterations": 5,
+    }
+
+    results = runner.run(flow_id="flow-loop", run_id="run-loop", nodes=[loop_node])
+
+    assert [exec.node_id for exec in results] == ["node-a", "node-a"]
+    assert [exec.iteration for exec in results] == [1, 2]
+    assert adapter.executed == ["node-a@1", "node-a@2"]
+
+    events = [(evt.event, evt.scope_type) for evt in trace_emitter.events]
+    assert ("loop_start", "loop") in events
+    assert any(evt.event == "loop_stop" and evt.scope_id == "loop-1" for evt in trace_emitter.events)
+    assert adapter.executed.count("node-a@1") == 1
+
+
+def test_policy_violation_leaves_budgets_uncharged(
+    trace_emitter: TraceEventEmitter,
+    policy_stack: PolicyStack,
+) -> None:
+    manager = _loop_specs(trace_emitter)
+    policy_stack.push({"deny_tools": ["echo"]}, scope="test")
+    adapter = LoopAwareAdapter(cost_ms=10.0)
+    runner = FlowRunner(
+        adapters={"echo": adapter},
+        budget_manager=manager,
+        policy_stack=policy_stack,
+        trace=trace_emitter,
+    )
+    nodes = [{"id": "n1", "tool": "echo", "params": {}}]
+
+    try:
+        with pytest.raises(PolicyViolationError):
+            runner.run(flow_id="flow-policy", run_id="run-policy", nodes=nodes)
+    finally:
+        policy_stack.pop("test")
+
+    run_scope = bm.ScopeKey(scope_type="run", scope_id="run-policy")
+    assert manager.spent(run_scope, "run-soft") == bm.CostSnapshot.zero()
+    assert adapter.executed == []
+
+    events = [evt.event for evt in trace_emitter.events]
+    assert "policy_violation" in events
+    assert "budget_charge" not in events

--- a/codex/code/work/tests/test_trace_emitter_validation.py
+++ b/codex/code/work/tests/test_trace_emitter_validation.py
@@ -1,0 +1,43 @@
+import pytest
+
+from codex.code.work.dsl.trace import TraceEventEmitter
+
+
+def _budget_validator(event):
+    if event.event == "budget_charge" and "spec_name" not in event.payload:
+        raise ValueError("budget charge payload missing spec_name")
+
+
+def test_validator_accepts_valid_budget_event() -> None:
+    emitter = TraceEventEmitter()
+    captured: list = []
+    emitter.attach_validator(_budget_validator)
+    emitter.attach_sink(captured.append)
+
+    event = emitter.emit(
+        "budget_charge",
+        scope_type="run",
+        scope_id="run-1",
+        payload={"spec_name": "run", "remaining": {}, "overage": {}},
+    )
+
+    assert emitter.events == (event,)
+    assert captured == [event]
+
+
+def test_validator_blocks_invalid_event() -> None:
+    emitter = TraceEventEmitter()
+    captured: list = []
+    emitter.attach_validator(_budget_validator)
+    emitter.attach_sink(captured.append)
+
+    with pytest.raises(ValueError):
+        emitter.emit(
+            "budget_charge",
+            scope_type="run",
+            scope_id="run-1",
+            payload={"remaining": {}},
+        )
+
+    assert emitter.events == ()
+    assert captured == []


### PR DESCRIPTION
## Summary
- extend FlowRunner with loop-aware execution, preview-before-commit budgeting, and iteration traces
- add trace emitter validator hook plus regression tests for loop stops and policy denials
- publish phase 3 planning, review, post-execution, documentation, and missing test artifacts

## Testing
- pytest codex/code/work/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8bdef46f0832cb681466563bffb89