### PR TITLE
Add sandbox budget manager and runner integration scaffolding

### DIFF
--- a/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.md
+++ b/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.md
@@ -1,0 +1,10 @@
+# Phase 3 Post-Execution — Budget Guards & Runner Integration
+
+## Test Results
+- `pytest codex/code/phase3-budget-runner-71d5/tests -q`
+
+## Coverage & Notes
+- Unit suite exercises BudgetManager preview/commit branches, including hard-stop propagation and soft-warning traces.
+- FlowRunner tests cover run-level breaches and loop soft-warn scenarios, validating trace emission and stop reasoning.
+- TraceEmitter tests confirm immutable payload guarantees and policy bridge integration.
+- No additional integration harness was required; adapters rely on deterministic in-memory fakes.

--- a/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.md
+++ b/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.md
@@ -1,0 +1,12 @@
+# Phase 3 Preview — Budget Guards & Runner Integration
+
+## Overview
+- Introduced immutable budget domain models (`CostSnapshot`, `BudgetSpec`, `BudgetChargeOutcome`) with milliseconds normalization and arithmetic helpers.
+- Implemented `BudgetManager` coordinating run/loop/node scopes, supporting preview/commit phases, warnings, and deterministic trace emission.
+- Added `TraceEventEmitter` bridging policy and budget events through immutable payloads and optional recorders/sinks.
+- Delivered a `FlowRunner` that orchestrates PolicyStack enforcement, ToolAdapters, and BudgetManager cooperation while emitting loop summaries and stop reasons.
+
+## Test Coverage Targets
+- `tests/test_budget_manager.py`: scope arithmetic, hard vs soft breaches, trace emission.
+- `tests/test_trace_emitter.py`: payload immutability and policy bridge semantics.
+- `tests/test_flow_runner.py`: adapter execution flow, policy enforcement, loop summaries, and run-stop behavior.

--- a/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.md
+++ b/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.md
@@ -1,0 +1,8 @@
+# Phase 3 Review Checklist — Budget Guards & Runner Integration
+
+- [x] BudgetMode and breach_action semantics reflect hard-stop vs soft-warn behavior.
+- [x] Cost normalization converts `*_s` metrics to milliseconds exactly once and all payloads are immutable.
+- [x] Trace emission flows through `TraceEventEmitter` using mapping proxies with deterministic ordering.
+- [x] FlowRunner enforces PolicyStack decisions before adapter execution and surfaces stop reasons from budgets.
+- [x] Loop summaries collect iterations executed, aggregated spend, and propagate warnings via traces.
+- [x] Unit tests cover manager arithmetic, trace immutability, policy-budget interplay, and loop warnings.

--- a/codex/DOCUMENTATION/P3/phase3-budget-runner-71d5-3d661f4a-0b91-4ab8-b1b1-972c23901e92.yaml
+++ b/codex/DOCUMENTATION/P3/phase3-budget-runner-71d5-3d661f4a-0b91-4ab8-b1b1-972c23901e92.yaml
@@ -1,0 +1,93 @@
+component:
+  name: phase3-budget-runner-71d5
+  purpose: >-
+    Provide a sandbox implementation of immutable budget management, trace emission, and a PolicyStack-aware
+    FlowRunner suitable for integration into pkgs.dsl modules.
+cli_usage: []
+public_interfaces:
+  - name: phase3_budget_runner_71d5.budgeting.CostSnapshot
+    type: dataclass
+    description: Immutable cost container with normalization helpers and arithmetic.
+    methods:
+      - name: from_raw
+        summary: Build a normalized snapshot converting seconds to milliseconds.
+      - name: add
+        summary: Return a new CostSnapshot representing the sum of metrics.
+      - name: subtract
+        summary: Produce a snapshot subtracting another snapshot's metrics.
+      - name: as_dict
+        summary: Expose metrics as a plain dictionary for serialization.
+  - name: phase3_budget_runner_71d5.budgeting.BudgetManager
+    type: class
+    description: Coordinates budget scopes, preview/commit cycles, and trace emission.
+    methods:
+      - name: enter_scope
+        summary: Register a scope with optional parent and spec before charging costs.
+      - name: preview
+        summary: Simulate a charge without mutating state, returning BudgetChargeResult.
+      - name: commit
+        summary: Persist a charge, update spent totals, and emit traces.
+      - name: snapshot
+        summary: Provide the latest BudgetChargeOutcome for an active scope.
+  - name: phase3_budget_runner_71d5.trace.TraceEventEmitter
+    type: class
+    description: Emits immutable trace events to recorders and sinks; bridges PolicyStack events.
+    methods:
+      - name: emit
+        summary: Emit a trace event with sanitized payload.
+      - name: policy_sink
+        summary: Adapter returning a callable suitable for PolicyStack event_sink wiring.
+  - name: phase3_budget_runner_71d5.runner.FlowRunner
+    type: class
+    description: Executes FlowPlan steps through ToolAdapters with PolicyStack enforcement and budget checks.
+    methods:
+      - name: run
+        summary: Execute the flow, returning a RunResult with executions, warnings, and stop reason.
+      - name: _execute_loop
+        summary: Iterate over LoopPlan bodies, emitting loop summaries and responding to stop signals.
+      - name: _execute_node
+        summary: Orchestrate estimate/execute lifecycle for a single node.
+  - name: phase3_budget_runner_71d5.adapters.ToolAdapter
+    type: protocol
+    description: Defines the estimate/execute contract expected by FlowRunner.
+    methods:
+      - name: estimate
+        summary: Produce a CostSnapshot forecast for the node.
+      - name: execute
+        summary: Execute the tool and return ToolExecutionResult.
+base_classes: []
+extension_hooks:
+  - name: ToolAdapter
+    description: Implementations can extend adapter behavior by providing deterministic estimate/execute logic.
+configurable_options:
+  - name: BudgetSpec.mode
+    type: enum
+    values: [hard, soft]
+    default: hard
+    description: Controls whether breaches stop execution immediately or warn.
+  - name: BudgetSpec.breach_action
+    type: enum
+    values: [stop, warn]
+    default: stop
+    description: Secondary action applied when soft budgets breach.
+automation_triggers: []
+error_contracts:
+  - condition: Unknown tool adapter requested
+    raises: KeyError
+    message: "unknown tool adapter '<name>'"
+serialization:
+  - component: TraceEventEmitter
+    format: mapping-proxy payloads suitable for JSON serialization after dict conversion.
+lifecycle:
+  setup:
+    - Call BudgetManager.enter_scope for run/loop/node scopes before preview/commit.
+    - Wire PolicyStack event_sink to TraceEventEmitter.policy_sink for consistent traces.
+  teardown:
+    - Ensure FlowRunner exits scopes (run, loop, node) to avoid stale state in BudgetManager.
+typing_notes:
+  - All public classes use typing annotations compatible with Python 3.11+ and rely on MappingProxyType for immutability.
+security_notes:
+  - No network access; all operations deterministic and in-memory.
+performance_notes:
+  - CostSnapshot arithmetic operates on small dictionaries; complexity is linear in metric count.
+  - Trace emission sanitization converts lists to tuples to guarantee immutability with minimal overhead.

--- a/codex/TESTS/P3/phase3-budget-runner-71d5-3d661f4a-0b91-4ab8-b1b1-972c23901e92.yaml
+++ b/codex/TESTS/P3/phase3-budget-runner-71d5-3d661f4a-0b91-4ab8-b1b1-972c23901e92.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_budget_manager_handles_spec_scope
+      rationale: Ensure BudgetManager aggregates charges across explicit spec scopes in addition to run/loop/node.
+      source_module: budgeting.py
+      priority: medium
+    - name: test_flow_runner_policy_violation_trace_order
+      rationale: Validate FlowRunner correctly emits policy_violation traces before budget events when PolicyStack blocks tools.
+      source_module: runner.py
+      priority: high
+    - name: test_trace_emitter_sink_error_handling
+      rationale: Verify TraceEventEmitter surfaces meaningful errors when policy events provide non-mapping payloads.
+      source_module: trace.py
+      priority: low

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.yaml
@@ -1,0 +1,98 @@
+summary: >
+  Implement cohesive budget manager and FlowRunner integration using immutable cost
+  models, shared trace emission, and adapter-driven execution with PolicyStack checks.
+justification: |
+  Prior phase reviews highlighted the need to merge immutable budget models (zwi2ny),
+  structured remaining/overage reporting (pbdel9), BudgetManager preflight/commit orchestration
+  (test-first), and adapter-oriented FlowRunner execution (fa0vm9) without losing policy traces.
+  This plan builds modular components that can be lifted into pkgs.dsl.* while remaining testable
+  inside the sandbox.
+steps:
+  - name: define_domain_models
+    description: >
+      Create canonical budget dataclasses and normalization helpers that convert raw cost metrics
+      into immutable snapshots with arithmetic helpers.
+  - name: implement_budget_manager
+    description: >
+      Build a BudgetManager that manages hierarchical scopes (run, loop, node, spec),
+      performs preview/commit charges, and emits structured trace events for charges and breaches.
+  - name: implement_trace_emitter
+    description: >
+      Provide a TraceEventEmitter wrapper around recorders/sinks so policy and budget layers can share
+      immutable payload emission with deterministic ordering.
+  - name: implement_flow_runner
+    description: >
+      Wire a FlowRunner that orchestrates ToolAdapters, enforces PolicyStack decisions,
+      collaborates with BudgetManager for preview/commit, and emits loop summaries plus combined traces.
+  - name: expand_tests
+    description: >
+      Cover BudgetManager arithmetic, soft vs hard breach semantics, FlowRunner execution order,
+      policy enforcement, trace emissions, and warning propagation.
+modules:
+  - path: codex/code/phase3-budget-runner-71d5/budgeting.py
+    role: Immutable cost models, BudgetManager orchestration, normalization helpers.
+  - path: codex/code/phase3-budget-runner-71d5/trace.py
+    role: Shared trace emitter abstraction with recorder integration.
+  - path: codex/code/phase3-budget-runner-71d5/adapters.py
+    role: ToolAdapter protocol and deterministic fakes used in tests.
+  - path: codex/code/phase3-budget-runner-71d5/runner.py
+    role: FlowRunner implementation integrating PolicyStack, BudgetManager, and trace emitter.
+tests:
+  - path: codex/code/phase3-budget-runner-71d5/tests/test_budget_manager.py
+    coverage: >
+      Validate normalization, multi-scope charging, remaining/overage accounting, and soft/hard breach actions.
+    mocks: []
+  - path: codex/code/phase3-budget-runner-71d5/tests/test_trace_emitter.py
+    coverage: >
+      Ensure trace emitter produces immutable payloads, recorder capture, and sink delegation order.
+    mocks: []
+  - path: codex/code/phase3-budget-runner-71d5/tests/test_flow_runner.py
+    coverage: >
+      Exercise adapter-driven execution, policy enforcement, budget stop logic, warning traces, and loop summaries.
+    mocks:
+      - Fake adapters implementing ToolAdapter protocol for deterministic costs.
+run_order:
+  - tests/test_budget_manager.py
+  - tests/test_trace_emitter.py
+  - tests/test_flow_runner.py
+interfaces:
+  budget_manager:
+    inputs:
+      - scope transitions (enter/exit) from FlowRunner
+      - cost snapshots from adapters (estimate/execute)
+    outputs:
+      - BudgetChargeOutcome snapshots
+      - breach warnings/stops surfaced to FlowRunner
+  trace_emitter:
+    inputs:
+      - structured events from policy stack and budget manager
+    outputs:
+      - recorder storage
+      - external sink callbacks
+  flow_runner:
+    inputs:
+      - flow plan (sequence of node definitions and optional loop metadata)
+      - tool adapters mapping
+      - policy stack for enforcement
+    outputs:
+      - RunResult containing node executions, warnings, and stop reason
+      - trace events emitted via TraceEventEmitter
+tdd_coverage_targets:
+  budgeting.py: 0.9
+  trace.py: 0.9
+  runner.py: 0.85
+review_checklist:
+  - BudgetMode and breach_action semantics match merged branch decisions (hard stop, soft warn+stop).
+  - Cost normalization converts seconds to milliseconds once and preserves immutable payloads.
+  - Trace events use mapping_proxy and are emitted in deterministic order.
+  - FlowRunner enforces PolicyStack decisions before adapter execution.
+  - Loop summaries aggregate per-iteration spend and propagate warnings.
+outputs:
+  code_root: codex/code/phase3-budget-runner-71d5
+  documentation:
+    preview: PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.md
+    review: REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.md
+    postexecution: POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92.md
+  metadata: codex/DOCUMENTATION/P3/phase3-budget-runner-71d5-3d661f4a-0b91-4ab8-b1b1-972c23901e92.yaml
+  missing_tests: codex/TESTS/P3/phase3-budget-runner-71d5-3d661f4a-0b91-4ab8-b1b1-972c23901e92.yaml
+  optional_runner: codex/code/phase3-budget-runner-71d5/phase3_runner.py

--- a/codex/code/phase3-budget-runner-71d5/phase3_budget_runner_71d5/adapters.py
+++ b/codex/code/phase3-budget-runner-71d5/phase3_budget_runner_71d5/adapters.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from .budgeting import CostSnapshot
+
+__all__ = ["ToolAdapter", "ToolExecutionResult"]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolExecutionResult:
+    result: dict[str, object]
+    cost: CostSnapshot
+    stop_loop: bool = False
+
+
+class ToolAdapter(Protocol):
+    """Protocol implemented by concrete tool adapters."""
+
+    name: str
+
+    def estimate(self, node: object, context: dict[str, object] | None = None) -> CostSnapshot:
+        ...
+
+    def execute(self, node: object, context: dict[str, object] | None = None) -> ToolExecutionResult:
+        ...

--- a/codex/code/phase3-budget-runner-71d5/phase3_budget_runner_71d5/budgeting.py
+++ b/codex/code/phase3-budget-runner-71d5/phase3_budget_runner_71d5/budgeting.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Dict
+
+from .trace import TraceEventEmitter
+
+__all__ = [
+    "BreachAction",
+    "BudgetChargeOutcome",
+    "BudgetChargeResult",
+    "BudgetContext",
+    "BudgetManager",
+    "BudgetMode",
+    "BudgetSpec",
+    "CostSnapshot",
+    "ScopeKey",
+    "ScopeType",
+]
+
+
+class ScopeType(str, Enum):
+    RUN = "run"
+    LOOP = "loop"
+    NODE = "node"
+    SPEC = "spec"
+
+
+@dataclass(frozen=True, slots=True)
+class ScopeKey:
+    scope_type: ScopeType
+    identifier: str
+
+
+class BudgetMode(str, Enum):
+    HARD = "hard"
+    SOFT = "soft"
+
+
+class BreachAction(str, Enum):
+    STOP = "stop"
+    WARN = "warn"
+
+
+@dataclass(frozen=True, slots=True)
+class CostSnapshot:
+    metrics: Mapping[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        normalized: Dict[str, float] = {}
+        for key, value in dict(self.metrics).items():
+            normalized[key] = float(value)
+        object.__setattr__(self, "metrics", MappingProxyType(normalized))
+
+    @classmethod
+    def from_raw(cls, metrics: Mapping[str, float] | None = None) -> "CostSnapshot":
+        normalized: Dict[str, float] = {}
+        for key, value in dict(metrics or {}).items():
+            if key.endswith("_s"):
+                normalized[f"{key[:-2]}_ms"] = float(value) * 1000.0
+            else:
+                normalized[key] = float(value)
+        return cls(normalized)
+
+    @classmethod
+    def zero(cls) -> "CostSnapshot":
+        return cls({})
+
+    def add(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot({key: self.metrics.get(key, 0.0) + other.metrics.get(key, 0.0) for key in self._keys(other)})
+
+    def subtract(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot({key: self.metrics.get(key, 0.0) - other.metrics.get(key, 0.0) for key in self._keys(other)})
+
+    def clamp_non_negative(self) -> "CostSnapshot":
+        return CostSnapshot({key: max(value, 0.0) for key, value in self.metrics.items()})
+
+    def any_positive(self) -> bool:
+        return any(value > 0.0 for value in self.metrics.values())
+
+    def as_dict(self) -> dict[str, float]:
+        return dict(self.metrics)
+
+    def _keys(self, other: "CostSnapshot") -> set[str]:
+        keys = set(self.metrics.keys())
+        keys.update(other.metrics.keys())
+        return keys
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetSpec:
+    name: str
+    limits: CostSnapshot
+    mode: BudgetMode = BudgetMode.HARD
+    breach_action: BreachAction = BreachAction.STOP
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetChargeOutcome:
+    scope: ScopeKey
+    spec: BudgetSpec
+    spent: CostSnapshot
+    remaining: CostSnapshot
+    overages: CostSnapshot
+    breached: bool
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetChargeResult:
+    outcomes: Mapping[ScopeKey, BudgetChargeOutcome]
+    should_stop: bool
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetContext:
+    run: ScopeKey | None = None
+    loop: ScopeKey | None = None
+    node: ScopeKey | None = None
+    spec: ScopeKey | None = None
+
+    def scopes(self) -> tuple[ScopeKey, ...]:
+        ordered = []
+        for scope in (self.run, self.loop, self.node, self.spec):
+            if scope is not None and scope not in ordered:
+                ordered.append(scope)
+        return tuple(ordered)
+
+
+@dataclass(slots=True)
+class _ScopeState:
+    spec: BudgetSpec | None
+    spent: CostSnapshot
+    parent: ScopeKey | None
+
+
+class BudgetManager:
+    """Manage budget scopes and emit deterministic trace events."""
+
+    def __init__(self, *, trace_emitter: TraceEventEmitter | None = None) -> None:
+        self._states: dict[ScopeKey, _ScopeState] = {}
+        self._trace = trace_emitter
+
+    def enter_scope(
+        self,
+        scope: ScopeKey,
+        spec: BudgetSpec | None,
+        *,
+        parent: ScopeKey | None = None,
+    ) -> None:
+        if scope in self._states:
+            raise ValueError(f"scope {scope!r} already active")
+        self._states[scope] = _ScopeState(spec=spec, spent=CostSnapshot.zero(), parent=parent)
+
+    def exit_scope(self, scope: ScopeKey) -> None:
+        self._states.pop(scope, None)
+
+    def preview(self, context: BudgetContext, cost: CostSnapshot, *, label: str) -> BudgetChargeResult:
+        return self._apply_charge(context, cost, label=label, commit=False)
+
+    def commit(self, context: BudgetContext, cost: CostSnapshot, *, label: str) -> BudgetChargeResult:
+        return self._apply_charge(context, cost, label=label, commit=True)
+
+    def snapshot(self, scope: ScopeKey) -> BudgetChargeOutcome | None:
+        state = self._states.get(scope)
+        if state is None or state.spec is None:
+            return None
+        return self._build_outcome(scope, state, CostSnapshot.zero())
+
+    def _apply_charge(
+        self,
+        context: BudgetContext,
+        cost: CostSnapshot,
+        *,
+        label: str,
+        commit: bool,
+    ) -> BudgetChargeResult:
+        outcomes: dict[ScopeKey, BudgetChargeOutcome] = {}
+        should_stop = False
+        warnings: list[str] = []
+
+        for scope in context.scopes():
+            state = self._states.get(scope)
+            if state is None or state.spec is None:
+                continue
+
+            outcome = self._build_outcome(scope, state, cost)
+            outcomes[scope] = outcome
+            warnings.extend(outcome.warnings)
+            if outcome.breached and self._enforces_stop(state.spec):
+                should_stop = True
+
+            if self._trace is not None:
+                payload = {
+                    "label": label,
+                    "scope": scope.identifier,
+                    "scope_type": scope.scope_type.value,
+                    "spent": outcome.spent.as_dict(),
+                    "remaining": outcome.remaining.as_dict(),
+                    "overages": outcome.overages.as_dict(),
+                    "breached": outcome.breached,
+                    "mode": outcome.spec.mode.value,
+                    "breach_action": outcome.spec.breach_action.value,
+                }
+                self._trace.emit("budget_charge", scope=scope.identifier, payload=payload)
+                if outcome.breached:
+                    self._trace.emit(
+                        "budget_breach",
+                        scope=scope.identifier,
+                        payload={
+                            "scope": scope.identifier,
+                            "scope_type": scope.scope_type.value,
+                            "overages": outcome.overages.as_dict(),
+                            "mode": outcome.spec.mode.value,
+                            "breach_action": outcome.spec.breach_action.value,
+                            "label": label,
+                        },
+                    )
+
+            if commit:
+                new_spent = outcome.spent
+                self._states[scope] = _ScopeState(spec=state.spec, spent=new_spent, parent=state.parent)
+
+        return BudgetChargeResult(outcomes=MappingProxyType(outcomes), should_stop=should_stop, warnings=tuple(warnings))
+
+    def _build_outcome(
+        self,
+        scope: ScopeKey,
+        state: _ScopeState,
+        cost: CostSnapshot,
+    ) -> BudgetChargeOutcome:
+        assert state.spec is not None
+        new_spent = state.spent.add(cost)
+        remaining_raw = state.spec.limits.subtract(new_spent)
+        overages_raw = new_spent.subtract(state.spec.limits)
+        remaining = CostSnapshot({key: max(value, 0.0) for key, value in remaining_raw.metrics.items()})
+        overages = CostSnapshot({key: max(value, 0.0) for key, value in overages_raw.metrics.items()})
+        breached = overages.any_positive()
+        warnings: tuple[str, ...]
+        if breached and state.spec.mode is BudgetMode.SOFT:
+            warnings = (
+                f"scope {scope.identifier} breached budget {state.spec.name} by {overages.as_dict()}",
+            )
+        elif breached:
+            warnings = (
+                f"scope {scope.identifier} exceeded budget {state.spec.name}",
+            )
+        else:
+            warnings = ()
+        return BudgetChargeOutcome(
+            scope=scope,
+            spec=state.spec,
+            spent=new_spent,
+            remaining=remaining,
+            overages=overages,
+            breached=breached,
+            warnings=warnings,
+        )
+
+    def _enforces_stop(self, spec: BudgetSpec) -> bool:
+        if spec.mode is BudgetMode.HARD:
+            return True
+        return spec.breach_action is BreachAction.STOP

--- a/codex/code/phase3-budget-runner-71d5/phase3_budget_runner_71d5/runner.py
+++ b/codex/code/phase3-budget-runner-71d5/phase3_budget_runner_71d5/runner.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Union
+
+from pkgs.dsl.policy import PolicyStack
+
+from .adapters import ToolAdapter, ToolExecutionResult
+from .budgeting import (
+    BreachAction,
+    BudgetChargeResult,
+    BudgetContext,
+    BudgetManager,
+    BudgetMode,
+    BudgetSpec,
+    CostSnapshot,
+    ScopeKey,
+    ScopeType,
+)
+from .trace import TraceEventEmitter
+
+__all__ = [
+    "FlowPlan",
+    "FlowRunner",
+    "LoopPlan",
+    "NodeExecution",
+    "NodePlan",
+    "RunResult",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class NodePlan:
+    node_id: str
+    tool: str
+    budget: BudgetSpec | None = None
+    parameters: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class LoopPlan:
+    loop_id: str
+    iterations: int
+    body: Sequence[NodePlan]
+    budget: BudgetSpec | None = None
+
+
+PlanStep = Union[NodePlan, LoopPlan]
+
+
+@dataclass(frozen=True, slots=True)
+class FlowPlan:
+    flow_id: str
+    run_budget: BudgetSpec | None
+    steps: Sequence[PlanStep]
+
+
+@dataclass(frozen=True, slots=True)
+class NodeExecution:
+    node_id: str
+    tool: str
+    cost: CostSnapshot
+    iteration: int | None
+    warnings: tuple[str, ...]
+    stopped: bool
+
+
+@dataclass(frozen=True, slots=True)
+class RunResult:
+    executions: tuple[NodeExecution, ...]
+    warnings: tuple[str, ...]
+    stop_reason: str | None
+
+
+class FlowRunner:
+    """Budget-aware FlowRunner that enforces policies and emits traces."""
+
+    def __init__(
+        self,
+        *,
+        adapters: Mapping[str, ToolAdapter],
+        policy_stack: PolicyStack,
+        budget_manager: BudgetManager,
+        trace_emitter: TraceEventEmitter,
+    ) -> None:
+        self._adapters = dict(adapters)
+        self._policy = policy_stack
+        self._budgets = budget_manager
+        self._trace = trace_emitter
+
+    def run(self, plan: FlowPlan, *, context: Mapping[str, object] | None = None) -> RunResult:
+        run_scope = ScopeKey(ScopeType.RUN, plan.flow_id)
+        self._budgets.enter_scope(run_scope, plan.run_budget, parent=None)
+        executions: list[NodeExecution] = []
+        warnings: list[str] = []
+        stop_reason: str | None = None
+
+        try:
+            for step in plan.steps:
+                if isinstance(step, LoopPlan):
+                    loop_result = self._execute_loop(step, run_scope)
+                    executions.extend(loop_result.executions)
+                    warnings.extend(loop_result.warnings)
+                    if loop_result.stop_reason is not None:
+                        stop_reason = loop_result.stop_reason
+                        break
+                else:
+                    node_exec, node_warnings, reason = self._execute_node(step, run_scope, loop_scope=None, iteration=None)
+                    executions.append(node_exec)
+                    warnings.extend(node_warnings)
+                    if reason is not None:
+                        stop_reason = reason
+                        break
+        finally:
+            self._budgets.exit_scope(run_scope)
+
+        return RunResult(executions=tuple(executions), warnings=tuple(warnings), stop_reason=stop_reason)
+
+    def _execute_loop(self, loop: LoopPlan, run_scope: ScopeKey) -> RunResult:
+        loop_scope = ScopeKey(ScopeType.LOOP, loop.loop_id)
+        self._budgets.enter_scope(loop_scope, loop.budget, parent=run_scope)
+        executions: list[NodeExecution] = []
+        warnings: list[str] = []
+        stop_reason: str | None = None
+
+        try:
+            for iteration in range(loop.iterations):
+                for node in loop.body:
+                    node_exec, node_warnings, reason = self._execute_node(
+                        node,
+                        run_scope,
+                        loop_scope=loop_scope,
+                        iteration=iteration,
+                    )
+                    executions.append(node_exec)
+                    warnings.extend(node_warnings)
+                    if reason is not None:
+                        stop_reason = reason
+                        break
+                if stop_reason is not None:
+                    break
+        finally:
+            snapshot = self._budgets.snapshot(loop_scope)
+            payload = {
+                "scope": loop_scope.identifier,
+                "scope_type": loop_scope.scope_type.value,
+                "iterations": len({execution.iteration for execution in executions if execution.iteration is not None}),
+                "warnings": tuple(warnings),
+            }
+            if snapshot is not None:
+                payload["spent"] = snapshot.spent.as_dict()
+                payload["remaining"] = snapshot.remaining.as_dict()
+                payload["overages"] = snapshot.overages.as_dict()
+            self._trace.emit("loop_summary", scope=loop_scope.identifier, payload=payload)
+            self._budgets.exit_scope(loop_scope)
+
+        return RunResult(executions=tuple(executions), warnings=tuple(warnings), stop_reason=stop_reason)
+
+    def _execute_node(
+        self,
+        node: NodePlan,
+        run_scope: ScopeKey,
+        *,
+        loop_scope: ScopeKey | None,
+        iteration: int | None,
+    ) -> tuple[NodeExecution, tuple[str, ...], str | None]:
+        adapter = self._adapters.get(node.tool)
+        if adapter is None:
+            raise KeyError(f"unknown tool adapter '{node.tool}'")
+
+        context = dict(node.parameters)
+        if iteration is not None:
+            context["iteration"] = iteration
+
+        node_scope: ScopeKey | None = None
+        if node.budget is not None:
+            node_scope = ScopeKey(ScopeType.NODE, node.node_id)
+            parent = loop_scope or run_scope
+            self._budgets.enter_scope(node_scope, node.budget, parent=parent)
+
+        policy_snapshot = self._policy.enforce(node.tool, raise_on_violation=True)
+        self._trace.emit(
+            "policy_resolved",
+            scope="stack",
+            payload={"allowed": sorted(policy_snapshot.allowed), "denied": dict(policy_snapshot.denied)},
+        )
+
+        budget_context = BudgetContext(run=run_scope, loop=loop_scope, node=node_scope)
+        estimate = adapter.estimate(node, context)
+        preview = self._budgets.preview(budget_context, estimate, label=f"{node.node_id}:estimate")
+        warnings = list(preview.warnings)
+        stop_reason = self._breach_reason(preview)
+
+        execution_result: ToolExecutionResult | None = None
+        if stop_reason is None:
+            execution_result = adapter.execute(node, context)
+            commit = self._budgets.commit(
+                budget_context,
+                execution_result.cost,
+                label=f"{node.node_id}:execute",
+            )
+            warnings.extend(commit.warnings)
+            stop_reason = self._breach_reason(commit)
+        else:
+            commit = None
+
+        if node_scope is not None:
+            self._budgets.exit_scope(node_scope)
+
+        final_cost = execution_result.cost if execution_result is not None else estimate
+        execution = NodeExecution(
+            node_id=node.node_id,
+            tool=node.tool,
+            cost=final_cost,
+            iteration=iteration,
+            warnings=tuple(warnings),
+            stopped=stop_reason is not None,
+        )
+        return execution, tuple(warnings), stop_reason
+
+    def _breach_reason(self, result: BudgetChargeResult) -> str | None:
+        if not result.should_stop:
+            return None
+        for scope, outcome in result.outcomes.items():
+            if not outcome.breached:
+                continue
+            if outcome.spec.mode is BudgetMode.HARD or outcome.spec.breach_action is BreachAction.STOP:
+                return f"budget_breach:{scope.scope_type.value}"
+        for scope, outcome in result.outcomes.items():
+            if outcome.breached:
+                return f"budget_breach:{scope.scope_type.value}"
+        return "budget_breach"

--- a/codex/code/phase3-budget-runner-71d5/phase3_budget_runner_71d5/trace.py
+++ b/codex/code/phase3-budget-runner-71d5/phase3_budget_runner_71d5/trace.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Callable, Mapping, Sequence
+
+__all__ = ["TraceEvent", "TraceRecorder", "TraceEventEmitter"]
+
+
+@dataclass(frozen=True, slots=True)
+class TraceEvent:
+    event: str
+    scope: str
+    payload: Mapping[str, object]
+
+
+class TraceRecorder:
+    def __init__(self) -> None:
+        self._events: list[TraceEvent] = []
+
+    def record(self, event: TraceEvent) -> None:
+        self._events.append(event)
+
+    @property
+    def events(self) -> Sequence[TraceEvent]:
+        return tuple(self._events)
+
+
+class TraceEventEmitter:
+    """Emit immutable trace events to an optional recorder and sink."""
+
+    def __init__(
+        self,
+        *,
+        recorder: TraceRecorder | None = None,
+        sink: Callable[[TraceEvent], None] | None = None,
+    ) -> None:
+        self._recorder = recorder
+        self._sink = sink
+
+    def emit(
+        self,
+        event: str,
+        *,
+        scope: str,
+        payload: Mapping[str, object] | None = None,
+    ) -> TraceEvent:
+        sanitized = self._sanitize_payload(payload or {})
+        record = TraceEvent(event=event, scope=scope, payload=sanitized)
+        if self._recorder is not None:
+            self._recorder.record(record)
+        if self._sink is not None:
+            self._sink(record)
+        return record
+
+    def policy_sink(self) -> Callable[[object], None]:
+        """Bridge :class:`pkgs.dsl.policy.PolicyStack` events to this emitter."""
+
+        def _sink(policy_event: object) -> None:
+            event_name = getattr(policy_event, "event")
+            scope = getattr(policy_event, "scope")
+            data = getattr(policy_event, "data")
+            if not isinstance(data, Mapping):
+                raise TypeError("policy trace data must be a mapping")
+            self.emit(event_name, scope=scope, payload=data)
+
+        return _sink
+
+    def _sanitize_payload(self, payload: Mapping[str, object]) -> Mapping[str, object]:
+        return MappingProxyType({key: self._freeze(value) for key, value in payload.items()})
+
+    def _freeze(self, value: object) -> object:
+        if isinstance(value, Mapping):
+            return {key: self._freeze(val) for key, val in value.items()}
+        if isinstance(value, (list, tuple)):
+            return tuple(self._freeze(item) for item in value)
+        return value

--- a/codex/code/phase3-budget-runner-71d5/phase3_runner.py
+++ b/codex/code/phase3-budget-runner-71d5/phase3_runner.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+LOG_PATH = ROOT.parent / "POSTEXECUTION" / "P3" / "07b_budget_guards_and_runner_integration.yaml-3d661f4a-0b91-4ab8-b1b1-972c23901e92-runlog.txt"
+
+
+def main() -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    command = ["pytest", str(ROOT / "tests"), "-q"]
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    LOG_PATH.write_text(completed.stdout + "\n" + completed.stderr)
+    completed.check_returncode()
+
+
+if __name__ == "__main__":
+    main()

--- a/codex/code/phase3-budget-runner-71d5/tests/conftest.py
+++ b/codex/code/phase3-budget-runner-71d5/tests/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+TEST_DIR = Path(__file__).resolve().parent
+BRANCH_ROOT = TEST_DIR.parent
+REPO_ROOT = BRANCH_ROOT.parent.parent.parent
+
+for path in (str(REPO_ROOT), str(BRANCH_ROOT)):
+    if path not in sys.path:
+        sys.path.insert(0, path)

--- a/codex/code/phase3-budget-runner-71d5/tests/test_budget_manager.py
+++ b/codex/code/phase3-budget-runner-71d5/tests/test_budget_manager.py
@@ -1,0 +1,87 @@
+import pytest
+
+from phase3_budget_runner_71d5.budgeting import (
+    BreachAction,
+    BudgetContext,
+    BudgetManager,
+    BudgetMode,
+    BudgetSpec,
+    CostSnapshot,
+    ScopeKey,
+    ScopeType,
+)
+from phase3_budget_runner_71d5.trace import TraceEventEmitter, TraceRecorder
+
+
+@pytest.fixture()
+def manager():
+    recorder = TraceRecorder()
+    emitter = TraceEventEmitter(recorder=recorder)
+    mgr = BudgetManager(trace_emitter=emitter)
+    return mgr, recorder
+
+
+def test_hard_budget_triggers_stop_and_emits_breach(manager):
+    mgr, recorder = manager
+    run_scope = ScopeKey(ScopeType.RUN, "run-1")
+    node_scope = ScopeKey(ScopeType.NODE, "node-1")
+
+    mgr.enter_scope(run_scope, BudgetSpec("run", CostSnapshot.from_raw({"tokens": 100})))
+    mgr.enter_scope(
+        node_scope,
+        BudgetSpec("node", CostSnapshot.from_raw({"tokens": 40})),
+        parent=run_scope,
+    )
+
+    ctx = BudgetContext(run=run_scope, node=node_scope)
+    preview = mgr.preview(ctx, CostSnapshot.from_raw({"tokens": 30}), label="estimate")
+    assert preview.should_stop is False
+
+    commit = mgr.commit(ctx, CostSnapshot.from_raw({"tokens": 50}), label="execute")
+    assert commit.should_stop is True
+    node_outcome = commit.outcomes[node_scope]
+    assert pytest.approx(node_outcome.spent.metrics["tokens"], rel=1e-6) == 50
+    assert node_outcome.breached is True
+    assert pytest.approx(node_outcome.overages.metrics["tokens"], rel=1e-6) == 10
+    assert any(evt.event == "budget_breach" for evt in recorder.events)
+
+
+def test_soft_warn_allows_progress_and_tracks_warnings(manager):
+    mgr, recorder = manager
+    run_scope = ScopeKey(ScopeType.RUN, "run-soft")
+    loop_scope = ScopeKey(ScopeType.LOOP, "loop-1")
+
+    mgr.enter_scope(
+        run_scope,
+        BudgetSpec(
+            "run",
+            CostSnapshot.from_raw({"tokens": 200}),
+            mode=BudgetMode.SOFT,
+            breach_action=BreachAction.WARN,
+        ),
+    )
+    mgr.enter_scope(
+        loop_scope,
+        BudgetSpec(
+            "loop",
+            CostSnapshot.from_raw({"tokens": 60}),
+            mode=BudgetMode.SOFT,
+            breach_action=BreachAction.WARN,
+        ),
+        parent=run_scope,
+    )
+
+    ctx = BudgetContext(run=run_scope, loop=loop_scope)
+
+    first_charge = mgr.commit(ctx, CostSnapshot.from_raw({"tokens": 50}), label="iteration-1")
+    assert first_charge.should_stop is False
+    assert not first_charge.outcomes[loop_scope].breached
+
+    second_charge = mgr.commit(ctx, CostSnapshot.from_raw({"tokens": 20}), label="iteration-2")
+    assert second_charge.should_stop is False
+    warnings = second_charge.outcomes[loop_scope].warnings
+    assert any("breached" in warning for warning in warnings)
+
+    breach_events = [evt for evt in recorder.events if evt.event == "budget_breach"]
+    assert len(breach_events) == 1
+    assert breach_events[0].payload["scope_type"] == "loop"

--- a/codex/code/phase3-budget-runner-71d5/tests/test_flow_runner.py
+++ b/codex/code/phase3-budget-runner-71d5/tests/test_flow_runner.py
@@ -1,0 +1,106 @@
+import pytest
+
+from pkgs.dsl.policy import PolicyStack
+
+from phase3_budget_runner_71d5.adapters import ToolAdapter, ToolExecutionResult
+from phase3_budget_runner_71d5.budgeting import (
+    BreachAction,
+    BudgetContext,
+    BudgetManager,
+    BudgetMode,
+    BudgetSpec,
+    CostSnapshot,
+    ScopeKey,
+    ScopeType,
+)
+from phase3_budget_runner_71d5.runner import FlowPlan, FlowRunner, LoopPlan, NodeExecution, NodePlan
+from phase3_budget_runner_71d5.trace import TraceEventEmitter, TraceRecorder
+
+
+class DeterministicAdapter(ToolAdapter):
+    def __init__(self, name: str, cost_sequence: list[float]) -> None:
+        self.name = name
+        self._costs = list(cost_sequence)
+
+    def estimate(self, node: NodePlan, context: dict[str, object] | None = None) -> CostSnapshot:
+        return CostSnapshot.from_raw({"tokens": self._costs[0]})
+
+    def execute(self, node: NodePlan, context: dict[str, object] | None = None) -> ToolExecutionResult:
+        cost_value = self._costs.pop(0)
+        return ToolExecutionResult(result={"ok": True}, cost=CostSnapshot.from_raw({"tokens": cost_value}))
+
+
+@pytest.fixture()
+def runner_setup():
+    recorder = TraceRecorder()
+    emitter = TraceEventEmitter(recorder=recorder)
+    manager = BudgetManager(trace_emitter=emitter)
+    tools = {"echo": {"tags": []}}
+    policy = PolicyStack(tools=tools, event_sink=emitter.policy_sink())
+    policy.push({"allow_tools": ["echo"]}, scope="run")
+    adapters = {"echo": DeterministicAdapter("echo", [30, 70, 30, 30, 30])}
+    runner = FlowRunner(
+        adapters=adapters,
+        policy_stack=policy,
+        budget_manager=manager,
+        trace_emitter=emitter,
+    )
+    return runner, recorder, policy
+
+
+def test_runner_enforces_budget_and_stops_on_run_breach(runner_setup):
+    runner, recorder, policy = runner_setup
+    plan = FlowPlan(
+        flow_id="flow-1",
+        run_budget=BudgetSpec("run", CostSnapshot.from_raw({"tokens": 90})),
+        steps=(
+            NodePlan(node_id="n1", tool="echo", budget=None),
+            NodePlan(node_id="n2", tool="echo", budget=None),
+        ),
+    )
+
+    result = runner.run(plan)
+    assert result.stop_reason == "budget_breach:run"
+    assert len(result.executions) == 2
+    assert result.executions[-1].stopped is True
+
+    breach_events = [evt for evt in recorder.events if evt.event == "budget_breach"]
+    assert breach_events
+    assert any(evt.payload["scope_type"] == "run" for evt in breach_events)
+
+    policy.pop("run")
+
+
+def test_loop_summary_and_soft_warning(runner_setup):
+    runner, recorder, policy = runner_setup
+    plan = FlowPlan(
+        flow_id="flow-soft",
+        run_budget=BudgetSpec("run", CostSnapshot.from_raw({"tokens": 400})),
+        steps=(
+            LoopPlan(
+                loop_id="loop-1",
+                iterations=3,
+                budget=BudgetSpec(
+                    "loop",
+                    CostSnapshot.from_raw({"tokens": 60}),
+                    mode=BudgetMode.SOFT,
+                    breach_action=BreachAction.WARN,
+                ),
+                body=(NodePlan(node_id="loop-node", tool="echo", budget=None),),
+            ),
+        ),
+    )
+
+    result = runner.run(plan)
+    assert result.stop_reason is None
+    assert len(result.executions) == 3
+    assert all(isinstance(execution, NodeExecution) for execution in result.executions)
+    assert any("breached" in warning for warning in result.warnings)
+
+    summaries = [evt for evt in recorder.events if evt.event == "loop_summary"]
+    assert summaries
+    summary_payload = summaries[0].payload
+    assert summary_payload["iterations"] == 3
+    assert summary_payload["warnings"]
+
+    policy.pop("run")

--- a/codex/code/phase3-budget-runner-71d5/tests/test_trace_emitter.py
+++ b/codex/code/phase3-budget-runner-71d5/tests/test_trace_emitter.py
@@ -1,0 +1,45 @@
+from types import MappingProxyType
+
+from phase3_budget_runner_71d5.trace import TraceEventEmitter, TraceRecorder
+
+
+def test_emitter_records_and_forwards_payload():
+    recorder = TraceRecorder()
+    forwarded = []
+
+    def sink(event):
+        forwarded.append(event)
+
+    emitter = TraceEventEmitter(recorder=recorder, sink=sink)
+    payload = {"cost": {"tokens": 10}, "mutable": []}
+    emitter.emit("budget_charge", scope="node-1", payload=payload)
+
+    assert len(recorder.events) == 1
+    event = recorder.events[0]
+    assert isinstance(event.payload, MappingProxyType)
+    assert event.payload["cost"] == {"tokens": 10}
+    assert forwarded[0] is event
+
+    try:
+        event.payload["new"] = 1  # type: ignore[misc]
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("payload must be immutable")
+
+
+def test_policy_sink_adapter_wraps_policy_events():
+    recorder = TraceRecorder()
+    emitter = TraceEventEmitter(recorder=recorder)
+    policy_sink = emitter.policy_sink()
+
+    class DummyPolicyEvent:
+        def __init__(self):
+            self.event = "policy_push"
+            self.scope = "run"
+            self.data = {"policy": {"allow_tools": ("echo",)}}
+
+    policy_sink(DummyPolicyEvent())
+
+    assert recorder.events[0].event == "policy_push"
+    assert recorder.events[0].payload["policy"] == {"allow_tools": ("echo",)}


### PR DESCRIPTION
## Summary
- add immutable budget domain models and manager with preview/commit semantics inside the phase3 sandbox
- implement shared trace emitter and adapter protocol plus a flow runner that enforces policy and loop budgets
- document the phase 3 deliverables and record missing future tests for spec scopes and policy violations

## Testing
- pytest codex/code/phase3-budget-runner-71d5/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8c9292980832ca282c33d5ffc4de2