### PR TITLE
Phase 3: stage budget guard integration workspace

### DIFF
--- a/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.md
+++ b/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.md
@@ -1,0 +1,14 @@
+# Phase 3 Post-Execution – Budget guards and runner integration
+
+## Test Summary
+- `pytest codex/code/integrate_budget_guards_runner_p3/tests -q`
+  - All 11 tests passed covering trace emitter, budget math, manager lifecycle, and FlowRunner integration scenarios.
+
+## Coverage & Behaviour Notes
+- TraceEventEmitter verified for immutability and sink forwarding; no mutation leaks observed.
+- BudgetManager history lookup validated after scope exit, ensuring diagnostic inspection persists beyond execution.
+- FlowRunner propagates `PolicyViolationError` with accompanying trace payloads while stopping on node-level budget breaches and warning on soft run budgets.
+
+## Follow-ups
+- Consider bridging PolicyStack `policy_resolved` events into the shared emitter when schema validation tooling is available.
+- Extend tests to cover nested loop scopes and combined policy + budget breaches in future phases.

--- a/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.md
+++ b/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.md
@@ -1,0 +1,10 @@
+# Phase 3 Preview – Budget guards and runner integration
+
+## Overview
+- Branch workspace `codex/code/integrate_budget_guards_runner_p3` stages the canonical budget models, manager, and FlowRunner abstractions from the synthesis plan.
+- Trace emission uses the shared `TraceEventEmitter` to capture immutable payloads for budget charges, breaches, run/node lifecycle, and policy violations.
+- Tests target cost normalisation, decision blocking, manager lifecycle (including history), and FlowRunner integration with policy enforcement and adapter-backed execution.
+
+## Planned Validation
+- Unit suites under `codex/code/integrate_budget_guards_runner_p3/tests/` cover trace emitter, budget model math, manager orchestration, and FlowRunner end-to-end behaviours.
+- pytest command: `pytest codex/code/integrate_budget_guards_runner_p3/tests -q`

--- a/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.md
+++ b/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.md
@@ -1,0 +1,12 @@
+# Phase 3 Review Notes – Budget guards and runner integration
+
+## Checklist
+- [x] Trace payloads use `MappingProxyType` to guarantee immutability before emission.
+- [x] BudgetManager tracks scope state, raises `BudgetBreachError` for blocking outcomes, and persists history for inspection.
+- [x] FlowRunner integrates adapters, policy enforcement, and budget guards while emitting lifecycle + violation traces.
+- [x] Tests reside under `codex/code/integrate_budget_guards_runner_p3/tests/` satisfying branch segmentation requirement.
+- [x] pytest suite (`pytest codex/code/integrate_budget_guards_runner_p3/tests -q`) passes locally.
+
+## Notes
+- Policy traces currently surface violations through the shared emitter; future work may map `policy_resolved` records explicitly if schema gating demands it.
+- Trace sink attachment remains synchronous but is pluggable for downstream streaming once schema validators land.

--- a/codex/DOCUMENTATION/P3/integrate_budget_guards_runner_p3-20250518-gpt5codex.yaml
+++ b/codex/DOCUMENTATION/P3/integrate_budget_guards_runner_p3-20250518-gpt5codex.yaml
@@ -1,0 +1,54 @@
+component: integrate_budget_guards_runner_p3
+purpose: |
+  Stage the canonical budget data models, manager orchestration, and adapter-backed FlowRunner
+  inside the Phase 3 workspace for branch-isolated validation of budget guards and policy traces.
+cli_usage:
+  description: Execute the branch-scoped regression suite for budgets and runner integration.
+  command: pytest codex/code/integrate_budget_guards_runner_p3/tests -q
+public_interfaces:
+  - name: codex.code.integrate_budget_guards_runner_p3.dsl.trace.TraceEventEmitter
+    description: Emits immutable trace records with optional sink forwarding for observability pipelines.
+  - name: codex.code.integrate_budget_guards_runner_p3.dsl.budget_models.CostSnapshot
+    description: Normalises raw adapter estimates (seconds/milliseconds/tokens) into canonical charge units.
+  - name: codex.code.integrate_budget_guards_runner_p3.dsl.budget_manager.BudgetManager
+    description: Coordinates scope lifecycle, preview/commit flows, breach tracing, and state inspection.
+  - name: codex.code.integrate_budget_guards_runner_p3.dsl.flow_runner.FlowRunner
+    description: Executes nodes through adapters with integrated budget enforcement and policy violations handling.
+extension_hooks:
+  - hook: TraceEventEmitter.attach_sink
+    extension: Attach downstream logging/telemetry sinks to receive immutable trace events.
+  - hook: BudgetManager.record_breach
+    extension: Override to enrich or reroute breach diagnostics before raising stop conditions.
+configurable_options:
+  - name: BudgetSpec.mode
+    values: [hard, soft]
+    default: hard
+  - name: BudgetSpec.breach_action
+    values: [stop, warn]
+    default: stop
+automation_triggers:
+  - trigger: FlowRunner.run
+    outcome: Executes adapter nodes, enforcing budgets/policies and emitting trace records per node/run scope.
+  - trigger: BudgetManager.commit_charge
+    outcome: Persists spend totals and emits `budget_charge` events for downstream monitors.
+error_contracts:
+  - name: BudgetBreachError
+    raised_when: A blocking budget outcome is committed after preview signalling stop semantics.
+    payload: Contains the breached scope key and the associated BudgetChargeOutcome.
+  - name: BudgetError
+    raised_when: Manager invariants are broken (e.g., missing scope state or blocking decision without outcome).
+serialization:
+  trace_payloads: Immutable mapping proxies including scope metadata, spend totals, remaining budget, and overages.
+  cost_snapshot: JSON-compatible dict with `time_ms` (float) and `tokens` (int) for logging/telemetry.
+lifecycle:
+  - FlowRunner enters run scope -> per-node scope -> previews budgets -> records breach warnings -> commits charges or raises.
+  - BudgetManager retains last scope state in history for inspection after exit.
+typing:
+  language: Python 3.12
+  typing: Dataclasses and Protocols provide static typing for models and adapters.
+security:
+  - Trust boundary remains at adapter execution; FlowRunner assumes adapters are safe and synchronous.
+  - Trace payloads may include tool identifiers—ensure downstream sinks are access-controlled.
+performance:
+  - Budget computations are O(number of specs per scope) and rely on simple numeric arithmetic.
+  - Trace emission is synchronous; attach asynchronous sinks if high-volume execution becomes a bottleneck.

--- a/codex/TESTS/P3/integrate_budget_guards_runner_p3-20250518-gpt5codex.yaml
+++ b/codex/TESTS/P3/integrate_budget_guards_runner_p3-20250518-gpt5codex.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_flow_runner_loop_scope_breach_stops_nested_execution
+      rationale: Current suite covers run/node scopes only; loop scope semantics and stop propagation remain untested.
+      source_module: codex/code/integrate_budget_guards_runner_p3/dsl/flow_runner.py
+      priority: high
+    - name: test_policy_and_budget_violation_same_node
+      rationale: Need regression asserting simultaneous policy denial and budget breach ordering for trace emission.
+      source_module: codex/code/integrate_budget_guards_runner_p3/dsl/flow_runner.py
+      priority: medium
+    - name: test_budget_manager_reenter_scope_error_message
+      rationale: Entering an already active scope should raise with informative error; currently unverified.
+      source_module: codex/code/integrate_budget_guards_runner_p3/dsl/budget_manager.py
+      priority: low

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.yaml
@@ -1,0 +1,71 @@
+summary: Re-stage canonical budget manager and FlowRunner integration with schema-aligned traces for branch-specific testing.
+justification: |
+  Phase 2 established the object model (CostSnapshot, BudgetSpec, BudgetDecision), manager orchestration, and FlowRunner hooks.
+  Phase 3 must port these pieces into the new branch workspace while validating budget + policy behaviour and immutable tracing.
+  The plan mirrors the prior "work" branch but enforces branch-scoped tests and adds coverage for trace payload immutability.
+steps:
+  - analyse_prior_artifacts: Review P2 previews/reviews/postexecution outputs to reuse tested abstractions and avoid regressions.
+  - stage_branch_workspace: Create codex/code/integrate_budget_guards_runner_p3 with module skeletons and branch-local __init__ files.
+  - author_tests_first: Port and extend budget model/manager/runner tests into branch-scoped suite asserting trace emissions.
+  - implement_domain_models: Recreate CostSnapshot, BudgetSpec, BudgetChargeOutcome, and BudgetDecision with normalization helpers.
+  - implement_budget_manager: Provide scope lifecycle, preview/commit/record breach flows, and trace emission.
+  - implement_flow_runner: Integrate adapters, budgets, and policy stack with stop/warn semantics and policy trace forwarding.
+  - validate_trace_emitter: Ensure TraceEventEmitter emits immutable payloads and supports sink attachment (unit tested).
+  - run_pytest: Execute pytest for branch tests verifying red/green cycle.
+modules:
+  codex/code/integrate_budget_guards_runner_p3/__init__.py: Package marker for branch workspace.
+  codex/code/integrate_budget_guards_runner_p3/dsl/__init__.py: DSL namespace init exporting key classes.
+  codex/code/integrate_budget_guards_runner_p3/dsl/trace.py: Immutable trace event dataclass and emitter with sink support.
+  codex/code/integrate_budget_guards_runner_p3/dsl/budget_models.py: Budget scope keys, specs, cost snapshots, and decision helpers.
+  codex/code/integrate_budget_guards_runner_p3/dsl/budget_manager.py: Scope-aware manager orchestrating preview/commit and traces.
+  codex/code/integrate_budget_guards_runner_p3/dsl/flow_runner.py: Adapter-backed FlowRunner wiring budgets and policies.
+tests:
+  - file: codex/code/integrate_budget_guards_runner_p3/tests/conftest.py
+    focus: Insert repository root onto sys.path for imports; branch-isolated fixtures.
+  - file: codex/code/integrate_budget_guards_runner_p3/tests/test_trace_emitter.py
+    coverage: Ensure TraceEventEmitter returns immutable events and forwards to sinks.
+  - file: codex/code/integrate_budget_guards_runner_p3/tests/test_budget_models.py
+    coverage: Cost normalization, charge math, decision blocking, trace payload immutability.
+  - file: codex/code/integrate_budget_guards_runner_p3/tests/test_budget_manager.py
+    coverage: Scope lifecycle, preview/commit stop semantics, breach tracing, history inspection.
+  - file: codex/code/integrate_budget_guards_runner_p3/tests/test_flow_runner_budget_integration.py
+    coverage: Adapter integration, policy enforcement, run/node budgets, breach warnings/stops, trace sequencing.
+run_order:
+  - author_tests_first
+  - implement_domain_models
+  - implement_budget_manager
+  - implement_flow_runner
+  - validate_trace_emitter
+  - run_pytest
+interfaces:
+  - name: TraceEventEmitter
+    contract: emit(event, scope_type, scope_id, payload) -> TraceEvent; payload is immutable mapping; optional sink callback.
+  - name: BudgetManager
+    contract: enter_scope/exit_scope, preview_charge returning BudgetDecision, commit_charge raising BudgetBreachError for blocking outcomes, record_breach for warnings.
+  - name: FlowRunner
+    contract: run(flow_id, run_id, nodes) -> list[NodeExecution]; integrates PolicyStack.enforce and BudgetManager charges per scope.
+  - name: ToolAdapter
+    contract: estimate_cost(node) -> Mapping; execute(node) -> object; FlowRunner obtains adapters by tool key.
+tdd_coverage_targets:
+  budget_models: 0.9
+  budget_manager: 0.9
+  flow_runner: 0.85
+  trace: 0.9
+review_checklist:
+  - Validate trace events use MappingProxyType to prevent mutation.
+  - Confirm BudgetManager history retains last scope state post-exit for inspection tests.
+  - Ensure FlowRunner stops on blocking budget outcomes and emits budget_breach before raising.
+  - Verify PolicyStack interactions raise PolicyViolationError and propagate traces.
+  - Check tests reside under codex/code/integrate_budget_guards_runner_p3/tests/ per branch requirement.
+outputs:
+  - codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.yaml
+  - codex/code/integrate_budget_guards_runner_p3/dsl/trace.py
+  - codex/code/integrate_budget_guards_runner_p3/dsl/budget_models.py
+  - codex/code/integrate_budget_guards_runner_p3/dsl/budget_manager.py
+  - codex/code/integrate_budget_guards_runner_p3/dsl/flow_runner.py
+  - codex/code/integrate_budget_guards_runner_p3/tests/*
+  - PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.md
+  - REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.md
+  - POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex.md
+  - codex/DOCUMENTATION/P3/integrate_budget_guards_runner_p3-20250518-gpt5codex.yaml
+  - codex/TESTS/P3/integrate_budget_guards_runner_p3-20250518-gpt5codex.yaml

--- a/codex/code/integrate_budget_guards_runner_p3/__init__.py
+++ b/codex/code/integrate_budget_guards_runner_p3/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 3 branch workspace for budget guard integration."""

--- a/codex/code/integrate_budget_guards_runner_p3/dsl/__init__.py
+++ b/codex/code/integrate_budget_guards_runner_p3/dsl/__init__.py
@@ -1,0 +1,31 @@
+"""DSL namespace for integrate_budget_guards_runner_p3 branch."""
+
+__all__ = [
+    "TraceEventEmitter",
+    "TraceEvent",
+    "CostSnapshot",
+    "BudgetSpec",
+    "BudgetCharge",
+    "BudgetChargeOutcome",
+    "BudgetDecision",
+    "BudgetManager",
+    "BudgetBreachError",
+    "BudgetError",
+    "FlowRunner",
+    "ToolAdapter",
+    "NodeExecution",
+]
+
+from .trace import TraceEvent, TraceEventEmitter
+from .budget_models import (
+    CostSnapshot,
+    BudgetSpec,
+    BudgetCharge,
+    BudgetChargeOutcome,
+    BudgetDecision,
+    ScopeKey,
+)
+from .budget_manager import BudgetBreachError, BudgetError, BudgetManager
+from .flow_runner import FlowRunner, NodeExecution, ToolAdapter
+
+__all__.append("ScopeKey")

--- a/codex/code/integrate_budget_guards_runner_p3/dsl/budget_manager.py
+++ b/codex/code/integrate_budget_guards_runner_p3/dsl/budget_manager.py
@@ -1,0 +1,139 @@
+"""Scope-aware budget manager coordinating previews, commits, and traces."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from . import budget_models as bm
+from .trace import TraceEventEmitter
+
+__all__ = ["BudgetManager", "BudgetBreachError", "BudgetError"]
+
+
+class BudgetError(RuntimeError):
+    """Base error for budget management."""
+
+
+class BudgetBreachError(BudgetError):
+    """Raised when a budget breach requires execution to stop."""
+
+    def __init__(self, scope: bm.ScopeKey, outcome: bm.BudgetChargeOutcome) -> None:
+        super().__init__(
+            f"Budget '{outcome.spec.name}' breached at {scope.scope_type}:{scope.scope_id}"
+        )
+        self.scope = scope
+        self.outcome = outcome
+
+
+@dataclass(slots=True)
+class _ScopeState:
+    scope: bm.ScopeKey
+    spent: dict[str, bm.CostSnapshot]
+
+
+class BudgetManager:
+    """Coordinate budget previews and commits across scopes."""
+
+    def __init__(
+        self,
+        *,
+        specs: Iterable[bm.BudgetSpec],
+        trace: TraceEventEmitter | None = None,
+    ) -> None:
+        self._trace = trace or TraceEventEmitter()
+        self._specs_by_scope: dict[str, list[bm.BudgetSpec]] = defaultdict(list)
+        for spec in specs:
+            self._specs_by_scope[spec.scope_type].append(spec)
+        self._scopes: dict[bm.ScopeKey, _ScopeState] = {}
+        self._history: dict[bm.ScopeKey, _ScopeState] = {}
+
+    # ------------------------------------------------------------------
+    # Scope management
+    # ------------------------------------------------------------------
+    def enter_scope(self, scope: bm.ScopeKey) -> None:
+        if scope in self._scopes:
+            raise KeyError(f"scope already active: {scope}")
+        self._history.pop(scope, None)
+        specs = self._specs_by_scope.get(scope.scope_type, [])
+        spent = {spec.name: bm.CostSnapshot.zero() for spec in specs}
+        self._scopes[scope] = _ScopeState(scope=scope, spent=spent)
+
+    def exit_scope(self, scope: bm.ScopeKey) -> None:
+        if scope not in self._scopes:
+            raise KeyError(f"scope not active: {scope}")
+        state = self._scopes.pop(scope)
+        self._history[scope] = state
+
+    # ------------------------------------------------------------------
+    # Charging
+    # ------------------------------------------------------------------
+    def preview_charge(
+        self,
+        scope: bm.ScopeKey,
+        cost: bm.CostSnapshot,
+    ) -> bm.BudgetDecision:
+        state = self._scopes.get(scope)
+        if state is None:
+            raise KeyError(f"scope not active: {scope}")
+        specs = self._specs_by_scope.get(scope.scope_type, [])
+        outcomes: list[bm.BudgetChargeOutcome] = []
+        for spec in specs:
+            prior = state.spent[spec.name]
+            outcome = bm.BudgetChargeOutcome.compute(spec=spec, prior=prior, cost=cost)
+            outcomes.append(outcome)
+        decision = bm.BudgetDecision.make(scope=scope, cost=cost, outcomes=outcomes)
+        return decision
+
+    def commit_charge(self, decision: bm.BudgetDecision) -> None:
+        state = self._scopes.get(decision.scope)
+        if state is None:
+            raise KeyError(f"scope not active: {decision.scope}")
+        if decision.should_stop:
+            blocking = decision.blocking
+            if blocking is None:  # pragma: no cover - defensive guard
+                raise BudgetError("blocking outcome missing for stop decision")
+            raise BudgetBreachError(decision.scope, blocking)
+        for outcome in decision.outcomes:
+            state.spent[outcome.spec.name] = outcome.charge.new_total
+            self._trace.emit(
+                "budget_charge",
+                scope_type=decision.scope.scope_type,
+                scope_id=decision.scope.scope_id,
+                payload=outcome.to_trace_payload(
+                    scope_type=decision.scope.scope_type,
+                    scope_id=decision.scope.scope_id,
+                ),
+            )
+
+    def record_breach(self, decision: bm.BudgetDecision) -> None:
+        state = self._scopes.get(decision.scope)
+        if state is None:
+            raise KeyError(f"scope not active: {decision.scope}")
+        for outcome in decision.outcomes:
+            if outcome.breached:
+                self._trace.emit(
+                    "budget_breach",
+                    scope_type=decision.scope.scope_type,
+                    scope_id=decision.scope.scope_id,
+                    payload=outcome.to_trace_payload(
+                        scope_type=decision.scope.scope_type,
+                        scope_id=decision.scope.scope_id,
+                    ),
+                )
+
+    # ------------------------------------------------------------------
+    # Inspection helpers
+    # ------------------------------------------------------------------
+    def spent(self, scope: bm.ScopeKey, spec_name: str) -> bm.CostSnapshot:
+        state = self._scopes.get(scope)
+        if state is None:
+            state = self._history.get(scope)
+            if state is None:
+                raise KeyError(f"scope not active: {scope}")
+        return state.spent[spec_name]
+
+    @property
+    def trace(self) -> TraceEventEmitter:
+        return self._trace

--- a/codex/code/integrate_budget_guards_runner_p3/dsl/budget_models.py
+++ b/codex/code/integrate_budget_guards_runner_p3/dsl/budget_models.py
@@ -1,0 +1,212 @@
+"""Canonical budget models reused by manager and FlowRunner."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .trace import TraceEventEmitter
+
+__all__ = [
+    "ScopeKey",
+    "CostSnapshot",
+    "BudgetSpec",
+    "BudgetCharge",
+    "BudgetChargeOutcome",
+    "BudgetDecision",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ScopeKey:
+    """Identifies a budget scope (run/node/loop/etc.)."""
+
+    scope_type: str
+    scope_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class CostSnapshot:
+    """Normalized cost snapshot in milliseconds and tokens."""
+
+    time_ms: float = 0.0
+    tokens: int = 0
+
+    def __add__(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot(
+            time_ms=self.time_ms + other.time_ms,
+            tokens=self.tokens + other.tokens,
+        )
+
+    def __sub__(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot(
+            time_ms=max(0.0, self.time_ms - other.time_ms),
+            tokens=max(0, self.tokens - other.tokens),
+        )
+
+    @classmethod
+    def zero(cls) -> "CostSnapshot":
+        return cls()
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any] | None) -> "CostSnapshot":
+        if raw is None:
+            return cls.zero()
+        time_ms = float(raw.get("time_ms", 0.0))
+        if "time_s" in raw:
+            time_ms += float(raw["time_s"]) * 1000.0
+        tokens = int(raw.get("tokens", 0))
+        return cls(time_ms=time_ms, tokens=tokens)
+
+    def has_positive(self) -> bool:
+        return self.time_ms > 0.0 or self.tokens > 0
+
+    def to_payload(self) -> dict[str, float | int]:
+        return {"time_ms": float(self.time_ms), "tokens": int(self.tokens)}
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetSpec:
+    """Declarative definition of a budget."""
+
+    name: str
+    scope_type: str
+    limit: CostSnapshot
+    mode: str = "hard"  # "hard" or "soft"
+    breach_action: str = "stop"  # "stop" or "warn"
+
+    def __post_init__(self) -> None:  # pragma: no cover - validation
+        mode = self.mode.lower()
+        action = self.breach_action.lower()
+        if mode not in {"hard", "soft"}:
+            raise ValueError("mode must be 'hard' or 'soft'")
+        if action not in {"stop", "warn"}:
+            raise ValueError("breach_action must be 'stop' or 'warn'")
+        object.__setattr__(self, "mode", mode)
+        object.__setattr__(self, "breach_action", action)
+
+    def should_stop(self, breached: bool) -> bool:
+        if not breached:
+            return False
+        if self.mode == "hard":
+            return True
+        return self.breach_action == "stop"
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetCharge:
+    """Computed charge against a spec."""
+
+    spec: BudgetSpec
+    cost: CostSnapshot
+    prior: CostSnapshot
+    new_total: CostSnapshot
+    remaining: CostSnapshot
+    overage: CostSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetChargeOutcome:
+    """Outcome of applying a cost to a budget spec."""
+
+    spec: BudgetSpec
+    charge: BudgetCharge
+    breached: bool
+
+    @classmethod
+    def compute(
+        cls,
+        *,
+        spec: BudgetSpec,
+        prior: CostSnapshot,
+        cost: CostSnapshot,
+    ) -> "BudgetChargeOutcome":
+        new_total = prior + cost
+        remaining_time = spec.limit.time_ms - new_total.time_ms
+        remaining_tokens = spec.limit.tokens - new_total.tokens
+        remaining = CostSnapshot(time_ms=remaining_time, tokens=remaining_tokens)
+        overage = CostSnapshot(
+            time_ms=max(0.0, -remaining_time),
+            tokens=max(0, -remaining_tokens),
+        )
+        breached = overage.has_positive()
+        charge = BudgetCharge(
+            spec=spec,
+            cost=cost,
+            prior=prior,
+            new_total=new_total,
+            remaining=remaining,
+            overage=overage,
+        )
+        return cls(spec=spec, charge=charge, breached=breached)
+
+    @property
+    def should_stop(self) -> bool:
+        return self.spec.should_stop(self.breached)
+
+    def to_trace_payload(self, *, scope_type: str, scope_id: str) -> Mapping[str, Any]:
+        from types import MappingProxyType
+
+        payload = {
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "spec_name": self.spec.name,
+            "mode": self.spec.mode,
+            "breach_action": self.spec.breach_action,
+            "breached": self.breached,
+            "should_stop": self.should_stop,
+            "cost": self.charge.cost.to_payload(),
+            "prior": self.charge.prior.to_payload(),
+            "new_total": self.charge.new_total.to_payload(),
+            "remaining": self.charge.remaining.to_payload(),
+            "overage": self.charge.overage.to_payload(),
+        }
+        return MappingProxyType(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetDecision:
+    """Aggregate of multiple budget outcomes for a scope."""
+
+    scope: ScopeKey
+    cost: CostSnapshot
+    outcomes: tuple[BudgetChargeOutcome, ...]
+    blocking: BudgetChargeOutcome | None
+
+    @classmethod
+    def make(
+        cls,
+        *,
+        scope: ScopeKey,
+        cost: CostSnapshot,
+        outcomes: Iterable[BudgetChargeOutcome],
+    ) -> "BudgetDecision":
+        materialized = tuple(outcomes)
+        blocking = next((out for out in materialized if out.should_stop), None)
+        return cls(scope=scope, cost=cost, outcomes=materialized, blocking=blocking)
+
+    @property
+    def breached(self) -> bool:
+        return any(outcome.breached for outcome in self.outcomes)
+
+    @property
+    def should_stop(self) -> bool:
+        return self.blocking is not None
+
+    def to_trace_records(
+        self,
+        *,
+        emitter: TraceEventEmitter,
+        event: str,
+    ) -> None:
+        for outcome in self.outcomes:
+            emitter.emit(
+                event,
+                scope_type=self.scope.scope_type,
+                scope_id=self.scope.scope_id,
+                payload=outcome.to_trace_payload(
+                    scope_type=self.scope.scope_type,
+                    scope_id=self.scope.scope_id,
+                ),
+            )

--- a/codex/code/integrate_budget_guards_runner_p3/dsl/flow_runner.py
+++ b/codex/code/integrate_budget_guards_runner_p3/dsl/flow_runner.py
@@ -1,0 +1,132 @@
+"""Adapter-backed FlowRunner integrating budgets and policies."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from pkgs.dsl.policy import PolicyStack, PolicyViolationError
+
+from . import budget_models as bm
+from .budget_manager import BudgetBreachError, BudgetError, BudgetManager
+from .trace import TraceEventEmitter
+
+__all__ = ["ToolAdapter", "NodeExecution", "FlowRunner"]
+
+
+@runtime_checkable
+class ToolAdapter(Protocol):
+    """Protocol implemented by tool adapters."""
+
+    def estimate_cost(self, node: Mapping[str, object]) -> Mapping[str, object]:
+        ...
+
+    def execute(self, node: Mapping[str, object]) -> object:
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class NodeExecution:
+    """Immutable record of node execution."""
+
+    node_id: str
+    tool: str
+    result: object
+
+
+class FlowRunner:
+    """Execute flow nodes with policy enforcement and budget guards."""
+
+    def __init__(
+        self,
+        *,
+        adapters: Mapping[str, ToolAdapter],
+        budget_manager: BudgetManager,
+        policy_stack: PolicyStack,
+        trace: TraceEventEmitter | None = None,
+    ) -> None:
+        self._adapters = dict(adapters)
+        self._budgets = budget_manager
+        self._policies = policy_stack
+        self._trace = trace or budget_manager.trace
+
+    def run(
+        self,
+        *,
+        flow_id: str,
+        run_id: str,
+        nodes: Iterable[Mapping[str, object]],
+    ) -> list[NodeExecution]:
+        run_scope = bm.ScopeKey(scope_type="run", scope_id=run_id)
+        self._budgets.enter_scope(run_scope)
+        self._trace.emit(
+            "run_start",
+            scope_type="run",
+            scope_id=run_id,
+            payload={"flow_id": flow_id},
+        )
+        executions: list[NodeExecution] = []
+        try:
+            for raw_node in nodes:
+                node_id = str(raw_node["id"])
+                tool = str(raw_node["tool"])
+                adapter = self._adapters.get(tool)
+                if adapter is None:
+                    raise KeyError(f"unknown adapter for tool '{tool}'")
+                node_scope = bm.ScopeKey(scope_type="node", scope_id=node_id)
+                self._budgets.enter_scope(node_scope)
+                self._trace.emit(
+                    "node_start",
+                    scope_type="node",
+                    scope_id=node_id,
+                    payload={"tool": tool},
+                )
+                try:
+                    self._policies.enforce(tool)
+                    cost_snapshot = bm.CostSnapshot.from_raw(adapter.estimate_cost(raw_node))
+                    self._apply_budget(run_scope, cost_snapshot)
+                    self._apply_budget(node_scope, cost_snapshot)
+                    result = adapter.execute(raw_node)
+                    executions.append(
+                        NodeExecution(node_id=node_id, tool=tool, result=result)
+                    )
+                    self._trace.emit(
+                        "node_complete",
+                        scope_type="node",
+                        scope_id=node_id,
+                        payload={"tool": tool},
+                    )
+                except PolicyViolationError as exc:
+                    self._trace.emit(
+                        "policy_violation",
+                        scope_type="node",
+                        scope_id=node_id,
+                        payload={"tool": tool, "error": str(exc)},
+                    )
+                    raise
+                finally:
+                    self._budgets.exit_scope(node_scope)
+            self._trace.emit(
+                "run_complete",
+                scope_type="run",
+                scope_id=run_id,
+                payload={"flow_id": flow_id},
+            )
+            return executions
+        finally:
+            self._budgets.exit_scope(run_scope)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _apply_budget(self, scope: bm.ScopeKey, cost: bm.CostSnapshot) -> None:
+        decision = self._budgets.preview_charge(scope, cost)
+        if decision.breached:
+            self._budgets.record_breach(decision)
+        if decision.should_stop:
+            blocking = decision.blocking
+            if blocking is None:  # pragma: no cover - defensive guard
+                raise BudgetError("blocking outcome missing for stop decision")
+            raise BudgetBreachError(scope, blocking)
+        self._budgets.commit_charge(decision)

--- a/codex/code/integrate_budget_guards_runner_p3/dsl/trace.py
+++ b/codex/code/integrate_budget_guards_runner_p3/dsl/trace.py
@@ -1,0 +1,60 @@
+"""Immutable trace event emitter used by budget and policy layers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+__all__ = ["TraceEvent", "TraceEventEmitter"]
+
+
+@dataclass(frozen=True, slots=True)
+class TraceEvent:
+    """Immutable trace record."""
+
+    event: str
+    scope_type: str
+    scope_id: str
+    payload: Mapping[str, Any]
+
+
+class TraceEventEmitter:
+    """Emit immutable trace events with optional sink forwarding."""
+
+    def __init__(self) -> None:
+        self._events: list[TraceEvent] = []
+        self._sink: Callable[[TraceEvent], None] | None = None
+
+    def attach_sink(self, sink: Callable[[TraceEvent], None] | None) -> None:
+        """Attach or clear an external sink that receives emitted events."""
+
+        self._sink = sink
+
+    def emit(
+        self,
+        event: str,
+        *,
+        scope_type: str,
+        scope_id: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> TraceEvent:
+        data = dict(payload or {})
+        record = TraceEvent(
+            event=event,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            payload=MappingProxyType(data),
+        )
+        self._events.append(record)
+        if self._sink is not None:
+            self._sink(record)
+        return record
+
+    @property
+    def events(self) -> tuple[TraceEvent, ...]:
+        return tuple(self._events)
+
+    def clear(self) -> None:
+        self._events.clear()

--- a/codex/code/integrate_budget_guards_runner_p3/phase3_runner.py
+++ b/codex/code/integrate_budget_guards_runner_p3/phase3_runner.py
@@ -1,0 +1,26 @@
+"""Utility script to execute Phase 3 regression suite for this branch workspace."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+TEST_PATH = ROOT / "codex" / "code" / "integrate_budget_guards_runner_p3" / "tests"
+LOG_PATH = ROOT / "POSTEXECUTION" / "P3" / "07b_budget_guards_and_runner_integration.yaml-20250518-gpt5codex-runlog.txt"
+
+
+def main() -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "pytest",
+        str(TEST_PATH),
+        "-q",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    LOG_PATH.write_text(result.stdout + "\n" + result.stderr)
+    result.check_returncode()
+
+
+if __name__ == "__main__":
+    main()

--- a/codex/code/integrate_budget_guards_runner_p3/tests/conftest.py
+++ b/codex/code/integrate_budget_guards_runner_p3/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Test configuration for integrate_budget_guards_runner_p3 branch."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/codex/code/integrate_budget_guards_runner_p3/tests/test_budget_manager.py
+++ b/codex/code/integrate_budget_guards_runner_p3/tests/test_budget_manager.py
@@ -1,0 +1,91 @@
+"""BudgetManager orchestration tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from codex.code.integrate_budget_guards_runner_p3.dsl import budget_models as bm
+from codex.code.integrate_budget_guards_runner_p3.dsl.budget_manager import (
+    BudgetBreachError,
+    BudgetManager,
+)
+from codex.code.integrate_budget_guards_runner_p3.dsl.trace import TraceEventEmitter
+
+
+@pytest.fixture()
+def trace_emitter() -> TraceEventEmitter:
+    return TraceEventEmitter()
+
+
+@pytest.fixture()
+def budget_specs() -> list[bm.BudgetSpec]:
+    return [
+        bm.BudgetSpec(
+            name="run-soft",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 60}),
+            mode="soft",
+            breach_action="warn",
+        ),
+        bm.BudgetSpec(
+            name="run-hard",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 60}),
+            mode="hard",
+            breach_action="stop",
+        ),
+    ]
+
+
+@pytest.fixture()
+def manager(trace_emitter: TraceEventEmitter, budget_specs: list[bm.BudgetSpec]) -> BudgetManager:
+    return BudgetManager(specs=budget_specs, trace=trace_emitter)
+
+
+def test_commit_records_spend_and_emits_trace(manager: BudgetManager, trace_emitter: TraceEventEmitter) -> None:
+    scope = bm.ScopeKey("run", "run-1")
+    manager.enter_scope(scope)
+    cost = bm.CostSnapshot.from_raw({"time_ms": 20})
+
+    decision = manager.preview_charge(scope, cost)
+    assert decision.should_stop is False
+
+    manager.commit_charge(decision)
+    remaining = manager.spent(scope, "run-soft")
+    assert remaining.time_ms == pytest.approx(20.0)
+
+    events = [evt for evt in trace_emitter.events if evt.event == "budget_charge"]
+    assert len(events) == 2
+
+    manager.exit_scope(scope)
+
+
+def test_commit_raises_on_blocking_outcome(manager: BudgetManager, trace_emitter: TraceEventEmitter) -> None:
+    scope = bm.ScopeKey("run", "run-stop")
+    manager.enter_scope(scope)
+    cost = bm.CostSnapshot.from_raw({"time_ms": 80})
+
+    decision = manager.preview_charge(scope, cost)
+    assert decision.should_stop is True
+
+    manager.record_breach(decision)
+    breach_events = [evt for evt in trace_emitter.events if evt.event == "budget_breach"]
+    assert len(breach_events) == 2
+
+    with pytest.raises(BudgetBreachError) as excinfo:
+        manager.commit_charge(decision)
+    assert excinfo.value.scope == scope
+
+    manager.exit_scope(scope)
+
+
+def test_spent_history_available_after_exit(manager: BudgetManager) -> None:
+    scope = bm.ScopeKey("run", "history")
+    manager.enter_scope(scope)
+    cost = bm.CostSnapshot.from_raw({"time_ms": 30})
+    decision = manager.preview_charge(scope, cost)
+    manager.commit_charge(decision)
+    manager.exit_scope(scope)
+
+    spent = manager.spent(scope, "run-soft")
+    assert spent.time_ms == pytest.approx(30.0)

--- a/codex/code/integrate_budget_guards_runner_p3/tests/test_budget_models.py
+++ b/codex/code/integrate_budget_guards_runner_p3/tests/test_budget_models.py
@@ -1,0 +1,76 @@
+"""Budget model behaviour tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from codex.code.integrate_budget_guards_runner_p3.dsl import budget_models as bm
+from codex.code.integrate_budget_guards_runner_p3.dsl.trace import TraceEventEmitter
+
+
+def test_cost_snapshot_from_raw_normalises_seconds_and_tokens() -> None:
+    snapshot = bm.CostSnapshot.from_raw({"time_s": 1.5, "tokens": 42})
+    assert snapshot.time_ms == pytest.approx(1500.0)
+    assert snapshot.tokens == 42
+
+    empty = bm.CostSnapshot.from_raw(None)
+    assert empty.time_ms == 0.0
+    assert empty.tokens == 0
+
+
+def test_budget_charge_outcome_compute_tracks_overage() -> None:
+    spec = bm.BudgetSpec(
+        name="node-hard",
+        scope_type="node",
+        limit=bm.CostSnapshot.from_raw({"time_ms": 100}),
+        mode="hard",
+        breach_action="stop",
+    )
+    prior = bm.CostSnapshot.from_raw({"time_ms": 70})
+    cost = bm.CostSnapshot.from_raw({"time_ms": 50})
+
+    outcome = bm.BudgetChargeOutcome.compute(spec=spec, prior=prior, cost=cost)
+
+    assert outcome.charge.new_total.time_ms == pytest.approx(120.0)
+    assert outcome.charge.overage.time_ms == pytest.approx(20.0)
+    assert outcome.breached is True
+    assert outcome.should_stop is True
+
+
+def test_budget_decision_emits_trace_records_and_identifies_blocking() -> None:
+    run_scope = bm.ScopeKey(scope_type="run", scope_id="run-1")
+    soft_spec = bm.BudgetSpec(
+        name="run-soft",
+        scope_type="run",
+        limit=bm.CostSnapshot.from_raw({"time_ms": 60}),
+        mode="soft",
+        breach_action="warn",
+    )
+    hard_spec = bm.BudgetSpec(
+        name="run-hard",
+        scope_type="run",
+        limit=bm.CostSnapshot.from_raw({"time_ms": 50}),
+        mode="hard",
+        breach_action="stop",
+    )
+    cost = bm.CostSnapshot.from_raw({"time_ms": 40})
+
+    soft_outcome = bm.BudgetChargeOutcome.compute(spec=soft_spec, prior=bm.CostSnapshot.zero(), cost=cost)
+    hard_outcome = bm.BudgetChargeOutcome.compute(spec=hard_spec, prior=bm.CostSnapshot.from_raw({"time_ms": 30}), cost=cost)
+
+    decision = bm.BudgetDecision.make(scope=run_scope, cost=cost, outcomes=[soft_outcome, hard_outcome])
+
+    assert decision.breached is True
+    assert decision.should_stop is True
+    assert decision.blocking is hard_outcome
+
+    emitter = TraceEventEmitter()
+    decision.to_trace_records(emitter=emitter, event="budget_charge")
+
+    events = emitter.events
+    assert len(events) == 2
+    for event in events:
+        with pytest.raises(TypeError):
+            event.payload["spec_name"] = "mutate"  # type: ignore[index]
+        assert event.payload["scope_type"] == "run"
+        assert event.payload["scope_id"] == "run-1"

--- a/codex/code/integrate_budget_guards_runner_p3/tests/test_flow_runner_budget_integration.py
+++ b/codex/code/integrate_budget_guards_runner_p3/tests/test_flow_runner_budget_integration.py
@@ -1,0 +1,163 @@
+"""Integration tests for FlowRunner budget and policy orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from codex.code.integrate_budget_guards_runner_p3.dsl import budget_models as bm
+from codex.code.integrate_budget_guards_runner_p3.dsl.budget_manager import BudgetBreachError, BudgetManager
+from codex.code.integrate_budget_guards_runner_p3.dsl.flow_runner import FlowRunner, ToolAdapter
+from codex.code.integrate_budget_guards_runner_p3.dsl.trace import TraceEventEmitter
+from pkgs.dsl.policy import PolicyStack, PolicyViolationError
+
+
+class FakeAdapter(ToolAdapter):
+    def __init__(self, cost_by_node: Mapping[str, Mapping[str, float]], results: Mapping[str, object]) -> None:
+        self._cost_by_node = dict(cost_by_node)
+        self._results = dict(results)
+        self.executed: list[str] = []
+
+    def estimate_cost(self, node: Mapping[str, object]) -> Mapping[str, float]:  # type: ignore[override]
+        return self._cost_by_node[node["id"]]
+
+    def execute(self, node: Mapping[str, object]) -> object:  # type: ignore[override]
+        node_id = str(node["id"])
+        self.executed.append(node_id)
+        return self._results[node_id]
+
+
+@pytest.fixture()
+def trace_emitter() -> TraceEventEmitter:
+    return TraceEventEmitter()
+
+
+@pytest.fixture()
+def policy_stack() -> PolicyStack:
+    tools = {"echo": {"tags": []}}
+    return PolicyStack(tools=tools, trace=None, event_sink=None)
+
+
+@pytest.fixture()
+def budget_manager(trace_emitter: TraceEventEmitter) -> BudgetManager:
+    specs = [
+        bm.BudgetSpec(
+            name="run-soft",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 100}),
+            mode="soft",
+            breach_action="warn",
+        ),
+        bm.BudgetSpec(
+            name="node-hard",
+            scope_type="node",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 50}),
+            mode="hard",
+            breach_action="stop",
+        ),
+    ]
+    return BudgetManager(specs=specs, trace=trace_emitter)
+
+
+def test_hard_node_breach_stops_execution(
+    budget_manager: BudgetManager,
+    policy_stack: PolicyStack,
+    trace_emitter: TraceEventEmitter,
+) -> None:
+    adapter = FakeAdapter(
+        cost_by_node={
+            "n1": {"time_ms": 40},
+            "n2": {"time_ms": 60},
+        },
+        results={"n1": "ok", "n2": "fail"},
+    )
+    runner = FlowRunner(
+        adapters={"echo": adapter},
+        budget_manager=budget_manager,
+        policy_stack=policy_stack,
+        trace=trace_emitter,
+    )
+    nodes = [
+        {"id": "n1", "tool": "echo", "params": {}},
+        {"id": "n2", "tool": "echo", "params": {}},
+    ]
+
+    with pytest.raises(BudgetBreachError) as excinfo:
+        runner.run(flow_id="flow-1", run_id="run-1", nodes=nodes)
+
+    assert excinfo.value.scope.scope_type == "node"
+    assert adapter.executed == ["n1"]
+
+    events = trace_emitter.events
+    assert any(evt.event == "budget_breach" and evt.scope_id == "n2" for evt in events)
+    assert any(evt.event == "run_start" for evt in events)
+
+
+def test_soft_run_breach_warns_but_completes(trace_emitter: TraceEventEmitter) -> None:
+    specs = [
+        bm.BudgetSpec(
+            name="run-soft",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 100}),
+            mode="soft",
+            breach_action="warn",
+        )
+    ]
+    manager = BudgetManager(specs=specs, trace=trace_emitter)
+    policy = PolicyStack(tools={"echo": {"tags": []}}, trace=None, event_sink=None)
+    adapter = FakeAdapter(
+        cost_by_node={
+            "n1": {"time_ms": 60},
+            "n2": {"time_ms": 60},
+        },
+        results={"n1": "ok", "n2": "ok"},
+    )
+    runner = FlowRunner(
+        adapters={"echo": adapter},
+        budget_manager=manager,
+        policy_stack=policy,
+        trace=trace_emitter,
+    )
+    nodes = [
+        {"id": "n1", "tool": "echo", "params": {}},
+        {"id": "n2", "tool": "echo", "params": {}},
+    ]
+
+    results = runner.run(flow_id="flow-2", run_id="run-2", nodes=nodes)
+
+    assert [record.node_id for record in results] == ["n1", "n2"]
+    spent = manager.spent(bm.ScopeKey("run", "run-2"), "run-soft")
+    assert spent.time_ms == pytest.approx(120.0)
+
+    events = [evt.event for evt in trace_emitter.events]
+    assert "budget_breach" in events
+    assert events.count("budget_charge") == 2
+
+
+def test_policy_violation_propagates_and_traces(policy_stack: PolicyStack, trace_emitter: TraceEventEmitter) -> None:
+    policy_stack.push({"deny_tools": ["echo"]}, scope="session")
+    specs = [
+        bm.BudgetSpec(
+            name="run-hard",
+            scope_type="run",
+            limit=bm.CostSnapshot.from_raw({"time_ms": 200}),
+            mode="hard",
+            breach_action="stop",
+        )
+    ]
+    manager = BudgetManager(specs=specs, trace=trace_emitter)
+    adapter = FakeAdapter(cost_by_node={"n1": {"time_ms": 10}}, results={"n1": "ok"})
+    runner = FlowRunner(
+        adapters={"echo": adapter},
+        budget_manager=manager,
+        policy_stack=policy_stack,
+        trace=trace_emitter,
+    )
+
+    with pytest.raises(PolicyViolationError):
+        runner.run(flow_id="flow-3", run_id="run-3", nodes=[{"id": "n1", "tool": "echo"}])
+
+    events = [evt for evt in trace_emitter.events if evt.event == "policy_violation"]
+    assert events
+    assert events[0].payload["tool"] == "echo"

--- a/codex/code/integrate_budget_guards_runner_p3/tests/test_trace_emitter.py
+++ b/codex/code/integrate_budget_guards_runner_p3/tests/test_trace_emitter.py
@@ -1,0 +1,44 @@
+"""Unit tests for TraceEventEmitter."""
+
+from __future__ import annotations
+
+import pytest
+
+from codex.code.integrate_budget_guards_runner_p3.dsl.trace import TraceEventEmitter
+
+
+def test_emit_records_event_and_forwards_to_sink() -> None:
+    emitter = TraceEventEmitter()
+    received: list = []
+
+    def sink(event):  # type: ignore[no-untyped-def]
+        received.append(event)
+
+    emitter.attach_sink(sink)
+    event = emitter.emit(
+        "budget_charge",
+        scope_type="run",
+        scope_id="run-1",
+        payload={"value": 10},
+    )
+
+    assert event.payload["value"] == 10
+    with pytest.raises(TypeError):  # immutability enforced
+        event.payload["value"] = 11  # type: ignore[index]
+
+    assert received == [event]
+    assert emitter.events == (event,)
+
+    emitter.clear()
+    assert emitter.events == ()
+
+
+def test_attach_sink_none_disables_forwarding() -> None:
+    emitter = TraceEventEmitter()
+    received: list = []
+
+    emitter.attach_sink(None)
+    event = emitter.emit("policy_resolved", scope_type="stack", scope_id="root", payload={})
+
+    assert received == []
+    assert emitter.events == (event,)


### PR DESCRIPTION
## Summary
- add integrate_budget_guards_runner_p3 workspace with canonical budget models, manager, and FlowRunner wiring
- implement branch-scoped pytest suite covering trace emitter, budget math, manager orchestration, and FlowRunner integration
- author phase-3 documentation artifacts plus automation metadata and missing-test proposals

## Testing
- pytest codex/code/integrate_budget_guards_runner_p3/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8bdef46f0832cb681466563bffb89