### PR TITLE
Phase 3: budget manager and FlowRunner sandbox integration

### DIFF
--- a/codex/DOCUMENTATION/P3/phase3-budget-guards-d98ee6c7-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.yaml
+++ b/codex/DOCUMENTATION/P3/phase3-budget-guards-d98ee6c7-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.yaml
@@ -1,0 +1,88 @@
+component:
+  name: phase3-budget-guards-d98ee6c7
+  purpose: Sandbox integration of budget enforcement with FlowRunner and policy tracing.
+  cli_usage: |
+    python codex/code/phase3-budget-guards-d98ee6c7/phase3_runner.py
+  lifecycle:
+    init: Budget specs registered via BudgetManager.enter_scope before FlowRunner.run.
+    runtime: FlowRunner coordinates adapter execution, budget charging, and policy events.
+    shutdown: BudgetManager.exit_scope invoked by callers once execution completes.
+interfaces:
+  budget_models:
+    public_classes:
+      - name: BudgetSpec
+        role: Immutable configuration for per-scope budget limits and breach behaviour.
+      - name: CostSnapshot
+        role: Normalised cost value object with millisecond arithmetic helpers.
+      - name: BudgetDecision
+        role: Outcome of preflight/commit describing remaining budget, overage, and stop semantics.
+    automation_hooks:
+      - BudgetManager.preflight
+      - BudgetManager.commit
+  trace_pipeline:
+    public_classes:
+      - name: TraceEventEmitter
+        role: Emits immutable budget/policy events through a TraceWriter.
+      - name: TraceWriter
+        role: Protocol to integrate with structured logging backends.
+    extension_points:
+      - Consumers may provide custom TraceWriter implementations that persist to JSONL sinks.
+  runner:
+    public_classes:
+      - name: FlowRunner
+        role: Executes FlowNode sequences under budget and policy control.
+      - name: FlowNode
+        role: Node wrapper carrying adapter reference and payload metadata.
+      - name: RunContext
+        role: Execution context containing run identifiers.
+      - name: RunResult
+        role: Aggregated output including completed nodes, warnings, and breach metadata.
+    hooks:
+      - Tool adapters must expose estimate_cost() and actual_cost_snapshot()/actual_ms.
+      - PolicyStack implementations can extend default behaviour to enforce policies prior to execution.
+config:
+  options:
+    - name: BudgetSpec.limit_ms
+      type: float
+      default: null
+      description: Upper bound for spend in milliseconds per scope.
+    - name: BudgetSpec.mode
+      type: enum[hard, soft]
+      default: hard
+      description: Controls whether overages warn or stop by default.
+    - name: BudgetSpec.breach_action
+      type: enum[stop, warn]
+      default: stop
+      description: Final authority on behaviour when limit exceeded.
+automation:
+  triggers:
+    - name: phase3_runner
+      description: Executes pytest with coverage for sandbox code and writes runlog to POSTEXECUTION artifacts.
+      outputs:
+        - codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c-runlog.txt
+error_contracts:
+  budget_breach:
+    description: Hard-stop breaches recorded in RunResult.breaches with action=stop and are emitted via TraceEventEmitter.
+  scope_missing:
+    description: BudgetManager raises KeyError when commit/preflight invoked for unknown scopes.
+serialization:
+  traces:
+    format: immutable mapping proxies emitted to TraceWriter for policy and budget events.
+    schema_fields:
+      - scope_id
+      - remaining_ms
+      - overage_ms
+      - action/breach_action
+      - event (policy events only)
+  results:
+    format: RunResult dataclass serialisable via asdict for downstream processing.
+typing:
+  notes: All public classes are typed using standard typing annotations and rely on literal enums for breach semantics.
+security:
+  considerations:
+    - Trace payloads exclude tool inputs/outputs to avoid leaking sensitive data in logs.
+    - Immutable payloads prevent downstream mutation that could corrupt audit trails.
+performance:
+  characteristics:
+    - CostSnapshot arithmetic is constant time; BudgetManager stores scope state in-memory keyed by (scope_type, scope_id).
+    - FlowRunner performs synchronous adapter execution; concurrency is not introduced in this sandbox.

--- a/codex/TESTS/P3/phase3-budget-guards-d98ee6c7-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.yaml
+++ b/codex/TESTS/P3/phase3-budget-guards-d98ee6c7-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.yaml
@@ -1,0 +1,15 @@
+missing_tests:
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  proposed_tests:
+    - name: test_budget_manager_nested_scope_accounting
+      rationale: Ensure BudgetManager tracks independent remaining/overage values when node and loop scopes are entered alongside run scope.
+      source_module: pkgs/dsl/budget.py
+      priority: high
+    - name: test_flow_runner_policy_violation_interleaving
+      rationale: Validate FlowRunner ordering when PolicyStack raises a violation concurrently with a budget breach.
+      source_module: pkgs/dsl/runner.py
+      priority: medium
+    - name: test_trace_emitter_schema_validation
+      rationale: Add regression that validates emitted payloads against the DSL trace schema to prevent field drift.
+      source_module: pkgs/dsl/trace.py
+      priority: medium

--- a/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.md
+++ b/codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.md
@@ -1,0 +1,14 @@
+# Phase 3 Post-Execution — Task 07b
+
+## Execution Summary
+- Pytest suite for sandbox branch executed successfully (see runlog and coverage output).
+- BudgetManager validated for soft/hard scenarios; FlowRunner integration verified for warn vs stop and policy ordering.
+- TraceEventEmitter confirmed to emit immutable payloads for budget and policy events.
+
+## Coverage & Metrics
+- Coverage collected via `phase3_runner.py` (pytest --cov) targeting `codex/code/phase3-budget-guards-d98ee6c7/pkgs`.
+- Manual run in container: `pytest codex/code/phase3-budget-guards-d98ee6c7/tests -q`.
+
+## Notes & Risks
+- Current implementation exercises run-level budgets; loop/node scope handling should be expanded in future phases.
+- Trace payloads are schema-aligned by contract but formal jsonschema validation remains a follow-up.

--- a/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.md
+++ b/codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.md
@@ -1,0 +1,16 @@
+# Phase 3 Preview — Task 07b Budget Guards and Runner Integration
+
+## Summary
+- Build immutable budget models plus a BudgetManager handling preflight/commit with scope registration.
+- Implement a TraceEventEmitter that emits immutable policy and budget events through a TraceWriter.
+- Retrofit a FlowRunner that orchestrates adapters, budgets, and policy stack interactions with deterministic trace ordering.
+
+## Key Considerations
+- Maintain millisecond-normalised `CostSnapshot` arithmetic to prevent drift between estimate and commit phases.
+- Distinguish soft-warn and hard-stop semantics via `BudgetMode` and `BreachAction` without reintroducing bespoke exception hierarchies.
+- Ensure policy push → resolve → pop ordering is traceable even when budgets halt execution mid-flow.
+
+## Test Strategy
+- Unit tests for `BudgetManager` covering soft/hard breaches and scope lifecycle.
+- Trace emitter tests validating immutable payloads and correct event routing.
+- FlowRunner integration tests simulating adapter execution, warnings, and hard stops while asserting trace emissions.

--- a/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.md
+++ b/codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.md
@@ -1,0 +1,18 @@
+# Phase 3 Review Notes — Task 07b
+
+## Checklist
+- [x] BudgetManager preflight/commit logic covers soft and hard actions with accurate remaining/overage calculations.
+- [x] TraceEventEmitter outputs immutable payloads for budget and policy events via MappingProxyType.
+- [x] FlowRunner coordinates adapters, budgets, and policy stack while respecting stop semantics and trace ordering.
+- [x] Tests added for manager, trace emitter, and runner integration run green under pytest.
+- [x] Optional runner script executes pytest with coverage logging into POSTEXECUTION artifacts.
+
+## Review Findings
+- Budget scopes are registered with explicit specs and guard against duplicate registration.
+- Hard-stop decisions emit breaches and terminate execution without executing subsequent nodes.
+- Soft budgets issue warnings recorded in RunResult without producing breaches.
+- Policy events propagate push → resolved → pop ordering even when execution terminates early.
+
+## Follow-ups
+- Consider extending scope handling to cover nested loop/node budgets beyond the run-level focus exercised here.
+- Future tasks should validate trace payloads against the canonical JSON schema to catch field drift automatically.

--- a/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.yaml
+++ b/codex/agents/TASKS_FINAL/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.yaml
@@ -1,0 +1,78 @@
+summary: Integrate canonical budget manager and trace emitter into a FlowRunner harness staged under codex/code/phase3-budget-guards-d98ee6c7
+justification: |
+  Phase 2 reviews highlighted the need to merge immutable budget models, a preflight/commit BudgetManager, and adapter-driven FlowRunner execution while standardising traces.
+  This plan builds those components in the sandbox branch with tests that capture soft vs hard semantics, policy interplay, and trace immutability before wiring implementation.
+steps:
+  - name: establish_budget_models_and_manager
+    description: Create immutable budget dataclasses and a BudgetManager that handles preflight/commit per scope with deterministic cost normalization.
+  - name: build_trace_emitter
+    description: Implement a TraceEventEmitter using the TraceWriter abstraction to emit schema-aligned immutable payloads for budget and policy events.
+  - name: integrate_runner_with_policies_and_budgets
+    description: Implement a FlowRunner orchestrating adapters, policies, and budgets, ensuring stop semantics, warnings, and trace ordering comply with spec expectations.
+modules:
+  - path: codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/budget.py
+    role: Immutable budget models, normalization helpers, and BudgetManager orchestration.
+  - path: codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/trace.py
+    role: TraceWriter protocol and TraceEventEmitter responsible for budget and policy events.
+  - path: codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/runner.py
+    role: FlowRunner implementation with adapter integration, policy enforcement, and budget charging.
+  - path: codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/policy.py
+    role: Minimal PolicyStack implementation mirroring push/resolve/pop semantics for runner integration tests.
+  - path: codex/code/phase3-budget-guards-d98ee6c7/__init__.py
+    role: Package marker enabling sandbox imports before canonical modules on sys.path.
+  - path: codex/code/phase3-budget-guards-d98ee6c7/pkgs/__init__.py
+    role: Package marker for pkgs namespace in sandbox.
+  - path: codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/__init__.py
+    role: Expose sandbox DSL components for tests.
+  - path: codex/code/phase3-budget-guards-d98ee6c7/phase3_runner.py
+    role: Optional helper to execute pytest and log coverage artifacts.
+
+tests:
+  - path: codex/code/phase3-budget-guards-d98ee6c7/tests/test_budget_manager.py
+    coverage: BudgetManager preflight/commit soft vs hard cases, scope stack entry/exit, remaining/overage calculations.
+    mocks: Fake TraceWriter, deterministic cost snapshots.
+  - path: codex/code/phase3-budget-guards-d98ee6c7/tests/test_trace_emitter.py
+    coverage: TraceEventEmitter ensures immutable payloads and event ordering for policy/budget events.
+    mocks: In-memory TraceWriter recording events.
+  - path: codex/code/phase3-budget-guards-d98ee6c7/tests/test_flow_runner_budget_integration.py
+    coverage: FlowRunner orchestrates adapters, policies, budgets with stop/warn semantics and combined traces.
+    mocks: Fake ToolAdapter implementations, deterministic PolicyStack fixture.
+run_order:
+  - codex/code/phase3-budget-guards-d98ee6c7/tests/test_budget_manager.py
+  - codex/code/phase3-budget-guards-d98ee6c7/tests/test_trace_emitter.py
+  - codex/code/phase3-budget-guards-d98ee6c7/tests/test_flow_runner_budget_integration.py
+interfaces:
+  budget_manager:
+    preflight: (scope_type: str, scope_id: str, estimate: CostSnapshot) -> BudgetDecision
+    commit: (scope_type: str, scope_id: str, actual: CostSnapshot) -> BudgetDecision
+    enter_scope: (scope_type: str, scope_id: str, spec: BudgetSpec) -> None
+    exit_scope: (scope_type: str, scope_id: str) -> None
+  trace_event_emitter:
+    emit_budget_charge: (decision: BudgetDecision) -> None
+    emit_budget_breach: (decision: BudgetDecision) -> None
+    emit_policy_event: (event: str, scope: str, payload: Mapping[str, Any]) -> None
+  flow_runner:
+    run: (flow: Sequence[FlowNode], context: RunContext) -> RunResult
+  policy_stack:
+    push: (node_id: str, metadata: Mapping[str, Any]) -> None
+    resolve: (node_id: str) -> None
+    pop: (node_id: str) -> None
+
+tdd_coverage_targets:
+  budget_manager: 90
+  trace_event_emitter: 85
+  flow_runner: 85
+review_checklist:
+  - Ensure budget and policy traces use immutable payloads.
+  - Validate that soft budgets warn without stopping and hard budgets stop execution.
+  - Confirm FlowRunner integrates adapters without fabricating costs.
+  - Verify cost normalization handles seconds vs milliseconds consistently.
+  - Assert PolicyStack events maintain push → resolve → pop ordering in traces.
+outputs:
+  code_root: codex/code/phase3-budget-guards-d98ee6c7
+  documentation_root: codex/DOCUMENTATION/P3
+  preview: codex/agents/PREVIEW/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.md
+  review: codex/agents/REVIEW/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.md
+  postexecution: codex/agents/POSTEXECUTION/P3/07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.md
+  metadata: codex/DOCUMENTATION/P3/phase3-budget-guards-d98ee6c7-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.yaml
+  missing_tests: codex/TESTS/P3/phase3-budget-guards-d98ee6c7-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c.yaml

--- a/codex/code/phase3-budget-guards-d98ee6c7/phase3_runner.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/phase3_runner.py
@@ -1,0 +1,32 @@
+"""Helper script to execute Phase 3 sandbox tests with coverage."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+TESTS = ROOT / "tests"
+RUNLOG = ROOT.parent / "agents" / "POSTEXECUTION" / "P3" / "07b_budget_guards_and_runner_integration.yaml-47537ede-0ec2-4de1-b9cd-10e0f3c0d68c-runlog.txt"
+
+
+def main() -> None:
+    RUNLOG.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "pytest",
+        str(TESTS),
+        "--maxfail=1",
+        "--disable-warnings",
+        "--cov",
+        "codex/code/phase3-budget-guards-d98ee6c7/pkgs",
+        "--cov-report",
+        "term-missing",
+    ]
+    with RUNLOG.open("w", encoding="utf-8") as handle:
+        process = subprocess.run(cmd, cwd=ROOT.parents[2], stdout=handle, stderr=subprocess.STDOUT, check=False)
+    if process.returncode != 0:
+        raise SystemExit(process.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/codex/code/phase3-budget-guards-d98ee6c7/pkgs/__init__.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/pkgs/__init__.py
@@ -1,0 +1,1 @@
+"""Sandbox pkgs package for phase 3 integration."""

--- a/codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/__init__.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/__init__.py
@@ -1,0 +1,1 @@
+"""Sandbox DSL package for phase 3 budget integration."""

--- a/codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/budget.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/budget.py
@@ -1,0 +1,135 @@
+"""Budget domain models and BudgetManager implementation for Phase 3 sandbox."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional, Tuple
+
+
+class BudgetMode(str, Enum):
+    """Enumeration describing how a budget should be enforced."""
+
+    HARD = "hard"
+    SOFT = "soft"
+
+
+class BreachAction(str, Enum):
+    """Actions to take when a budget is exceeded."""
+
+    STOP = "stop"
+    WARN = "warn"
+
+
+@dataclass(frozen=True)
+class BudgetSpec:
+    """Immutable description of a single budget scope."""
+
+    scope_type: str
+    limit_ms: float
+    mode: BudgetMode = BudgetMode.HARD
+    breach_action: BreachAction = BreachAction.STOP
+
+
+@dataclass(frozen=True)
+class CostSnapshot:
+    """Represents a normalised cost measurement in milliseconds."""
+
+    milliseconds: float
+
+    @classmethod
+    def from_seconds(cls, seconds: float) -> "CostSnapshot":
+        """Create a snapshot from seconds, converting to milliseconds."""
+
+        return cls(milliseconds=seconds * 1000.0)
+
+    def add(self, other: "CostSnapshot") -> "CostSnapshot":
+        return CostSnapshot(milliseconds=self.milliseconds + other.milliseconds)
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    """Outcome from preflight or commit phases."""
+
+    scope_id: str
+    should_stop: bool
+    action: BreachAction
+    remaining_ms: float
+    overage_ms: float
+
+    @property
+    def is_breached(self) -> bool:
+        return self.overage_ms > 0
+
+
+@dataclass
+class _ScopeState:
+    spec: BudgetSpec
+    spent: CostSnapshot
+
+
+class BudgetManager:
+    """Tracks remaining budget per scope and exposes preflight/commit APIs."""
+
+    def __init__(self, specs: Optional[Dict[Tuple[str, str], BudgetSpec]] = None) -> None:
+        self._specs = specs or {}
+        self._scopes: Dict[Tuple[str, str], _ScopeState] = {}
+
+    def _get_spec(self, scope_type: str, scope_id: str, explicit: Optional[BudgetSpec]) -> BudgetSpec:
+        if explicit is not None:
+            return explicit
+        try:
+            return self._specs[(scope_type, scope_id)]
+        except KeyError as exc:
+            raise KeyError(f"No budget spec for scope {(scope_type, scope_id)}") from exc
+
+    def enter_scope(self, scope_type: str, scope_id: str, spec: Optional[BudgetSpec] = None) -> None:
+        """Register a new scope with the provided spec."""
+
+        key = (scope_type, scope_id)
+        if key in self._scopes:
+            raise ValueError(f"Scope {key} already registered")
+        resolved_spec = self._get_spec(scope_type, scope_id, spec)
+        self._scopes[key] = _ScopeState(spec=resolved_spec, spent=CostSnapshot(milliseconds=0.0))
+
+    def exit_scope(self, scope_type: str, scope_id: str) -> None:
+        key = (scope_type, scope_id)
+        try:
+            del self._scopes[key]
+        except KeyError as exc:
+            raise KeyError(f"Scope {key} not registered") from exc
+
+    def _ensure_scope(self, scope_type: str, scope_id: str) -> _ScopeState:
+        try:
+            return self._scopes[(scope_type, scope_id)]
+        except KeyError as exc:
+            raise KeyError(f"Scope {(scope_type, scope_id)} not registered") from exc
+
+    def _make_decision(self, scope_id: str, spec: BudgetSpec, projected: float) -> BudgetDecision:
+        overage = max(projected - spec.limit_ms, 0.0)
+        remaining = max(spec.limit_ms - projected, 0.0)
+        if overage > 0:
+            action = spec.breach_action
+            should_stop = action == BreachAction.STOP
+        else:
+            action = BreachAction.WARN if spec.mode == BudgetMode.SOFT else BreachAction.STOP
+            should_stop = False
+        return BudgetDecision(
+            scope_id=scope_id,
+            should_stop=should_stop,
+            action=action,
+            remaining_ms=remaining,
+            overage_ms=overage,
+        )
+
+    def preflight(self, scope_type: str, scope_id: str, estimate: CostSnapshot) -> BudgetDecision:
+        state = self._ensure_scope(scope_type, scope_id)
+        projected = state.spent.milliseconds + estimate.milliseconds
+        return self._make_decision(scope_id, state.spec, projected)
+
+    def commit(self, scope_type: str, scope_id: str, actual: CostSnapshot) -> BudgetDecision:
+        state = self._ensure_scope(scope_type, scope_id)
+        new_spent = state.spent.add(actual)
+        state.spent = new_spent  # type: ignore[misc]
+        projected = new_spent.milliseconds
+        return self._make_decision(scope_id, state.spec, projected)

--- a/codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/policy.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/policy.py
@@ -1,0 +1,26 @@
+"""Minimal PolicyStack implementation for sandbox runner tests."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+
+class PolicyStack:
+    """Maintain a simple stack of node policies."""
+
+    def __init__(self) -> None:
+        self._stack: List[Tuple[str, Dict[str, Any]]] = []
+
+    def push(self, node_id: str, metadata: Dict[str, Any]) -> None:
+        self._stack.append((node_id, dict(metadata)))
+
+    def resolve(self, node_id: str) -> None:
+        if not self._stack or self._stack[-1][0] != node_id:
+            raise ValueError(f"Policy resolve order mismatch for {node_id}")
+
+    def pop(self, node_id: str) -> None:
+        if not self._stack:
+            raise ValueError("Policy stack empty")
+        top_id, _ = self._stack.pop()
+        if top_id != node_id:
+            raise ValueError(f"Policy pop order mismatch: expected {top_id}, got {node_id}")

--- a/codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/runner.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/runner.py
@@ -1,0 +1,106 @@
+"""FlowRunner integrating budgets, policies, and adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Mapping, Sequence
+
+from .budget import BreachAction, BudgetDecision, BudgetManager, CostSnapshot
+from .policy import PolicyStack
+from .trace import TraceEventEmitter
+
+
+@dataclass
+class FlowNode:
+    node_id: str
+    adapter: Any
+    input_payload: Mapping[str, Any]
+
+
+@dataclass
+class RunContext:
+    run_id: str
+
+
+@dataclass
+class RunResult:
+    completed_nodes: List[str]
+    warnings: List[str]
+    breaches: List[Mapping[str, Any]]
+
+
+class FlowRunner:
+    """Execute nodes while enforcing budgets and emitting traces."""
+
+    def __init__(self, budget_manager: BudgetManager, trace_emitter: TraceEventEmitter, policy_stack: PolicyStack) -> None:
+        self._budget_manager = budget_manager
+        self._trace = trace_emitter
+        self._policy_stack = policy_stack
+
+    def run(self, flow: Sequence[FlowNode], context: RunContext) -> RunResult:
+        completed: List[str] = []
+        warnings: List[str] = []
+        breaches: List[Mapping[str, Any]] = []
+
+        for node in flow:
+            adapter_name = getattr(node.adapter, "name", node.adapter.__class__.__name__)
+            policy_payload = {"adapter": adapter_name}
+            self._policy_stack.push(node.node_id, policy_payload)
+            self._trace.emit_policy_event("policy_push", node.node_id, policy_payload)
+
+            estimate = node.adapter.estimate_cost(context, node)
+            preflight = self._budget_manager.preflight("run", context.run_id, estimate)
+            if preflight.should_stop:
+                breaches.append(self._decision_payload(preflight, phase="preflight"))
+                self._trace.emit_budget_breach(preflight)
+                self._policy_stack.resolve(node.node_id)
+                self._trace.emit_policy_event("policy_resolved", node.node_id, {"phase": "preflight"})
+                self._policy_stack.pop(node.node_id)
+                self._trace.emit_policy_event("policy_pop", node.node_id, {"phase": "preflight"})
+                break
+
+            node.adapter.execute(context, node)
+            actual_snapshot = self._resolve_actual_cost(node.adapter, estimate)
+            decision = self._budget_manager.commit("run", context.run_id, actual_snapshot)
+            self._trace.emit_budget_charge(decision)
+
+            if decision.is_breached and decision.action == BreachAction.WARN:
+                warnings.append(self._format_warning(context.run_id, decision, phase="commit"))
+            if decision.should_stop:
+                breaches.append(self._decision_payload(decision, phase="commit"))
+                self._trace.emit_budget_breach(decision)
+
+            completed.append(node.node_id)
+            self._policy_stack.resolve(node.node_id)
+            self._trace.emit_policy_event("policy_resolved", node.node_id, {"phase": "commit"})
+            self._policy_stack.pop(node.node_id)
+            self._trace.emit_policy_event("policy_pop", node.node_id, {"phase": "commit"})
+
+            if decision.should_stop:
+                break
+
+        return RunResult(completed_nodes=completed, warnings=warnings, breaches=breaches)
+
+    def _resolve_actual_cost(self, adapter: Any, estimate: CostSnapshot) -> CostSnapshot:
+        actual_fn = getattr(adapter, "actual_cost_snapshot", None)
+        if callable(actual_fn):
+            return actual_fn()
+        actual_ms = getattr(adapter, "actual_ms", None)
+        if actual_ms is not None:
+            return CostSnapshot(milliseconds=float(actual_ms))
+        return estimate
+
+    def _format_warning(self, scope_id: str, decision: BudgetDecision, phase: str) -> str:
+        return (
+            f"Budget warn {scope_id}:{phase} overage={decision.overage_ms:.1f}ms "
+            f"remaining={decision.remaining_ms:.1f}ms"
+        )
+
+    def _decision_payload(self, decision: BudgetDecision, phase: str) -> Mapping[str, Any]:
+        return {
+            "scope_id": decision.scope_id,
+            "phase": phase,
+            "action": decision.action.value,
+            "overage_ms": decision.overage_ms,
+            "remaining_ms": decision.remaining_ms,
+        }

--- a/codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/trace.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/trace.py
@@ -1,0 +1,53 @@
+"""Trace utilities for the Phase 3 sandbox implementation."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any, Mapping, Protocol
+
+from .budget import BudgetDecision
+
+
+class TraceWriter(Protocol):
+    """Protocol for writing trace events."""
+
+    def write(self, event: str, payload: Mapping[str, Any]) -> None:
+        ...
+
+
+def _immutable(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType(dict(payload))
+
+
+class TraceEventEmitter:
+    """Emit immutable trace payloads through a TraceWriter."""
+
+    def __init__(self, writer: TraceWriter) -> None:
+        self._writer = writer
+
+    def emit(self, event: str, payload: Mapping[str, Any]) -> None:
+        self._writer.write(event, _immutable(payload))
+
+    def emit_budget_charge(self, decision: BudgetDecision) -> None:
+        payload = {
+            "scope_id": decision.scope_id,
+            "remaining_ms": decision.remaining_ms,
+            "overage_ms": decision.overage_ms,
+            "action": decision.action.value,
+            "should_stop": decision.should_stop,
+        }
+        self.emit("budget_charge", payload)
+
+    def emit_budget_breach(self, decision: BudgetDecision) -> None:
+        payload = {
+            "scope_id": decision.scope_id,
+            "remaining_ms": decision.remaining_ms,
+            "overage_ms": decision.overage_ms,
+            "breach_action": decision.action.value,
+            "should_stop": decision.should_stop,
+        }
+        self.emit("budget_breach", payload)
+
+    def emit_policy_event(self, event: str, scope: str, payload: Mapping[str, Any]) -> None:
+        enriched = {"scope": scope, "event": event, **payload}
+        self.emit(event, enriched)

--- a/codex/code/phase3-budget-guards-d98ee6c7/tests/conftest.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/tests/conftest.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BRANCH_ROOT = Path(__file__).resolve().parents[1]
+if str(BRANCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(BRANCH_ROOT))
+
+
+@pytest.fixture()
+def trace_collector():
+    events = []
+
+    class Collector:
+        def write(self, event: str, payload):
+            events.append((event, payload))
+
+    return Collector(), events

--- a/codex/code/phase3-budget-guards-d98ee6c7/tests/test_budget_manager.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/tests/test_budget_manager.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from pkgs.dsl.budget import (
+    BreachAction,
+    BudgetDecision,
+    BudgetManager,
+    BudgetMode,
+    BudgetSpec,
+    CostSnapshot,
+)
+
+
+@pytest.fixture()
+def manager():
+    return BudgetManager()
+
+
+def enter_default_scope(manager: BudgetManager, scope_id: str = "run-1", limit: int = 100) -> None:
+    manager.enter_scope(
+        scope_type="run",
+        scope_id=scope_id,
+        spec=BudgetSpec(scope_type="run", limit_ms=limit, mode=BudgetMode.HARD, breach_action=BreachAction.STOP),
+    )
+
+
+def test_preflight_and_commit_within_limit(manager: BudgetManager) -> None:
+    enter_default_scope(manager)
+    decision = manager.preflight("run", "run-1", CostSnapshot(milliseconds=20))
+    assert isinstance(decision, BudgetDecision)
+    assert decision.should_stop is False
+    assert decision.remaining_ms == pytest.approx(80)
+    commit_decision = manager.commit("run", "run-1", CostSnapshot(milliseconds=30))
+    assert commit_decision.should_stop is False
+    assert commit_decision.remaining_ms == pytest.approx(70)
+    assert commit_decision.overage_ms == pytest.approx(0)
+
+
+def test_soft_budget_warns_but_continues(manager: BudgetManager) -> None:
+    manager.enter_scope(
+        scope_type="run",
+        scope_id="run-soft",
+        spec=BudgetSpec(scope_type="run", limit_ms=50, mode=BudgetMode.SOFT, breach_action=BreachAction.WARN),
+    )
+    preview = manager.preflight("run", "run-soft", CostSnapshot.from_seconds(0.04))
+    assert preview.should_stop is False
+    assert preview.action == BreachAction.WARN
+    commit = manager.commit("run", "run-soft", CostSnapshot(milliseconds=60))
+    assert commit.should_stop is False
+    assert commit.action == BreachAction.WARN
+    assert commit.overage_ms == pytest.approx(10)
+
+
+def test_hard_budget_stops_on_overage(manager: BudgetManager) -> None:
+    enter_default_scope(manager, scope_id="run-hard", limit=30)
+    pre = manager.preflight("run", "run-hard", CostSnapshot(milliseconds=25))
+    assert pre.should_stop is False
+    commit = manager.commit("run", "run-hard", CostSnapshot(milliseconds=40))
+    assert commit.should_stop is True
+    assert commit.action == BreachAction.STOP
+    assert commit.overage_ms == pytest.approx(10)
+
+
+def test_exit_scope_removes_state(manager: BudgetManager) -> None:
+    enter_default_scope(manager, scope_id="temp")
+    manager.exit_scope("run", "temp")
+    with pytest.raises(KeyError):
+        manager.commit("run", "temp", CostSnapshot(milliseconds=1))

--- a/codex/code/phase3-budget-guards-d98ee6c7/tests/test_flow_runner_budget_integration.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/tests/test_flow_runner_budget_integration.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import pytest
+
+from pkgs.dsl.budget import (
+    BreachAction,
+    BudgetManager,
+    BudgetMode,
+    BudgetSpec,
+    CostSnapshot,
+)
+from pkgs.dsl.policy import PolicyStack
+from pkgs.dsl.runner import FlowNode, FlowRunner, RunContext
+from pkgs.dsl.trace import TraceEventEmitter
+
+
+@dataclass
+class FakeAdapter:
+    estimate_ms: float
+    actual_ms: float
+    output: Any = None
+
+    def estimate_cost(self, context: RunContext, node: FlowNode) -> CostSnapshot:
+        return CostSnapshot(milliseconds=self.estimate_ms)
+
+    def execute(self, context: RunContext, node: FlowNode) -> Any:
+        return self.output or {"node": node.node_id, "result": "ok"}
+
+    def actual_cost_snapshot(self) -> CostSnapshot:
+        return CostSnapshot(milliseconds=self.actual_ms)
+
+
+class RecordingPolicyStack(PolicyStack):
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+
+    def push(self, node_id: str, metadata: Dict[str, Any]) -> None:  # type: ignore[override]
+        self.calls.append(f"push:{node_id}")
+
+    def resolve(self, node_id: str) -> None:  # type: ignore[override]
+        self.calls.append(f"resolve:{node_id}")
+
+    def pop(self, node_id: str) -> None:  # type: ignore[override]
+        self.calls.append(f"pop:{node_id}")
+
+
+@pytest.fixture()
+def runner(trace_collector):
+    writer, events = trace_collector
+    manager = BudgetManager()
+    policy = RecordingPolicyStack()
+    emitter = TraceEventEmitter(writer)
+    return runner_factory(manager, policy, emitter), manager, policy, events
+
+
+def runner_factory(manager: BudgetManager, policy: PolicyStack, emitter: TraceEventEmitter) -> FlowRunner:
+    return FlowRunner(budget_manager=manager, trace_emitter=emitter, policy_stack=policy)
+
+
+def test_soft_warn_allows_completion(runner) -> None:
+    flow_runner, manager, policy, events = runner
+    run_id = "run-soft"
+    manager.enter_scope(
+        scope_type="run",
+        scope_id=run_id,
+        spec=BudgetSpec(scope_type="run", limit_ms=100, mode=BudgetMode.SOFT, breach_action=BreachAction.WARN),
+    )
+    context = RunContext(run_id=run_id)
+    flow = [
+        FlowNode("node-1", FakeAdapter(estimate_ms=40, actual_ms=40), {}),
+        FlowNode("node-2", FakeAdapter(estimate_ms=70, actual_ms=65), {}),
+    ]
+
+    result = flow_runner.run(flow, context)
+
+    assert result.completed_nodes == ["node-1", "node-2"]
+    assert result.breaches == []
+    assert len(result.warnings) == 1
+    assert "run-soft" in result.warnings[0]
+    assert any(event == "budget_charge" for event, _ in events)
+
+
+def test_hard_breach_stops_execution(runner) -> None:
+    flow_runner, manager, policy, events = runner
+    run_id = "run-hard"
+    manager.enter_scope(
+        "run",
+        run_id,
+        BudgetSpec(scope_type="run", limit_ms=60, mode=BudgetMode.HARD, breach_action=BreachAction.STOP),
+    )
+    context = RunContext(run_id=run_id)
+    flow = [
+        FlowNode("node-1", FakeAdapter(estimate_ms=30, actual_ms=30), {}),
+        FlowNode("node-2", FakeAdapter(estimate_ms=40, actual_ms=50), {}),
+    ]
+
+    result = flow_runner.run(flow, context)
+
+    assert result.completed_nodes == ["node-1"]
+    assert result.breaches != []
+    assert result.breaches[0]["scope_id"] == run_id
+    assert any(event == "budget_breach" for event, _ in events)
+
+
+def test_policy_stack_invocation_order(runner) -> None:
+    flow_runner, manager, policy, events = runner
+    run_id = "run-policy"
+    manager.enter_scope(
+        "run",
+        run_id,
+        BudgetSpec(scope_type="run", limit_ms=500, mode=BudgetMode.HARD, breach_action=BreachAction.WARN),
+    )
+    context = RunContext(run_id=run_id)
+    flow = [FlowNode("node-1", FakeAdapter(estimate_ms=10, actual_ms=10), {})]
+
+    flow_runner.run(flow, context)
+
+    assert policy.calls == ["push:node-1", "resolve:node-1", "pop:node-1"]
+    node_events = [payload for event, payload in events if event.startswith("policy_")]
+    assert node_events[0]["scope"] == "node-1"
+    assert node_events[0]["event"] == "policy_push"

--- a/codex/code/phase3-budget-guards-d98ee6c7/tests/test_trace_emitter.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/tests/test_trace_emitter.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from pkgs.dsl.budget import BreachAction, BudgetDecision
+from pkgs.dsl.trace import TraceEventEmitter
+
+
+def make_decision(scope_id: str = "run-1", overage: float = 0.0, remaining: float = 50.0, action: BreachAction = BreachAction.WARN):
+    return BudgetDecision(
+        scope_id=scope_id,
+        should_stop=action == BreachAction.STOP,
+        action=action,
+        remaining_ms=remaining,
+        overage_ms=overage,
+    )
+
+
+def test_budget_charge_payload_is_immutable(trace_collector) -> None:
+    writer, events = trace_collector
+    emitter = TraceEventEmitter(writer)
+    emitter.emit_budget_charge(make_decision(overage=5.0, remaining=45.0))
+    assert events[0][0] == "budget_charge"
+    payload = events[0][1]
+    assert isinstance(payload, MappingProxyType)
+    assert payload["scope_id"] == "run-1"
+    assert payload["overage_ms"] == 5.0
+    with pytest.raises(TypeError):
+        payload["overage_ms"] = 10
+
+
+def test_budget_breach_marks_breach_event(trace_collector) -> None:
+    writer, events = trace_collector
+    emitter = TraceEventEmitter(writer)
+    emitter.emit_budget_breach(make_decision(scope_id="node-1", overage=12.0, remaining=-2.0, action=BreachAction.STOP))
+    assert events[0][0] == "budget_breach"
+    payload = events[0][1]
+    assert payload["scope_id"] == "node-1"
+    assert payload["breach_action"] == "stop"
+    assert payload["overage_ms"] == 12.0
+
+
+def test_policy_events_passthrough_payload(trace_collector) -> None:
+    writer, events = trace_collector
+    emitter = TraceEventEmitter(writer)
+    emitter.emit_policy_event("policy_push", scope="node-2", payload={"policy": "allow"})
+    assert events[0][0] == "policy_push"
+    payload = events[0][1]
+    assert isinstance(payload, MappingProxyType)
+    assert payload["scope"] == "node-2"
+    assert payload["policy"] == "allow"
+


### PR DESCRIPTION
## Summary
- add immutable budget models with a BudgetManager coordinating preflight/commit lifecycle in the sandbox branch
- implement TraceEventEmitter and PolicyStack plumbing to emit immutable policy and budget events
- wire FlowRunner to adapters, budgets, and policies plus provide pytest/coverage runner alongside documentation artifacts

## Testing
- pytest codex/code/phase3-budget-guards-d98ee6c7/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e8c9292980832ca282c33d5ffc4de2