### PR TITLE
Add Phase 3 budget runner sandbox

### DIFF
--- a/codex/DOCUMENTATION/P3/phase3-budget-runner-4f72-565941d2177b4311b170222d4ecb5029.yaml
+++ b/codex/DOCUMENTATION/P3/phase3-budget-runner-4f72-565941d2177b4311b170222d4ecb5029.yaml
@@ -1,0 +1,61 @@
+component:
+  name: phase3-budget-runner-4f72
+  purpose: >-
+    Sandbox implementation of budget guards integrated with the FlowRunner for
+    task 07b. Demonstrates immutable budget accounting, shared trace emission,
+    and adapter-driven execution suitable for future consolidation into pkgs/dsl.
+  cli_usage: >-
+    No direct CLI entry-point; import modules from `dsl.*` within the sandbox
+    path (`codex/code/phase3-budget-runner-4f72`) and execute via pytest or a
+    host application embedding `FlowRunner`.
+interfaces:
+  public_classes:
+    - name: dsl.costs.normalize_cost
+      role: Canonical cost normaliser converting seconds→milliseconds and
+        freezing payloads.
+    - name: dsl.budget.BudgetManager
+      role: Coordinates preflight/commit budget checks with immutable outcomes
+        and trace emission.
+    - name: dsl.policy.PolicyStack
+      role: Allowlist-backed policy enforcement producing `policy_*` trace
+        events.
+    - name: dsl.runner.FlowRunner
+      role: Sequential adapter runner wiring PolicyStack + BudgetManager.
+  extension_points:
+    - name: dsl.runner.ToolAdapter
+      contract: Provide `name`, `estimate(context)`, and `execute(context)`.
+    - name: dsl.trace.TraceWriter
+      contract: Accept immutable trace payloads and expose `snapshot()`.
+configuration:
+  options:
+    - name: BudgetSpec.breach_action
+      values: ["warn", "stop"]
+      default: warn for soft budgets, stop for hard budgets.
+      effect: Controls whether overages trigger warnings or hard stops.
+    - name: PolicyStack.allowlist
+      values: set[str]
+      default: empty (allow all).
+      effect: Restricts adapters allowed to execute.
+  automation_triggers:
+    - trigger: Importing `TraceEventEmitter`
+      action: All policy/budget traces emitted to the supplied TraceWriter.
+error_contracts:
+  budget:
+    - exception: dsl.budget.BudgetHardStop
+      raised_when: Hard budgets are exceeded during commit.
+      payload: MappingProxy over overage metrics.
+  policy:
+    - exception: dsl.policy.PolicyViolation
+      raised_when: Adapter not present in allowlist.
+  lifecycle:
+    notes: >-
+      `BudgetManager.preflight` is pure and mutation-free; state is only updated
+      on successful `commit`. Hard stops leave accounts unchanged.
+serialization:
+  trace_payloads: Immutable mappings suitable for JSON serialisation; nested
+    payloads stored as mapping proxies.
+typing_security_performance:
+  typing: Modules use typing.Protocol and frozen dataclasses for clarity.
+  security: PolicyStack allowlist prevents execution of blocked adapters.
+  performance: Cost normalisation performs O(n) merges per call; acceptable for
+    small metric maps typical of runner budgets.

--- a/codex/TESTS/P3/phase3-budget-runner-4f72-565941d2177b4311b170222d4ecb5029.yaml
+++ b/codex/TESTS/P3/phase3-budget-runner-4f72-565941d2177b4311b170222d4ecb5029.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_budget_manager_handles_estimate_actual_delta
+      rationale: Ensure commit recomputes projected spend when actual costs differ from estimates, preventing silent drift.
+      source_module: dsl/budget.py
+      priority: medium
+    - name: test_flow_runner_emits_combined_policy_budget_traces
+      rationale: Validate ordering when a policy violation occurs after a soft warning within the same run, covering trace interleaving.
+      source_module: dsl/runner.py
+      priority: medium
+    - name: test_trace_writer_snapshot_returns_deeply_immutable_payloads
+      rationale: Guard against future regressions where nested payloads become mutable.
+      source_module: dsl/trace.py
+      priority: low

--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.md
@@ -1,0 +1,19 @@
+# Post-execution Report — Phase 3 Budget Guards Integration
+
+## Test Results
+- `PYTHONPATH=codex/code/phase3-budget-runner-4f72 pytest codex/code/phase3-budget-runner-4f72/tests -q`
+  - Status: ✅ (8 tests) — see run log chunk `f38e33`.
+
+## Coverage / Confidence
+- Unit-level verification covers cost normalisation and budget manager
+  semantics, exercising both soft and hard enforcement branches.
+- Integration tests drive FlowRunner through soft continuation, hard stop, and
+  policy violation paths ensuring trace sequencing works end-to-end.
+
+## Implementation Notes
+- `BudgetManager` scopes accounts by `f"{run_id}:{spec.scope_id}"` to avoid
+  cross-run leakage while preserving spec-level budgeting semantics.
+- PolicyStack split into `check`/`resolved` phases so `policy_resolved` only
+  fires after successful execution, preventing trace inflation on hard stops.
+- Loop summaries currently emit projected spend; additional aggregate fields can
+  be added once downstream schema requirements are clarified.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.md
@@ -1,0 +1,27 @@
+# Phase 3 Preview — Budget guards and runner integration
+
+## Overview
+- Built sandbox modules under `codex/code/phase3-budget-runner-4f72/` that compose
+  the adapter-driven runner from `codex/implement-budget-guards-with-test-first-approach-fa0vm9`
+  with immutable budget models and tracing patterns credited to
+  `codex/integrate-budget-guards-with-runner-zwi2ny` and
+  `codex/integrate-budget-guards-with-runner-pbdel9`.
+- Added a canonical cost normaliser to eliminate seconds→milliseconds drift,
+  honouring arithmetic decisions highlighted in branch `8wxk32`.
+- Layered PolicyStack hooks (from task 07a decisions) into the FlowRunner so
+  `policy_resolved` traces always accompany successful adapter execution while
+  budget warnings/stops emit shared trace payloads.
+
+## Test Strategy
+- Unit tests validate cost normalisation immutability, BudgetManager soft/hard
+  semantics, and trace emissions (charges + breaches).
+- Integration tests exercise FlowRunner control flow for
+  * soft budgets continuing execution with warnings,
+  * hard budgets halting before execution of the second node, and
+  * policy violations short-circuiting prior to budget checks.
+
+## Pending Risks / Questions
+- Current sandbox treats adapter execution costs as matching estimates; future
+  phases should decide how to reconcile estimate vs actual before committing.
+- Loop summaries are minimal; richer aggregation (per-iteration metrics) may be
+  required once we integrate with real flows.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.md
@@ -1,0 +1,24 @@
+# Review Notes — Phase 3 Budget Guards Integration
+
+## Summary
+- ✅ BudgetManager preflight/commit mirrors zwi2ny+pbdel9 immutable payloads while
+  enforcing qhq0jq soft/hard semantics; traces emitted through shared emitter.
+- ✅ FlowRunner keeps fa0vm9 adapter orchestration and stops cleanly on hard
+  breaches without executing downstream adapters.
+- ✅ PolicyStack produces `policy_resolved` events only after successful adapter
+  execution, matching POSTEXECUTION directives.
+
+## Checklist
+- [x] Cost normaliser returns MappingProxyType and converts seconds to ms once.
+- [x] BudgetManager soft breach leaves scope mutable and emits `budget_breach`
+      with severity `soft`.
+- [x] Hard breach raises `BudgetHardStop` and preserves prior spend state.
+- [x] FlowRunner does not execute adapters when preflight indicates hard stop.
+- [x] Policy violations emit `policy_violation` and skip budget checks.
+- [x] Tests cover soft warn continuation, hard stop halt, and policy violation.
+
+## Potential Follow-ups
+- Consider extending BudgetManager to reconcile estimate vs actual execution
+  costs for more realistic accounting.
+- Loop summary events currently carry projected spend only; downstream analytics
+  might need cumulative spent as well.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.yaml
@@ -1,0 +1,79 @@
+summary: Align budget guards with FlowRunner + PolicyStack using immutable models and shared tracing.
+justification: >-
+  Phase 2 analyses highlight strengths in specific experimental branches. We combine the
+  adapter-driven runner from codex/integrate-budget-guards-with-runner and codex/implement-budget-guards-with-test-first-approach-fa0vm9,
+  the immutable budget models from codex/integrate-budget-guards-with-runner-zwi2ny, and the
+  structured breach accounting from codex/integrate-budget-guards-with-runner-pbdel9/qhq0jq to
+  deliver deterministic budget enforcement with trace parity.
+steps:
+  - id: cost_normalization
+    desc: Reconcile divergent unit handling by introducing a canonical cost normalization helper inspired by 8wxk32/fa0vm9 branches.
+  - id: budget_manager
+    desc: Implement immutable budget specs, charge outcomes, and a BudgetManager orchestrating preflight/commit per scope (zwi2ny + pbdel9 + qhq0jq).
+  - id: trace_bridge
+    desc: Build a TraceEventEmitter layering zwi2ny TraceWriter semantics with pbdel9 overage payloads and ensure policy_resolved traces per P1 reviews.
+  - id: runner_integration
+    desc: Retrofit FlowRunner loop execution (fa0vm9 adapter protocol + baseline runner) to invoke BudgetManager and emit budget/policy traces deterministically.
+  - id: verification
+    desc: Author unit/integration tests covering soft/hard budgets, breach actions, trace ordering, and policy enforcement before implementation.
+modules:
+  - path: codex/code/phase3-budget-runner-4f72/dsl/costs.py
+    role: Cost normalization utilities reused by budgets and runner.
+  - path: codex/code/phase3-budget-runner-4f72/dsl/budget.py
+    role: Budget domain models and BudgetManager orchestration.
+  - path: codex/code/phase3-budget-runner-4f72/dsl/trace.py
+    role: TraceWriter protocol and TraceEventEmitter bridging policy/budget events.
+  - path: codex/code/phase3-budget-runner-4f72/dsl/policy.py
+    role: Lightweight PolicyStack enforcement with trace hooks per 07a dependencies.
+  - path: codex/code/phase3-budget-runner-4f72/dsl/runner.py
+    role: FlowRunner orchestrating adapters, policies, and budgets.
+tests:
+  - path: codex/code/phase3-budget-runner-4f72/tests/test_costs_normalization.py
+    coverage: Ensure seconds→milliseconds conversion and immutable payloads for normalized costs.
+    mocks: None (pure functions).
+  - path: codex/code/phase3-budget-runner-4f72/tests/test_budget_manager.py
+    coverage: BudgetManager preflight/commit outcomes for soft/hard modes, remaining/overages math, trace emissions.
+    mocks: Fake TraceWriter to capture events.
+  - path: codex/code/phase3-budget-runner-4f72/tests/test_flow_runner_integration.py
+    coverage: FlowRunner executing adapters with policy enforcement, verifying stop reasons, policy_resolved traces, and budget breach handling.
+    mocks: Deterministic ToolAdapter doubles providing estimate/execute results.
+run_order:
+  - cost_normalization
+  - budget_manager
+  - trace_bridge
+  - runner_integration
+  - verification
+interfaces:
+  - name: TraceWriter
+    contract: emit(event: str, payload: Mapping[str, object]) -> None; snapshot() -> Sequence[Mapping[str, object]]
+  - name: BudgetManager
+    contract: preflight(scope, scope_type, spec, cost) -> BudgetDecision; commit(decision) -> BudgetChargeOutcome
+  - name: FlowRunner
+    contract: run(flow, context) -> RunResult including traces and loop summaries
+  - name: PolicyStack
+    contract: check(node_id, adapter) -> PolicyDecision raising on violation while emitting traces
+  - name: ToolAdapter
+    contract: estimate(context) -> CostSnapshot; execute(context) -> NodeExecution
+tdd_coverage_targets:
+  - module: dsl/costs.py
+    minimum: 0.9
+  - module: dsl/budget.py
+    minimum: 0.9
+  - module: dsl/runner.py
+    minimum: 0.85
+review_checklist:
+  - Tests cover soft/hard budget paths and policy trace emission (policy_resolved) per POSTEXECUTION directives.
+  - Budget normalization converts seconds→milliseconds exactly once and returns immutable payloads.
+  - FlowRunner stops deterministically on hard breaches and continues on soft warnings.
+  - TraceWriter usage avoids mutable payload leaks (mapping_proxy enforced).
+  - Documentation attributes reused logic to specific branches.
+outputs:
+  plan_yaml: codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.yaml
+  tests_root: codex/code/phase3-budget-runner-4f72/tests/
+  code_root: codex/code/phase3-budget-runner-4f72/
+  preview_doc: codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.md
+  review_doc: codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.md
+  postexecution_doc: codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029.md
+  metadata_doc: codex/DOCUMENTATION/P3/phase3-budget-runner-4f72-565941d2177b4311b170222d4ecb5029.yaml
+  missing_tests_doc: codex/TESTS/P3/phase3-budget-runner-4f72-565941d2177b4311b170222d4ecb5029.yaml
+  optional_runner: codex/code/phase3-budget-runner-4f72/phase3_runner.py

--- a/codex/code/phase3-budget-runner-4f72/dsl/budget.py
+++ b/codex/code/phase3-budget-runner-4f72/dsl/budget.py
@@ -1,0 +1,203 @@
+"""Budget domain model and manager integration for the sandbox FlowRunner.
+
+The implementation threads together:
+* Immutable budget snapshots from `codex/integrate-budget-guards-with-runner-zwi2ny`.
+* Structured overage accounting from `codex/integrate-budget-guards-with-runner-pbdel9`.
+* Budget mode semantics originating in `codex/implement-budget-guards-with-test-first-approach-qhq0jq`.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, fields
+from enum import Enum
+from types import MappingProxyType
+from typing import Dict
+
+from .costs import normalize_cost
+from .trace import TraceEventEmitter
+
+
+class BudgetMode(str, Enum):
+    HARD = "hard"
+    SOFT = "soft"
+
+
+@dataclass(frozen=True, slots=True)
+class CostSnapshot:
+    metrics: Mapping[str, float]
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, float | int]) -> "CostSnapshot":
+        return cls(metrics=normalize_cost(raw))
+
+    def as_dict(self) -> dict[str, float]:
+        return dict(self.metrics)
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetSpec:
+    scope_id: str
+    limits: Mapping[str, float]
+    mode: BudgetMode = BudgetMode.HARD
+    breach_action: str = "stop"
+
+    def __post_init__(self) -> None:
+        normalised = normalize_cost(self.limits)
+        object.__setattr__(self, "limits", normalised)
+        action = self.breach_action.lower()
+        if action not in {"warn", "stop"}:
+            raise ValueError("breach_action must be either 'warn' or 'stop'")
+        object.__setattr__(self, "breach_action", action)
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetDecision:
+    run_id: str
+    node_id: str
+    scope: str
+    scope_type: str
+    spec: BudgetSpec
+    cost: CostSnapshot
+    spent: Mapping[str, float]
+    projected_spend: Mapping[str, float]
+    remaining: Mapping[str, float]
+    overages: Mapping[str, float]
+    breach_kind: str
+    should_stop: bool
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetChargeOutcome(BudgetDecision):
+    """Outcome returned after a successful commit."""
+
+
+class BudgetHardStop(RuntimeError):
+    """Raised when a hard budget requires termination."""
+
+    def __init__(self, scope: str, overages: Mapping[str, float]) -> None:
+        formatted = ", ".join(f"{metric}:+{value:.2f}" for metric, value in overages.items()) or "no overages"
+        super().__init__(f"Budget exceeded for {scope}: {formatted}")
+        self.scope = scope
+        self.overages = MappingProxyType(dict(overages))
+
+
+@dataclass
+class _BudgetAccount:
+    spec: BudgetSpec
+    spent: Dict[str, float]
+
+
+class BudgetManager:
+    """Coordinates budget preflight and commit operations while emitting traces."""
+
+    def __init__(self, emitter: TraceEventEmitter) -> None:
+        self._emitter = emitter
+        self._accounts: dict[str, _BudgetAccount] = {}
+
+    def preflight(
+        self,
+        run_id: str,
+        scope: str,
+        scope_type: str,
+        node_id: str,
+        spec: BudgetSpec,
+        cost: CostSnapshot,
+    ) -> BudgetDecision:
+        account = self._accounts.get(scope)
+        if account is None:
+            account = _BudgetAccount(spec=spec, spent={})
+            self._accounts[scope] = account
+        else:
+            # Allow updated limits but keep cumulative spend.
+            account.spec = spec
+
+        spent = dict(account.spent)
+        projected = _add_costs(spent, cost.metrics)
+
+        remaining = _remaining(spec.limits, projected)
+        overages = _overages(spec.limits, projected)
+        has_overage = any(value > 0 for value in overages.values())
+
+        if not has_overage:
+            breach_kind = "none"
+            should_stop = False
+        elif spec.mode is BudgetMode.SOFT and spec.breach_action != "stop":
+            breach_kind = "soft"
+            should_stop = False
+        else:
+            breach_kind = "hard"
+            should_stop = True
+
+        return BudgetDecision(
+            run_id=run_id,
+            node_id=node_id,
+            scope=scope,
+            scope_type=scope_type,
+            spec=spec,
+            cost=cost,
+            spent=_freeze_mapping(spent),
+            projected_spend=_freeze_mapping(projected),
+            remaining=_freeze_mapping(remaining),
+            overages=_freeze_mapping({k: v for k, v in overages.items() if v > 0}),
+            breach_kind=breach_kind,
+            should_stop=should_stop,
+        )
+
+    def commit(self, decision: BudgetDecision) -> BudgetChargeOutcome:
+        account = self._accounts[decision.scope]
+
+        self._emitter.budget_charge(
+            scope=decision.scope,
+            scope_type=decision.scope_type,
+            run_id=decision.run_id,
+            node_id=decision.node_id,
+            cost=decision.cost.metrics,
+            remaining=decision.remaining,
+        )
+
+        if decision.breach_kind != "none":
+            self._emitter.budget_breach(
+                scope=decision.scope,
+                scope_type=decision.scope_type,
+                run_id=decision.run_id,
+                node_id=decision.node_id,
+                overages=decision.overages,
+                remaining=decision.remaining,
+                severity="hard" if decision.should_stop else "soft",
+            )
+
+        if decision.should_stop:
+            raise BudgetHardStop(decision.scope, decision.overages)
+
+        account.spent = dict(decision.projected_spend)
+        payload = {field.name: getattr(decision, field.name) for field in fields(BudgetDecision)}
+        return BudgetChargeOutcome(**payload)
+
+
+def _add_costs(spent: Mapping[str, float], cost: Mapping[str, float]) -> Dict[str, float]:
+    combined: Dict[str, float] = dict(spent)
+    for key, value in cost.items():
+        combined[key] = combined.get(key, 0.0) + float(value)
+    return combined
+
+
+def _remaining(limits: Mapping[str, float], projected: Mapping[str, float]) -> Dict[str, float]:
+    remaining: Dict[str, float] = {}
+    for metric, limit in limits.items():
+        remaining[metric] = float(limit) - float(projected.get(metric, 0.0))
+    return remaining
+
+
+def _overages(limits: Mapping[str, float], projected: Mapping[str, float]) -> Dict[str, float]:
+    over: Dict[str, float] = {}
+    for metric, limit in limits.items():
+        projected_value = float(projected.get(metric, 0.0))
+        if projected_value > float(limit):
+            over[metric] = projected_value - float(limit)
+        else:
+            over[metric] = 0.0
+    return over
+
+
+def _freeze_mapping(values: Mapping[str, float]) -> Mapping[str, float]:
+    return MappingProxyType({key: float(amount) for key, amount in values.items()})

--- a/codex/code/phase3-budget-runner-4f72/dsl/costs.py
+++ b/codex/code/phase3-budget-runner-4f72/dsl/costs.py
@@ -1,0 +1,44 @@
+"""Cost normalization utilities for the Phase 3 budget integration sandbox.
+
+This module synthesizes the deterministic cost arithmetic from
+`codex/implement-budget-guards-with-test-first-approach-8wxk32` with the
+millisecond storage discipline adopted in
+`codex/implement-budget-guards-with-test-first-approach-fa0vm9`. The helper
+exposes a single entry-point that converts heterogeneous inputs (seconds,
+milliseconds, integer counts) into an immutable mapping suitable for the
+BudgetManager.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import MutableMapping
+
+
+def _ensure_mapping(cost: Mapping[str, float | int]) -> MutableMapping[str, float]:
+    result: MutableMapping[str, float] = {}
+    for key, value in cost.items():
+        if not isinstance(value, (int, float)):
+            raise TypeError(f"Cost value for {key!r} must be numeric, got {type(value)!r}")
+        numeric = float(value)
+        if numeric < 0:
+            raise ValueError(f"Cost value for {key!r} must be non-negative")
+        result[key] = numeric
+    return result
+
+
+def normalize_cost(cost: Mapping[str, float | int]) -> Mapping[str, float]:
+    """Normalise a raw cost mapping into canonical units and freeze the payload."""
+
+    materialised = _ensure_mapping(cost)
+    total: MutableMapping[str, float] = {}
+
+    for key, value in materialised.items():
+        if key == "time_seconds":
+            total["time_ms"] = total.get("time_ms", 0.0) + value * 1000.0
+        elif key == "time_ms":
+            total["time_ms"] = total.get("time_ms", 0.0) + value
+        else:
+            total[key] = total.get(key, 0.0) + value
+
+    return MappingProxyType({name: float(amount) for name, amount in total.items()})

--- a/codex/code/phase3-budget-runner-4f72/dsl/policy.py
+++ b/codex/code/phase3-budget-runner-4f72/dsl/policy.py
@@ -1,0 +1,42 @@
+"""Minimal PolicyStack used by the sandbox runner.
+
+The behaviour mirrors the allowlist enforcement path introduced during task 07a
+and emits explicit `policy_resolved` events to satisfy POSTEXECUTION
+requirements.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Set
+
+from .trace import TraceEventEmitter
+
+
+class PolicyViolation(RuntimeError):
+    """Raised when a node violates policy constraints."""
+
+    def __init__(self, node_id: str, adapter: str, reason: str) -> None:
+        super().__init__(f"Policy violation at {node_id} for adapter {adapter}: {reason}")
+        self.node_id = node_id
+        self.adapter = adapter
+        self.reason = reason
+
+
+@dataclass
+class PolicyStack:
+    emitter: TraceEventEmitter
+    allowlist: Set[str] = field(default_factory=set)
+
+    def check(self, run_id: str, node_id: str, adapter_name: str) -> None:
+        """Validate the adapter against the allowlist and emit `policy_push`."""
+        self.emitter.policy_push(node_id, adapter_name, run_id)
+        if self.allowlist and adapter_name not in self.allowlist:
+            reason = "adapter not allowed"
+            self.emitter.policy_violation(node_id, adapter_name, run_id, reason)
+            raise PolicyViolation(node_id, adapter_name, reason)
+
+    def resolved(self, run_id: str, node_id: str, adapter_name: str) -> None:
+        self.emitter.policy_resolved(node_id, adapter_name, run_id)
+
+    def extend_allowlist(self, adapters: Iterable[str]) -> None:
+        self.allowlist.update(adapters)

--- a/codex/code/phase3-budget-runner-4f72/dsl/runner.py
+++ b/codex/code/phase3-budget-runner-4f72/dsl/runner.py
@@ -1,0 +1,132 @@
+"""Adapter-driven FlowRunner for the sandbox environment.
+
+The loop structure reuses the adapter/loop orchestration ideas from
+`codex/implement-budget-guards-with-test-first-approach-fa0vm9` while relying on
+BudgetManager previews from the zwi2ny/qhq0jq branches. Policy enforcement is
+kept synchronous and emits `policy_resolved` traces before any budget work.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from .budget import BudgetHardStop, BudgetManager, BudgetSpec, CostSnapshot
+from .policy import PolicyStack
+from .trace import TraceEventEmitter
+
+
+class ToolAdapter(Protocol):
+    """Protocol describing the adapter interface expected by the runner."""
+
+    name: str
+
+    def estimate(self, context: "RunContext") -> CostSnapshot:
+        ...
+
+    def execute(self, context: "RunContext") -> object:
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class FlowNode:
+    node_id: str
+    adapter: ToolAdapter
+    budget_spec: BudgetSpec
+    scope_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class RunContext:
+    run_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class NodeExecution:
+    node_id: str
+    adapter: str
+    result: object
+    cost: CostSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class RunResult:
+    completed_nodes: list[NodeExecution]
+    stop_reason: str | None = None
+
+
+class FlowRunner:
+    """Coordinates policies, budgets, and adapters for sequential node execution."""
+
+    def __init__(
+        self,
+        *,
+        budget_manager: BudgetManager,
+        policy_stack: PolicyStack,
+        emitter: TraceEventEmitter,
+    ) -> None:
+        self._budget_manager = budget_manager
+        self._policy_stack = policy_stack
+        self._emitter = emitter
+
+    def run(self, flow: object, context: RunContext) -> RunResult:
+        completed: list[NodeExecution] = []
+        stop_reason: str | None = None
+
+        nodes = getattr(flow, "nodes", [])
+        for node in nodes:
+            adapter = node.adapter
+            self._policy_stack.check(context.run_id, node.node_id, adapter.name)
+
+            estimate = adapter.estimate(context)
+            scope_key = f"{context.run_id}:{node.budget_spec.scope_id}"
+            decision = self._budget_manager.preflight(
+                context.run_id,
+                scope_key,
+                node.scope_type,
+                node.node_id,
+                node.budget_spec,
+                estimate,
+            )
+
+            if decision.should_stop:
+                try:
+                    self._budget_manager.commit(decision)
+                except BudgetHardStop:
+                    stop_reason = "budget_hard_stop"
+                    self._emitter.loop_summary(
+                        run_id=context.run_id,
+                        node_id=node.node_id,
+                        stop_reason=stop_reason,
+                        spent=decision.projected_spend,
+                    )
+                    break
+            else:
+                result = adapter.execute(context)
+                try:
+                    outcome = self._budget_manager.commit(decision)
+                except BudgetHardStop:
+                    stop_reason = "budget_hard_stop"
+                    self._emitter.loop_summary(
+                        run_id=context.run_id,
+                        node_id=node.node_id,
+                        stop_reason=stop_reason,
+                        spent=decision.projected_spend,
+                    )
+                    break
+                completed.append(
+                    NodeExecution(
+                        node_id=node.node_id,
+                        adapter=adapter.name,
+                        result=result,
+                        cost=outcome.cost,
+                    )
+                )
+                self._policy_stack.resolved(context.run_id, node.node_id, adapter.name)
+                self._emitter.loop_summary(
+                    run_id=context.run_id,
+                    node_id=node.node_id,
+                    stop_reason=None,
+                    spent=outcome.projected_spend,
+                )
+
+        return RunResult(completed_nodes=completed, stop_reason=stop_reason)

--- a/codex/code/phase3-budget-runner-4f72/dsl/trace.py
+++ b/codex/code/phase3-budget-runner-4f72/dsl/trace.py
@@ -1,0 +1,150 @@
+"""Trace writer abstractions reused by the budget manager and FlowRunner.
+
+The design mirrors immutable event payloads introduced in
+`codex/integrate-budget-guards-with-runner-zwi2ny` while enriching breach
+metadata with the overage accounting popularised in the pbdel9 branch. Policy
+hooks emit `policy_resolved` events explicitly per POSTEXECUTION directives.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+
+class TraceWriter:
+    """Abstract trace sink used by runtime collaborators."""
+
+    def emit(self, event: str, payload: Mapping[str, object]) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def snapshot(self) -> tuple[Mapping[str, object], ...]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class InMemoryTraceWriter(TraceWriter):
+    """Simple trace writer that buffers immutable trace events in memory."""
+
+    def __init__(self) -> None:
+        self._events: list[Mapping[str, object]] = []
+
+    def emit(self, event: str, payload: Mapping[str, object]) -> None:
+        combined: MutableMapping[str, object] = {"event": event}
+        for key, value in payload.items():
+            combined[key] = _freeze_value(value)
+        self._events.append(MappingProxyType(combined))
+
+    def snapshot(self) -> tuple[Mapping[str, object], ...]:
+        return tuple(self._events)
+
+
+def _freeze_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        frozen_inner: MutableMapping[str, object] = {}
+        for inner_key, inner_value in value.items():
+            frozen_inner[str(inner_key)] = _freeze_value(inner_value)
+        return MappingProxyType(frozen_inner)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_value(item) for item in value)
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyTrace:
+    node_id: str
+    adapter: str
+    run_id: str
+
+
+class TraceEventEmitter:
+    """High-level trace emitter shared by PolicyStack, BudgetManager, and FlowRunner."""
+
+    def __init__(self, writer: TraceWriter) -> None:
+        self._writer = writer
+
+    def policy_push(self, node_id: str, adapter: str, run_id: str) -> None:
+        self._writer.emit(
+            "policy_push",
+            {"node_id": node_id, "adapter": adapter, "run_id": run_id},
+        )
+
+    def policy_resolved(self, node_id: str, adapter: str, run_id: str) -> None:
+        self._writer.emit(
+            "policy_resolved",
+            {"node_id": node_id, "adapter": adapter, "run_id": run_id},
+        )
+
+    def policy_violation(self, node_id: str, adapter: str, run_id: str, reason: str) -> None:
+        self._writer.emit(
+            "policy_violation",
+            {
+                "node_id": node_id,
+                "adapter": adapter,
+                "run_id": run_id,
+                "reason": reason,
+            },
+        )
+
+    def budget_charge(
+        self,
+        *,
+        scope: str,
+        scope_type: str,
+        run_id: str,
+        node_id: str,
+        cost: Mapping[str, float],
+        remaining: Mapping[str, float],
+    ) -> None:
+        self._writer.emit(
+            "budget_charge",
+            {
+                "scope": scope,
+                "scope_type": scope_type,
+                "run_id": run_id,
+                "node_id": node_id,
+                "cost": dict(cost),
+                "remaining": dict(remaining),
+            },
+        )
+
+    def budget_breach(
+        self,
+        *,
+        scope: str,
+        scope_type: str,
+        run_id: str,
+        node_id: str,
+        overages: Mapping[str, float],
+        remaining: Mapping[str, float],
+        severity: str,
+    ) -> None:
+        self._writer.emit(
+            "budget_breach",
+            {
+                "scope": scope,
+                "scope_type": scope_type,
+                "run_id": run_id,
+                "node_id": node_id,
+                "overages": dict(overages),
+                "remaining": dict(remaining),
+                "severity": severity,
+            },
+        )
+
+    def loop_summary(
+        self,
+        *,
+        run_id: str,
+        node_id: str,
+        stop_reason: str | None,
+        spent: Mapping[str, float],
+    ) -> None:
+        self._writer.emit(
+            "loop_summary",
+            {
+                "run_id": run_id,
+                "node_id": node_id,
+                "stop_reason": stop_reason,
+                "spent": dict(spent),
+            },
+        )

--- a/codex/code/phase3-budget-runner-4f72/phase3_runner.py
+++ b/codex/code/phase3-budget-runner-4f72/phase3_runner.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Utility script to execute the sandbox Phase 3 test suite."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+LOG = Path("codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-565941d2177b4311b170222d4ecb5029-runlog.txt")
+
+
+def main() -> int:
+    LOG.parent.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+    cmd = [sys.executable, "-m", "pytest", "-q", str(ROOT / "tests")]
+    with LOG.open("w", encoding="utf-8") as handle:
+        process = subprocess.run(cmd, cwd=ROOT, env=env, stdout=handle, stderr=subprocess.STDOUT)
+    return process.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/code/phase3-budget-runner-4f72/tests/test_budget_manager.py
+++ b/codex/code/phase3-budget-runner-4f72/tests/test_budget_manager.py
@@ -1,0 +1,66 @@
+import pytest
+
+from dsl.budget import (
+    BudgetManager,
+    BudgetMode,
+    BudgetSpec,
+    CostSnapshot,
+    BudgetHardStop,
+)
+from dsl.trace import InMemoryTraceWriter, TraceEventEmitter
+
+
+def make_spec(scope: str, limit: float, mode: BudgetMode, breach_action: str = "warn") -> BudgetSpec:
+    return BudgetSpec(scope_id=scope, limits={"time_ms": limit}, mode=mode, breach_action=breach_action)
+
+
+def make_cost(ms: float) -> CostSnapshot:
+    return CostSnapshot.from_raw({"time_ms": ms})
+
+
+def test_soft_budget_emits_warning_and_does_not_stop():
+    writer = InMemoryTraceWriter()
+    emitter = TraceEventEmitter(writer)
+    manager = BudgetManager(emitter)
+
+    spec = make_spec("run-1", 1000.0, BudgetMode.SOFT, breach_action="warn")
+    decision = manager.preflight("run-1", "run-1", "run", "n1", spec, make_cost(900.0))
+    outcome = manager.commit(decision)
+
+    assert outcome.should_stop is False
+    assert outcome.breach_kind == "none"
+
+    # Second charge pushes over the limit but should warn only.
+    decision_over = manager.preflight("run-1", "run-1", "run", "n2", spec, make_cost(200.0))
+    outcome_over = manager.commit(decision_over)
+    assert outcome_over.should_stop is False
+    assert outcome_over.breach_kind == "soft"
+
+    events = writer.snapshot()
+    budget_events = [event for event in events if event["event"].startswith("budget_")]
+    assert any(event["event"] == "budget_charge" for event in budget_events)
+    breach_events = [event for event in budget_events if event["event"] == "budget_breach"]
+    assert breach_events, "soft overage should emit budget_breach event"
+    assert breach_events[-1]["severity"] == "soft"
+    assert breach_events[-1]["overages"]["time_ms"] == pytest.approx(100.0)
+
+
+def test_hard_budget_raises_and_emits_hard_breach():
+    writer = InMemoryTraceWriter()
+    emitter = TraceEventEmitter(writer)
+    manager = BudgetManager(emitter)
+
+    spec = make_spec("run-2", 100.0, BudgetMode.HARD, breach_action="stop")
+    decision = manager.preflight("run-2", "run-2", "run", "n1", spec, make_cost(150.0))
+
+    with pytest.raises(BudgetHardStop):
+        manager.commit(decision)
+
+    events = writer.snapshot()
+    breach = [event for event in events if event["event"] == "budget_breach"][-1]
+    assert breach["severity"] == "hard"
+    assert breach["overages"]["time_ms"] == pytest.approx(50.0)
+    # Ensure the account was not mutated after the hard stop
+    decision_retry = manager.preflight("run-2", "run-2", "run", "n2", spec, make_cost(50.0))
+    assert decision_retry.spent.get("time_ms", 0.0) == pytest.approx(0.0)
+    assert decision_retry.should_stop is False

--- a/codex/code/phase3-budget-runner-4f72/tests/test_costs_normalization.py
+++ b/codex/code/phase3-budget-runner-4f72/tests/test_costs_normalization.py
@@ -1,0 +1,28 @@
+import pytest
+
+from dsl.costs import normalize_cost
+
+
+def test_normalize_seconds_to_milliseconds_and_freeze_mapping():
+    raw = {"time_seconds": 1.25, "tokens": 42}
+
+    normalized = normalize_cost(raw)
+
+    assert normalized["time_ms"] == pytest.approx(1250.0)
+    assert normalized["tokens"] == pytest.approx(42.0)
+    with pytest.raises(TypeError):
+        normalized["tokens"] = 99  # type: ignore[misc]
+
+
+def test_normalize_cost_rejects_negative_values():
+    with pytest.raises(ValueError):
+        normalize_cost({"time_seconds": -0.5})
+
+
+def test_normalize_cost_preserves_existing_milliseconds():
+    normalized = normalize_cost({"time_ms": 150.0})
+
+    assert normalized["time_ms"] == pytest.approx(150.0)
+    # idempotent call should not change data
+    normalized_again = normalize_cost(normalized)
+    assert normalized_again["time_ms"] == pytest.approx(150.0)

--- a/codex/code/phase3-budget-runner-4f72/tests/test_flow_runner_integration.py
+++ b/codex/code/phase3-budget-runner-4f72/tests/test_flow_runner_integration.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import pytest
+
+from dsl.budget import BudgetManager, BudgetMode, BudgetSpec, CostSnapshot
+from dsl.policy import PolicyStack, PolicyViolation
+from dsl.runner import FlowNode, FlowRunner, RunContext, RunResult
+from dsl.trace import InMemoryTraceWriter, TraceEventEmitter
+
+
+class FakeAdapter:
+    def __init__(self, name: str, estimate_ms: float, execute_ms: float | None = None) -> None:
+        self.name = name
+        self.estimate_ms = estimate_ms
+        self.execute_ms = execute_ms if execute_ms is not None else estimate_ms
+        self.executions: List[float] = []
+
+    def estimate(self, context: RunContext) -> CostSnapshot:
+        return CostSnapshot.from_raw({"time_ms": self.estimate_ms})
+
+    def execute(self, context: RunContext) -> float:
+        self.executions.append(self.execute_ms)
+        return self.execute_ms
+
+
+@dataclass
+class FakeFlow:
+    nodes: list[FlowNode]
+
+
+def make_soft_flow():
+    writer = InMemoryTraceWriter()
+    emitter = TraceEventEmitter(writer)
+    manager = BudgetManager(emitter)
+    policy_stack = PolicyStack(emitter, allowlist={"allowed"})
+    runner = FlowRunner(budget_manager=manager, policy_stack=policy_stack, emitter=emitter)
+
+    adapter1 = FakeAdapter("allowed", 800.0)
+    adapter2 = FakeAdapter("allowed", 400.0)
+    spec = BudgetSpec(scope_id="run", limits={"time_ms": 1000.0}, mode=BudgetMode.SOFT, breach_action="warn")
+    flow = FakeFlow(
+        nodes=[
+            FlowNode(node_id="n1", adapter=adapter1, budget_spec=spec, scope_type="run"),
+            FlowNode(node_id="n2", adapter=adapter2, budget_spec=spec, scope_type="run"),
+        ]
+    )
+    return flow, runner, writer, adapter1, adapter2
+
+
+def test_runner_continues_on_soft_budget_warn():
+    flow, runner, writer, adapter1, adapter2 = make_soft_flow()
+    context = RunContext(run_id="run-1")
+
+    result = runner.run(flow, context)
+
+    assert isinstance(result, RunResult)
+    assert result.stop_reason is None
+    assert [node.node_id for node in result.completed_nodes] == ["n1", "n2"]
+    assert adapter1.executions and adapter2.executions
+
+    events = writer.snapshot()
+    policy_resolved = [event for event in events if event["event"] == "policy_resolved"]
+    assert len(policy_resolved) == 2
+    breaches = [event for event in events if event["event"] == "budget_breach"]
+    assert breaches
+    assert breaches[-1]["severity"] == "soft"
+
+
+def test_runner_stops_on_hard_budget_before_execution():
+    writer = InMemoryTraceWriter()
+    emitter = TraceEventEmitter(writer)
+    manager = BudgetManager(emitter)
+    policy_stack = PolicyStack(emitter, allowlist={"allowed"})
+    runner = FlowRunner(budget_manager=manager, policy_stack=policy_stack, emitter=emitter)
+
+    adapter1 = FakeAdapter("allowed", 60.0)
+    adapter2 = FakeAdapter("allowed", 60.0)
+    spec = BudgetSpec(scope_id="run", limits={"time_ms": 100.0}, mode=BudgetMode.HARD, breach_action="stop")
+    flow = FakeFlow(
+        nodes=[
+            FlowNode(node_id="n1", adapter=adapter1, budget_spec=spec, scope_type="run"),
+            FlowNode(node_id="n2", adapter=adapter2, budget_spec=spec, scope_type="run"),
+        ]
+    )
+    context = RunContext(run_id="run-2")
+
+    result = runner.run(flow, context)
+
+    assert result.stop_reason == "budget_hard_stop"
+    assert [node.node_id for node in result.completed_nodes] == ["n1"]
+    assert adapter2.executions == []
+
+    events = writer.snapshot()
+    breaches = [event for event in events if event["event"] == "budget_breach"]
+    assert breaches[-1]["severity"] == "hard"
+    # Policy still resolves for the executed node
+    policy_resolved = [event for event in events if event["event"] == "policy_resolved"]
+    assert len(policy_resolved) == 1
+
+
+def test_runner_raises_policy_violation_before_budget_check():
+    writer = InMemoryTraceWriter()
+    emitter = TraceEventEmitter(writer)
+    manager = BudgetManager(emitter)
+    policy_stack = PolicyStack(emitter, allowlist={"allowed"})
+    runner = FlowRunner(budget_manager=manager, policy_stack=policy_stack, emitter=emitter)
+
+    violating_adapter = FakeAdapter("blocked", 10.0)
+    spec = BudgetSpec(scope_id="run", limits={"time_ms": 1000.0}, mode=BudgetMode.SOFT, breach_action="warn")
+    flow = FakeFlow([FlowNode(node_id="n1", adapter=violating_adapter, budget_spec=spec, scope_type="run")])
+
+    with pytest.raises(PolicyViolation):
+        runner.run(flow, RunContext(run_id="run-3"))
+
+    events = writer.snapshot()
+    assert any(event["event"] == "policy_violation" for event in events)
+    assert all(event["event"] != "budget_charge" for event in events)


### PR DESCRIPTION
## Summary
- implement a sandbox BudgetManager and FlowRunner that blend fa0vm9 adapter orchestration with zwi2ny/pbdel9 immutable budget models
- add shared TraceEventEmitter, PolicyStack hooks, and cost normalisation utilities dedicated to the 07b budget integration task
- provide pytest coverage and documentation artefacts for the Phase 3 staging branch

## Testing
- PYTHONPATH=codex/code/phase3-budget-runner-4f72 pytest codex/code/phase3-budget-runner-4f72/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8c9292980832ca282c33d5ffc4de2