### PR TITLE
Phase 3: sandbox FlowRunner budget guard integration

### DIFF
--- a/codex/DOCUMENTATION/P3/phase3-07b-budget-guards-b3c8-4403152c.yaml
+++ b/codex/DOCUMENTATION/P3/phase3-07b-budget-guards-b3c8-4403152c.yaml
@@ -1,0 +1,61 @@
+component:
+  name: sandbox_flow_runner_budget_integration
+  purpose: |
+    Demonstrate canonical budget management, policy enforcement, and trace emission for the FlowRunner
+    integration milestone in a sandbox environment.
+cli_usage:
+  entrypoints:
+    - command: python -m pytest codex/code/phase3-07b-budget-guards-b3c8/tests -q
+      description: Execute the sandbox regression suite covering budget manager and runner integration.
+public_interfaces:
+  classes:
+    - name: dsl.budget.BudgetManager
+      responsibilities:
+        - Register run/loop/node budget specs.
+        - Provide preflight and commit decisions with immutable outcomes.
+    - name: dsl.trace.TraceEventEmitter
+      responsibilities:
+        - Emit policy and budget events with immutable payloads.
+        - Supply event history for audit-friendly assertions.
+    - name: dsl.runner.FlowRunner
+      responsibilities:
+        - Execute loop-based flows with adapters, budgets, and policies.
+        - Produce `RunResult` summaries and feed TraceEventEmitter.
+  extension_points:
+    - name: dsl.runner.ToolAdapter
+      type: protocol
+      notes: Implement `estimate` and `execute` to integrate real tool adapters.
+configurables:
+  budgets:
+    - field: BudgetSpec.limit_ms
+      description: Millisecond ceiling enforced per scope.
+    - field: BudgetSpec.mode
+      description: Determines hard vs soft breach semantics.
+    - field: BudgetSpec.breach_action
+      description: Controls whether breaches warn or stop execution.
+  policies:
+    - field: PolicyStack.allowlist
+      description: Restricts execution to allowed node ids when provided.
+automation_triggers:
+  - name: trace_event_emitter
+    description: Traces may be forwarded to automation pipelines that validate schema compliance before deployment.
+error_contracts:
+  budget:
+    - condition: Unknown ScopeKey
+      raises: KeyError
+    - condition: Negative BudgetSpec.limit_ms
+      raises: ValueError
+  policy:
+    - condition: Mismatched `PolicyStack.complete` order
+      raises: RuntimeError
+serialization:
+  trace_events:
+    format: mapping-proxy payloads suitable for JSON serialization.
+    lifecycle: Events remain in-memory for test assertions; emitter exposes immutable snapshots.
+typing_notes:
+  - Budget dataclasses and enums provide explicit typing for testability and IDE support.
+  - FlowRunner utilises the `ToolAdapter` protocol to maintain loose coupling with adapter implementations.
+security_notes:
+  - No external I/O; sandbox adapters execute deterministic in-memory actions only.
+performance_notes:
+  - Sequential scope charging avoids redundant commit calls once a stop decision is produced, reducing overhead in tight loops.

--- a/codex/TESTS/P3/phase3-07b-budget-guards-b3c8-4403152c.yaml
+++ b/codex/TESTS/P3/phase3-07b-budget-guards-b3c8-4403152c.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_policy_violation_emits_violation_trace
+      rationale: Validate that a denylisted node records a `policy_violation` event and halts execution before budget charges.
+      source_module: codex/code/phase3-07b-budget-guards-b3c8/dsl/policy.py
+      priority: medium
+    - name: test_run_scope_hard_budget_stops_all_loops
+      rationale: Ensure run-level hard budgets short-circuit remaining loops and emit a single breach event.
+      source_module: codex/code/phase3-07b-budget-guards-b3c8/dsl/runner.py
+      priority: high
+    - name: property_based_budget_charge_precision
+      rationale: Use Hypothesis to fuzz cost normalization and verify overage arithmetic stability.
+      source_module: codex/code/phase3-07b-budget-guards-b3c8/dsl/budget.py
+      priority: low

--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-4403152c.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-4403152c.md
@@ -1,0 +1,10 @@
+# Phase 3 Post-Execution — 07b_budget_guards_and_runner_integration
+
+## Test & Coverage Notes
+- Pytest suite for sandbox runner passes: `PYTHONPATH=codex/code/phase3-07b-budget-guards-b3c8 pytest codex/code/phase3-07b-budget-guards-b3c8/tests -q`. (see run log chunk 268758)
+- Budget manager, trace emitter, and runner modules exercised across normal/warn/stop pathways.
+
+## Implementation Observations
+- Sequential scope charging halts once a stop decision is observed to avoid duplicate breach events.
+- Loop summaries annotate `soft_budget_warn` vs `budget_stop` to preserve auditability.
+- Cost normalization clamps tiny floats to zero to maintain deterministic assertions.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-4403152c.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-4403152c.md
@@ -1,0 +1,16 @@
+# Phase 3 Preview — 07b_budget_guards_and_runner_integration
+
+## Overview
+- Stage sandbox FlowRunner integrating immutable budget models, a shared trace emitter, and policy stack plumbing.
+- Preserve adapter-driven execution with deterministic cost normalization and loop stop semantics.
+- Emit policy and budget traces through a single emitter to validate ordering and payload immutability.
+
+## Key Objectives
+1. Finalize `BudgetManager` with scope-aware preflight/commit lifecycle.
+2. Ensure `TraceEventEmitter` bridges policy and budget events for observability.
+3. Execute loops through FlowRunner, enforcing breach actions and summarizing stop reasons.
+
+## Anticipated Risks
+- Divergent breach semantics between scopes.
+- Maintaining event ordering amidst early loop exits.
+- Keeping dataclasses frozen while exposing useful diagnostics.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-4403152c.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-4403152c.md
@@ -1,0 +1,12 @@
+# Phase 3 Review — 07b_budget_guards_and_runner_integration
+
+## Checklist
+- [x] Cost normalization handles seconds vs milliseconds inputs.
+- [x] Soft breaches emit warnings without stopping loops; traces capture `budget_breach` once per scope.
+- [x] Hard breaches stop loop execution and annotate `RunResult.stop_reason`.
+- [x] Policy trace order verified as push → resolved → budget_charge → pop.
+- [x] Dataclasses frozen to prevent payload mutation.
+
+## Notes
+- Node budgets remain soft in the sandbox to isolate loop stop semantics.
+- Trace emitter short-circuits further budget charges once a stop decision occurs to avoid duplicate breach events.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-4403152c.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-4403152c.yaml
@@ -1,0 +1,62 @@
+summary: Integrate canonical budget manager and trace emission into a self-contained FlowRunner sandbox.
+justification: >-
+  Prior phase reviews highlighted the need to combine the adapter-driven runner from the baseline branch
+  with immutable budget models and a shared trace emitter. This plan sequences domain modeling, trace
+  plumbing, and runner orchestration so we can write targeted tests before implementation.
+steps:
+  - name: establish_budget_domain
+    description: Finalize immutable value objects, normalization helpers, and manager APIs for scope budgets.
+  - name: build_trace_and_policy_bridges
+    description: Provide a shared TraceEventEmitter and lightweight PolicyStack stub to validate ordering.
+  - name: integrate_runner_control_flow
+    description: Wire FlowRunner to consult the manager, honor breach actions, and emit deterministic traces.
+modules:
+  - path: codex/code/phase3-07b-budget-guards-b3c8/dsl/budget.py
+    role: Immutable budget models and BudgetManager orchestration.
+  - path: codex/code/phase3-07b-budget-guards-b3c8/dsl/trace.py
+    role: TraceEventEmitter producing schema-aligned policy and budget events.
+  - path: codex/code/phase3-07b-budget-guards-b3c8/dsl/policy.py
+    role: Minimal PolicyStack enforcing allow/deny semantics for runner integration tests.
+  - path: codex/code/phase3-07b-budget-guards-b3c8/dsl/runner.py
+    role: FlowRunner executing adapters with budget and policy enforcement.
+tests:
+  - path: codex/code/phase3-07b-budget-guards-b3c8/tests/test_budget_manager.py
+    coverage_targets:
+      - codex/code/phase3-07b-budget-guards-b3c8/dsl/budget.py
+    mocks:
+      - Fake time provider for deterministic timestamps.
+  - path: codex/code/phase3-07b-budget-guards-b3c8/tests/test_flow_runner_budget_integration.py
+    coverage_targets:
+      - codex/code/phase3-07b-budget-guards-b3c8/dsl/trace.py
+      - codex/code/phase3-07b-budget-guards-b3c8/dsl/policy.py
+      - codex/code/phase3-07b-budget-guards-b3c8/dsl/runner.py
+    mocks:
+      - Stub ToolAdapter implementations returning deterministic costs.
+run_order:
+  - tests/test_budget_manager.py
+  - tests/test_flow_runner_budget_integration.py
+interfaces:
+  - name: BudgetManager
+    contract: Provides preflight and commit methods returning immutable decisions and charge outcomes per scope.
+  - name: TraceEventEmitter
+    contract: Emits budget and policy events in a deterministic order with immutable payloads.
+  - name: FlowRunner.run
+    contract: Executes a flow descriptor, enforces policies, consults the manager, and returns a RunResult capturing stop reasons.
+tdd_coverage_targets:
+  - file: codex/code/phase3-07b-budget-guards-b3c8/dsl/budget.py
+    min_line_coverage: 0.85
+  - file: codex/code/phase3-07b-budget-guards-b3c8/dsl/runner.py
+    min_line_coverage: 0.85
+review_checklist:
+  - Verify cost normalization handles seconds and milliseconds inputs.
+  - Ensure soft breach warnings emit trace events without stopping loops.
+  - Confirm hard breaches stop loop execution and annotate RunResult stop_reason.
+  - Validate policy trace ordering remains push -> resolved -> pop alongside budget events.
+  - Check dataclasses are frozen to avoid mutable payload regressions.
+outputs:
+  - codex/code/phase3-07b-budget-guards-b3c8/dsl/budget.py
+  - codex/code/phase3-07b-budget-guards-b3c8/dsl/trace.py
+  - codex/code/phase3-07b-budget-guards-b3c8/dsl/policy.py
+  - codex/code/phase3-07b-budget-guards-b3c8/dsl/runner.py
+  - codex/code/phase3-07b-budget-guards-b3c8/tests/test_budget_manager.py
+  - codex/code/phase3-07b-budget-guards-b3c8/tests/test_flow_runner_budget_integration.py

--- a/codex/code/phase3-07b-budget-guards-b3c8/dsl/__init__.py
+++ b/codex/code/phase3-07b-budget-guards-b3c8/dsl/__init__.py
@@ -1,0 +1,8 @@
+"""Sandbox DSL package for Phase 3 budget runner integration."""
+
+__all__ = [
+    "budget",
+    "trace",
+    "policy",
+    "runner",
+]

--- a/codex/code/phase3-07b-budget-guards-b3c8/dsl/budget.py
+++ b/codex/code/phase3-07b-budget-guards-b3c8/dsl/budget.py
@@ -1,0 +1,195 @@
+"""Budget domain models and manager for Phase 3 sandbox."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Dict, Iterable, Mapping, MutableMapping
+
+
+class BudgetMode(str, Enum):
+    """Budget enforcement modes."""
+
+    HARD = "hard"
+    SOFT = "soft"
+
+
+class BreachAction(str, Enum):
+    """Actions to take when a breach occurs."""
+
+    WARN = "warn"
+    STOP = "stop"
+
+
+@dataclass(frozen=True)
+class ScopeKey:
+    """Identifies a budget scope by type and identifier."""
+
+    scope_type: str
+    scope_id: str
+
+    def __str__(self) -> str:  # pragma: no cover - convenience for debugging
+        return f"{self.scope_type}:{self.scope_id}"
+
+
+@dataclass(frozen=True)
+class Cost:
+    """Normalized cost snapshot in milliseconds."""
+
+    milliseconds: float
+
+    def __post_init__(self) -> None:
+        normalized = round(float(self.milliseconds), 6)
+        if abs(normalized) < 1e-3:
+            normalized = 0.0
+        object.__setattr__(self, "milliseconds", max(0.0, normalized))
+
+    @classmethod
+    def from_seconds(cls, seconds: float) -> "Cost":
+        return cls(milliseconds=seconds * 1000.0)
+
+
+@dataclass(frozen=True)
+class BudgetSpec:
+    """Configuration for a budget scope."""
+
+    scope_type: str
+    scope_id: str
+    limit_ms: float
+    mode: BudgetMode
+    breach_action: BreachAction
+
+    def __post_init__(self) -> None:
+        if self.limit_ms < 0:
+            raise ValueError("Budget limit must be non-negative")
+
+
+@dataclass(frozen=True)
+class BudgetBreach:
+    """Details about a budget breach."""
+
+    scope: ScopeKey
+    limit_ms: float
+    attempted_ms: float
+    mode: BudgetMode
+    action: BreachAction
+
+    @property
+    def breach_kind(self) -> str:
+        return "soft" if self.mode is BudgetMode.SOFT else "hard"
+
+
+class BudgetDecisionStatus(str, Enum):
+    """Decision results produced during budget evaluation."""
+
+    ALLOW = "allow"
+    WARN = "warn"
+    STOP = "stop"
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    """Immutable decision returned during preflight or commit."""
+
+    status: BudgetDecisionStatus
+    breach: BudgetBreach | None = None
+
+    @property
+    def requires_stop(self) -> bool:
+        return self.status is BudgetDecisionStatus.STOP
+
+
+@dataclass(frozen=True)
+class BudgetCharge:
+    """Charge snapshot describing spend, remaining, and overages."""
+
+    scope: ScopeKey
+    spent_ms: float
+    remaining_ms: float
+    overage_ms: float
+
+    def as_payload(self) -> Mapping[str, float]:
+        payload = {
+            "spent_ms": self.spent_ms,
+            "remaining_ms": self.remaining_ms,
+            "overage_ms": self.overage_ms,
+        }
+        return MappingProxyType(payload)
+
+
+@dataclass(frozen=True)
+class BudgetChargeOutcome:
+    """Result returned from BudgetManager.commit."""
+
+    decision: BudgetDecision
+    charge: BudgetCharge
+    breach: BudgetBreach | None
+
+    @property
+    def requires_stop(self) -> bool:
+        return self.decision.requires_stop
+
+
+class BudgetManager:
+    """Coordinates budget scopes and charges."""
+
+    def __init__(self, specs: Mapping[ScopeKey, BudgetSpec]) -> None:
+        self._specs: Mapping[ScopeKey, BudgetSpec] = MappingProxyType(dict(specs))
+        self._spent: MutableMapping[ScopeKey, float] = {key: 0.0 for key in self._specs}
+
+    def spec_for(self, scope: ScopeKey) -> BudgetSpec:
+        try:
+            return self._specs[scope]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise KeyError(f"Unknown scope {scope}") from exc
+
+    def preflight(self, scope: ScopeKey, cost: Cost) -> BudgetDecision:
+        spec = self._specs[scope]
+        spent = self._spent[scope]
+        attempted = spent + cost.milliseconds
+        overage = max(0.0, attempted - spec.limit_ms)
+        if overage <= 0.0:
+            return BudgetDecision(status=BudgetDecisionStatus.ALLOW)
+
+        breach = BudgetBreach(
+            scope=scope,
+            limit_ms=spec.limit_ms,
+            attempted_ms=attempted,
+            mode=spec.mode,
+            action=spec.breach_action,
+        )
+        if spec.breach_action is BreachAction.WARN and spec.mode is BudgetMode.SOFT:
+            status = BudgetDecisionStatus.WARN
+        else:
+            status = BudgetDecisionStatus.STOP
+        return BudgetDecision(status=status, breach=breach)
+
+    def commit(self, scope: ScopeKey, cost: Cost) -> BudgetChargeOutcome:
+        decision = self.preflight(scope, cost)
+        spec = self._specs[scope]
+        previous_spent = self._spent[scope]
+        attempted = previous_spent + cost.milliseconds
+        remaining_after_attempt = max(0.0, spec.limit_ms - min(spec.limit_ms, attempted))
+        overage = max(0.0, attempted - spec.limit_ms)
+        charge = BudgetCharge(
+            scope=scope,
+            spent_ms=attempted,
+            remaining_ms=remaining_after_attempt,
+            overage_ms=overage,
+        )
+        # Clamp stored spend to the limit to avoid infinite overage accumulation while preserving totals.
+        self._spent[scope] = min(spec.limit_ms, attempted)
+        return BudgetChargeOutcome(decision=decision, charge=charge, breach=decision.breach)
+
+    def remaining(self, scope: ScopeKey) -> float:
+        spec = self._specs[scope]
+        spent = self._spent[scope]
+        return max(0.0, spec.limit_ms - spent)
+
+    def scopes(self) -> Iterable[ScopeKey]:  # pragma: no cover - utility
+        return self._specs.keys()
+
+    @property
+    def specs(self) -> Mapping[ScopeKey, BudgetSpec]:
+        return self._specs

--- a/codex/code/phase3-07b-budget-guards-b3c8/dsl/policy.py
+++ b/codex/code/phase3-07b-budget-guards-b3c8/dsl/policy.py
@@ -1,0 +1,53 @@
+"""Lightweight PolicyStack implementation for the sandbox runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from .trace import TraceEventEmitter
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    allowed: bool
+    reason: str | None = None
+
+
+class PolicyStack:
+    """Minimal stack that emits trace events around policy evaluation."""
+
+    def __init__(
+        self,
+        trace_emitter: TraceEventEmitter,
+        allowlist: Sequence[str] | None = None,
+        denylist: Sequence[str] | None = None,
+    ) -> None:
+        self._trace = trace_emitter
+        self._allow = set(allowlist or [])
+        self._deny = set(denylist or [])
+        self._stack: List[str] = []
+
+    def evaluate(self, node_id: str, context: dict) -> PolicyDecision:
+        self._trace.emit_policy_push(node_id)
+        if self._deny and node_id in self._deny:
+            decision = PolicyDecision(allowed=False, reason="denied_by_policy")
+            self._trace.emit_policy_violation(node_id, decision.reason)
+        elif self._allow and node_id not in self._allow:
+            decision = PolicyDecision(allowed=False, reason="not_allowlisted")
+            self._trace.emit_policy_violation(node_id, decision.reason)
+        else:
+            decision = PolicyDecision(allowed=True, reason=None)
+            self._trace.emit_policy_resolved(node_id)
+        self._stack.append(node_id)
+        return decision
+
+    def complete(self, node_id: str) -> None:
+        if not self._stack or self._stack[-1] != node_id:
+            raise RuntimeError(f"Policy stack out of order for node {node_id}")
+        self._stack.pop()
+        self._trace.emit_policy_pop(node_id)
+
+    @property
+    def stack(self) -> Iterable[str]:  # pragma: no cover - inspection helper
+        return tuple(self._stack)

--- a/codex/code/phase3-07b-budget-guards-b3c8/dsl/runner.py
+++ b/codex/code/phase3-07b-budget-guards-b3c8/dsl/runner.py
@@ -1,0 +1,141 @@
+"""FlowRunner integrating budget manager and policy stack for sandbox tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Protocol, Sequence
+
+from .budget import (
+    BudgetDecisionStatus,
+    BudgetManager,
+    Cost,
+    ScopeKey,
+)
+from .policy import PolicyDecision, PolicyStack
+from .trace import TraceEventEmitter
+
+
+class ToolAdapter(Protocol):
+    def estimate(self, context: dict) -> Cost:
+        ...
+
+    def execute(self, context: dict) -> object:
+        ...
+
+
+@dataclass(frozen=True)
+class NodeSpec:
+    node_id: str
+    adapter: ToolAdapter
+    scope_key: ScopeKey
+
+
+@dataclass(frozen=True)
+class LoopSpec:
+    loop_id: str
+    iterations: int
+    nodes: Sequence[str]
+    scope_key: ScopeKey
+
+
+@dataclass(frozen=True)
+class FlowSpec:
+    flow_id: str
+    nodes: Sequence[NodeSpec]
+    loops: Sequence[LoopSpec]
+    run_scope: ScopeKey = field(default_factory=lambda: ScopeKey("run", "run"))
+
+    def node_map(self) -> Dict[str, NodeSpec]:
+        return {node.node_id: node for node in self.nodes}
+
+
+@dataclass(frozen=True)
+class LoopSummary:
+    loop_id: str
+    iterations_completed: int
+    stop_reason: str | None
+
+
+@dataclass(frozen=True)
+class RunResult:
+    completed: bool
+    stop_reason: str | None
+    loop_summaries: Sequence[LoopSummary]
+
+
+class FlowRunner:
+    """Executes flows with budget enforcement."""
+
+    def __init__(
+        self,
+        budget_manager: BudgetManager,
+        trace_emitter: TraceEventEmitter,
+        policy_stack: PolicyStack,
+    ) -> None:
+        self._budget_manager = budget_manager
+        self.trace_emitter = trace_emitter
+        self._policy_stack = policy_stack
+
+    def run(self, flow: FlowSpec) -> RunResult:
+        node_lookup = flow.node_map()
+        loop_summaries: List[LoopSummary] = []
+        run_stop_reason: str | None = None
+
+        for loop in flow.loops:
+            iterations_completed = 0
+            loop_stop_reason: str | None = None
+            saw_warning = False
+
+            for iteration in range(loop.iterations):
+                iteration_stop = False
+                for node_id in loop.nodes:
+                    node = node_lookup[node_id]
+                    context = {"flow_id": flow.flow_id, "loop_id": loop.loop_id, "iteration": iteration}
+                    decision = self._policy_stack.evaluate(node.node_id, context)
+                    if not decision.allowed:
+                        run_stop_reason = f"policy_violation({node.node_id})"
+                        loop_stop_reason = "policy_violation"
+                        iteration_stop = True
+                        self._policy_stack.complete(node.node_id)
+                        break
+
+                    cost = node.adapter.estimate(context)
+                    for scope_key in (flow.run_scope, loop.scope_key, node.scope_key):
+                        outcome = self._budget_manager.commit(scope_key, cost)
+                        self.trace_emitter.emit_budget_charge(outcome)
+                        if outcome.breach:
+                            self.trace_emitter.emit_budget_breach(outcome.breach)
+                            if outcome.decision.status is BudgetDecisionStatus.WARN and loop_stop_reason != "budget_stop":
+                                saw_warning = True
+                                loop_stop_reason = loop_stop_reason or "soft_budget_warn"
+                        if outcome.requires_stop and loop_stop_reason != "budget_stop":
+                            loop_stop_reason = "budget_stop"
+                            if run_stop_reason is None:
+                                run_stop_reason = f"budget_breach({outcome.charge.scope})"
+                            iteration_stop = True
+                            break
+                    if not iteration_stop:
+                        node.adapter.execute(context)
+                    self._policy_stack.complete(node.node_id)
+                    if iteration_stop:
+                        break
+                iterations_completed += 1
+                if iteration_stop:
+                    break
+
+            if loop_stop_reason is None and saw_warning:
+                loop_stop_reason = "soft_budget_warn"
+
+            loop_summary = LoopSummary(
+                loop_id=loop.loop_id,
+                iterations_completed=iterations_completed,
+                stop_reason=loop_stop_reason,
+            )
+            loop_summaries.append(loop_summary)
+            self.trace_emitter.emit_loop_summary(loop.scope_key, iterations_completed, loop_stop_reason)
+
+            if run_stop_reason:
+                break
+
+        completed = run_stop_reason is None
+        return RunResult(completed=completed, stop_reason=run_stop_reason, loop_summaries=tuple(loop_summaries))

--- a/codex/code/phase3-07b-budget-guards-b3c8/dsl/trace.py
+++ b/codex/code/phase3-07b-budget-guards-b3c8/dsl/trace.py
@@ -1,0 +1,89 @@
+"""Trace emission helpers for the sandbox FlowRunner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Iterable, List, Mapping
+
+from .budget import BudgetBreach, BudgetChargeOutcome, BudgetDecisionStatus, ScopeKey
+
+
+@dataclass(frozen=True)
+class TraceEvent:
+    """Immutable trace event captured for assertions."""
+
+    event: str
+    scope: str
+    payload: Mapping[str, object]
+
+
+class TraceEventEmitter:
+    """Collects trace events with immutable payloads."""
+
+    def __init__(self) -> None:
+        self._events: List[TraceEvent] = []
+
+    def emit_policy_push(self, node_id: str) -> None:
+        self._emit("policy_push", scope=node_id, payload={})
+
+    def emit_policy_resolved(self, node_id: str, policy_name: str | None = None) -> None:
+        payload: dict[str, object] = {}
+        if policy_name:
+            payload["policy"] = policy_name
+        self._emit("policy_resolved", scope=node_id, payload=payload)
+
+    def emit_policy_pop(self, node_id: str) -> None:
+        self._emit("policy_pop", scope=node_id, payload={})
+
+    def emit_policy_violation(self, node_id: str, reason: str | None = None) -> None:
+        payload = {} if reason is None else {"reason": reason}
+        self._emit("policy_violation", scope=node_id, payload=payload)
+
+    def emit_budget_charge(self, outcome: BudgetChargeOutcome) -> None:
+        charge_payload = dict(outcome.charge.as_payload())
+        charge_payload.update(
+            {
+                "scope": str(outcome.charge.scope),
+                "decision_status": outcome.decision.status.value,
+            }
+        )
+        if outcome.breach:
+            charge_payload["breach_kind"] = outcome.breach.breach_kind
+            charge_payload["action"] = outcome.breach.action.value
+        self._emit("budget_charge", scope=str(outcome.charge.scope), payload=charge_payload)
+
+    def emit_budget_breach(self, breach: BudgetBreach) -> None:
+        payload = {
+            "scope": str(breach.scope),
+            "breach_kind": breach.breach_kind,
+            "limit_ms": breach.limit_ms,
+            "attempted_ms": breach.attempted_ms,
+            "action": breach.action.value,
+        }
+        self._emit("budget_breach", scope=str(breach.scope), payload=payload)
+
+    def emit_loop_summary(
+        self,
+        loop: ScopeKey,
+        iterations_completed: int,
+        stop_reason: str | None,
+    ) -> None:
+        payload: dict[str, object] = {
+            "loop_id": loop.scope_id,
+            "iterations_completed": iterations_completed,
+        }
+        if stop_reason:
+            payload["stop_reason"] = stop_reason
+        self._emit("loop_summary", scope=str(loop), payload=payload)
+
+    def _emit(self, event: str, scope: str, payload: Mapping[str, object]) -> None:
+        immutable_payload = MappingProxyType(dict(payload))
+        self._events.append(TraceEvent(event=event, scope=scope, payload=immutable_payload))
+
+    @property
+    def events(self) -> Iterable[TraceEvent]:
+        return tuple(self._events)
+
+    def reset(self) -> None:  # pragma: no cover - utility for manual testing
+        self._events.clear()

--- a/codex/code/phase3-07b-budget-guards-b3c8/tests/test_budget_manager.py
+++ b/codex/code/phase3-07b-budget-guards-b3c8/tests/test_budget_manager.py
@@ -1,0 +1,104 @@
+import math
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from dsl import budget as budget_module
+from dsl.budget import (
+    BreachAction,
+    BudgetDecisionStatus,
+    BudgetManager,
+    BudgetMode,
+    BudgetSpec,
+    Cost,
+    ScopeKey,
+)
+
+
+@pytest.fixture
+def manager():
+    specs = {
+        ScopeKey(scope_type="run", scope_id="run"): BudgetSpec(
+            scope_type="run",
+            scope_id="run",
+            limit_ms=150,
+            mode=BudgetMode.SOFT,
+            breach_action=BreachAction.WARN,
+        ),
+        ScopeKey(scope_type="loop", scope_id="loop1"): BudgetSpec(
+            scope_type="loop",
+            scope_id="loop1",
+            limit_ms=120,
+            mode=BudgetMode.SOFT,
+            breach_action=BreachAction.WARN,
+        ),
+        ScopeKey(scope_type="node", scope_id="node1"): BudgetSpec(
+            scope_type="node",
+            scope_id="node1",
+            limit_ms=80,
+            mode=BudgetMode.HARD,
+            breach_action=BreachAction.STOP,
+        ),
+    }
+    return BudgetManager(specs)
+
+
+def test_cost_normalization_supports_seconds_and_ms():
+    cost_seconds = Cost.from_seconds(0.25)
+    cost_ms = Cost(milliseconds=250.0)
+    assert math.isclose(cost_seconds.milliseconds, 250.0)
+    assert cost_seconds == cost_ms
+
+
+def test_preflight_warns_for_soft_budget(manager):
+    decision = manager.preflight(ScopeKey("run", "run"), Cost(milliseconds=160))
+    assert decision.status is BudgetDecisionStatus.WARN
+    assert decision.breach is not None
+    assert decision.breach.action is BreachAction.WARN
+
+
+def test_commit_updates_remaining_and_overage(manager):
+    outcome = manager.commit(ScopeKey("loop", "loop1"), Cost(milliseconds=130))
+    assert outcome.decision.status is BudgetDecisionStatus.WARN
+    assert outcome.charge.spent_ms == pytest.approx(130.0)
+    assert outcome.charge.remaining_ms == pytest.approx(0.0)
+    assert outcome.charge.overage_ms == pytest.approx(10.0)
+    assert outcome.breach is not None
+    assert manager.remaining(ScopeKey("loop", "loop1")) == pytest.approx(0.0)
+
+
+def test_hard_budget_commit_requires_stop(manager):
+    manager.commit(ScopeKey("node", "node1"), Cost(milliseconds=60))
+    decision = manager.preflight(ScopeKey("node", "node1"), Cost(milliseconds=30))
+    assert decision.status is BudgetDecisionStatus.STOP
+    outcome = manager.commit(ScopeKey("node", "node1"), Cost(milliseconds=30))
+    assert outcome.decision.status is BudgetDecisionStatus.STOP
+    assert outcome.requires_stop is True
+    assert outcome.breach is not None
+    assert outcome.charge.overage_ms == pytest.approx(10.0)
+
+
+def test_unknown_scope_raises_value_error(manager):
+    with pytest.raises(KeyError):
+        manager.preflight(ScopeKey("node", "missing"), Cost(milliseconds=1))
+
+
+def test_budget_dataclasses_are_frozen(manager):
+    outcome = manager.commit(ScopeKey("loop", "loop1"), Cost(milliseconds=130))
+    with pytest.raises(FrozenInstanceError):
+        outcome.charge.spent_ms = 0.0  # type: ignore[misc]
+
+    with pytest.raises(AttributeError):
+        outcome.decision.new_field = 1  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    "milliseconds, expected",
+    [
+        (0.0, 0.0),
+        (1e-6, 0.0),
+        (100.0, 100.0),
+    ],
+)
+def test_cost_rounding(milliseconds, expected):
+    assert Cost(milliseconds=milliseconds).milliseconds == pytest.approx(expected)

--- a/codex/code/phase3-07b-budget-guards-b3c8/tests/test_flow_runner_budget_integration.py
+++ b/codex/code/phase3-07b-budget-guards-b3c8/tests/test_flow_runner_budget_integration.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import pytest
+
+from dsl.budget import (
+    BreachAction,
+    BudgetDecisionStatus,
+    BudgetManager,
+    BudgetMode,
+    BudgetSpec,
+    Cost,
+    ScopeKey,
+)
+from dsl.policy import PolicyStack
+from dsl.runner import FlowRunner, FlowSpec, LoopSpec, NodeSpec, RunResult
+from dsl.trace import TraceEventEmitter
+
+
+@dataclass
+class FakeAdapter:
+    cost_ms: float
+    result: str
+
+    def estimate(self, context: dict) -> Cost:
+        return Cost(milliseconds=self.cost_ms)
+
+    def execute(self, context: dict) -> str:
+        return self.result
+
+
+def build_runner(run_limit: float, loop_limit: float, node_limit: float, hard_loop: bool = False) -> FlowRunner:
+    specs = {
+        ScopeKey("run", "run"): BudgetSpec(
+            scope_type="run",
+            scope_id="run",
+            limit_ms=run_limit,
+            mode=BudgetMode.SOFT,
+            breach_action=BreachAction.WARN,
+        ),
+        ScopeKey("loop", "loop1"): BudgetSpec(
+            scope_type="loop",
+            scope_id="loop1",
+            limit_ms=loop_limit,
+            mode=BudgetMode.HARD if hard_loop else BudgetMode.SOFT,
+            breach_action=BreachAction.STOP if hard_loop else BreachAction.WARN,
+        ),
+        ScopeKey("node", "node1"): BudgetSpec(
+            scope_type="node",
+            scope_id="node1",
+            limit_ms=node_limit,
+            mode=BudgetMode.SOFT,
+            breach_action=BreachAction.WARN,
+        ),
+    }
+    manager = BudgetManager(specs)
+    trace = TraceEventEmitter()
+    policy = PolicyStack(trace)
+    return FlowRunner(budget_manager=manager, trace_emitter=trace, policy_stack=policy)
+
+
+def collect_event_names(trace: TraceEventEmitter) -> List[str]:
+    return [event.event for event in trace.events]
+
+
+def test_soft_loop_budget_emits_warning_and_continues():
+    runner = build_runner(run_limit=300, loop_limit=120, node_limit=200, hard_loop=False)
+    adapter = FakeAdapter(cost_ms=70, result="ok")
+    flow = FlowSpec(
+        flow_id="flow",
+        nodes=[NodeSpec(node_id="node1", adapter=adapter, scope_key=ScopeKey("node", "node1"))],
+        loops=[LoopSpec(loop_id="loop1", iterations=2, nodes=["node1"], scope_key=ScopeKey("loop", "loop1"))],
+    )
+
+    result = runner.run(flow)
+
+    assert result.completed is True
+    assert result.stop_reason is None
+    assert len(result.loop_summaries) == 1
+    loop_summary = result.loop_summaries[0]
+    assert loop_summary.loop_id == "loop1"
+    assert loop_summary.iterations_completed == 2
+    assert loop_summary.stop_reason == "soft_budget_warn"
+
+    events = collect_event_names(runner.trace_emitter)
+    assert events.count("budget_breach") == 1
+    assert "policy_push" in events
+    assert events.index("policy_push") < events.index("policy_resolved") < events.index("policy_pop")
+    assert events.index("budget_charge") > events.index("policy_resolved")
+
+    breach_event = next(event for event in runner.trace_emitter.events if event.event == "budget_breach")
+    assert breach_event.payload["breach_kind"] == "soft"
+    assert breach_event.payload["action"] == "warn"
+
+
+def test_hard_loop_budget_stops_runner():
+    runner = build_runner(run_limit=300, loop_limit=100, node_limit=200, hard_loop=True)
+    adapter = FakeAdapter(cost_ms=70, result="ok")
+    flow = FlowSpec(
+        flow_id="flow",
+        nodes=[NodeSpec(node_id="node1", adapter=adapter, scope_key=ScopeKey("node", "node1"))],
+        loops=[LoopSpec(loop_id="loop1", iterations=3, nodes=["node1"], scope_key=ScopeKey("loop", "loop1"))],
+    )
+
+    result = runner.run(flow)
+
+    assert result.completed is False
+    assert result.stop_reason == "budget_breach(loop:loop1)"
+    loop_summary = result.loop_summaries[0]
+    assert loop_summary.iterations_completed == 2
+    assert loop_summary.stop_reason == "budget_stop"
+
+    events = collect_event_names(runner.trace_emitter)
+    assert events.count("budget_breach") == 1
+    breach_event = next(event for event in runner.trace_emitter.events if event.event == "budget_breach")
+    assert breach_event.payload["breach_kind"] == "hard"
+    assert breach_event.payload["action"] == "stop"
+
+    # Node budget should register a stop decision on the second iteration attempt.
+    stop_decisions = [
+        event
+        for event in runner.trace_emitter.events
+        if event.event == "budget_charge" and event.payload["decision_status"] == BudgetDecisionStatus.STOP.value
+    ]
+    assert len(stop_decisions) == 1


### PR DESCRIPTION
## Summary
- add a phase 3 plan describing sandbox FlowRunner budget, trace, and policy integration work
- implement sandbox budget manager, trace emitter, policy stack, and FlowRunner along with targeted unit tests
- document implementation details, post-execution notes, and future test gaps for downstream automation

## Testing
- PYTHONPATH=codex/code/phase3-07b-budget-guards-b3c8 pytest codex/code/phase3-07b-budget-guards-b3c8/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8c9292980832ca282c33d5ffc4de2