### PR TITLE
Add Phase 4 evaluation artifacts for budget runner task

### DIFF
--- a/codex/DOCUMENTATION/P4/07b_budget_guards_and_runner_integration.yaml-006584c3-01d5-4132-8dd0-12fa533c4053
+++ b/codex/DOCUMENTATION/P4/07b_budget_guards_and_runner_integration.yaml-006584c3-01d5-4132-8dd0-12fa533c4053
@@ -1,0 +1,303 @@
+developer_doc_metadata:
+  code_task: 07b_budget_guards_and_runner_integration.yaml
+  components_documented:
+    - name: BudgetManager
+      description: "Coordinates scope-aware budget previews, commits, and breach telemetry."
+      source_file: codex/code/work/dsl/budget_manager.py
+
+      cli_usage:
+        exposed: false
+        commands: []
+        entry_point: null
+
+      public_interface:
+        methods:
+          - name: enter_scope
+            signature: "def enter_scope(self, scope: ScopeKey) -> None"
+            purpose: "Activate a scope with zeroed spend tracking before running nodes."
+          - name: preview_charge
+            signature: "def preview_charge(self, scope: ScopeKey, cost: CostSnapshot) -> BudgetDecision"
+            purpose: "Compute decision outcomes without mutating spend totals."
+          - name: commit_charge
+            signature: "def commit_charge(self, decision: BudgetDecision) -> None"
+            purpose: "Persist spend and emit charge traces when decision is non-blocking."
+          - name: record_breach
+            signature: "def record_breach(self, decision: BudgetDecision) -> None"
+            purpose: "Emit breach events for any outcome that exceeded its limits."
+          - name: spent
+            signature: "def spent(self, scope: ScopeKey, spec_name: str) -> CostSnapshot"
+            purpose: "Return accumulated spend for inspection and assertions."
+        classes:
+          - name: BudgetManager
+            base_classes: [object]
+            purpose: "Stateful coordinator that owns per-scope spend maps and trace emitter."
+
+      inheritance:
+        base_classes: []
+        implements_interfaces: []
+
+      lifecycle:
+        methods:
+          - name: __init__
+            stage: init
+            description: "Index budget specs by scope and prepare trace emitter."
+          - name: enter_scope
+            stage: pre-exec
+            description: "Create spend ledger for a scope before execution."
+          - name: commit_charge
+            stage: post-exec
+            description: "Persist new totals and emit traces after adapter execution."
+
+      extension_points:
+        - hook: trace
+          type: DI injection
+          usage: "Supply custom TraceEventEmitter when richer sinks are needed."
+          location: codex/code/work/dsl/budget_manager.py
+
+      configuration:
+        config_file: null
+        options: []
+
+      automation_support:
+        triggers: []
+        environment_variables: []
+        ci_tasks: []
+
+      error_contracts:
+        expected_exceptions:
+          - name: BudgetBreachError
+            raised_by: commit_charge
+            when: "A blocking outcome is encountered during commit."
+            recoverable: false
+
+      serialization:
+        format: json
+        serializer_class: null
+        fields_serialized: ["spec_name", "cost", "remaining", "overage"]
+        persistence_target: trace sinks
+
+      typing_constraints:
+        strict_mode: true
+        annotations:
+          - name: commit_charge
+            signature: "(BudgetDecision) -> None"
+
+      runtime_dependencies:
+        environment:
+          required_vars: []
+          required_tools: []
+          required_python_packages: []
+        services: []
+
+      security_notes:
+        permissions_required: []
+        sandbox_safe: true
+        sensitive_data_handled: false
+
+      deprecated_elements: []
+
+      performance_notes:
+        resource_impact:
+          cpu_ms: 0.5
+          memory_mb: 1.0
+          network_calls: 0
+        optimization_tips:
+          - "Reuse CostSnapshot instances when possible to limit allocations."
+
+    - name: FlowRunner
+      description: "Executes flow nodes with policy enforcement, loop control, and budget checks."
+      source_file: codex/code/work/dsl/flow_runner.py
+
+      cli_usage:
+        exposed: false
+        commands: []
+        entry_point: null
+
+      public_interface:
+        methods:
+          - name: run
+            signature: "def run(self, *, flow_id: str, run_id: str, nodes: Iterable[Mapping[str, object]]) -> list[NodeExecution]"
+            purpose: "Iterate over nodes, applying budgets and policies before executing adapters."
+        classes:
+          - name: FlowRunner
+            base_classes: [object]
+            purpose: "Coordinator owning adapters, budgets, policy stack, and trace emitter."
+          - name: NodeExecution
+            base_classes: [object]
+            purpose: "Immutable record capturing adapter results and loop metadata."
+
+      inheritance:
+        base_classes: []
+        implements_interfaces: [ToolAdapter]
+
+      lifecycle:
+        methods:
+          - name: run
+            stage: exec
+            description: "Creates run scope, iterates nodes, and emits lifecycle traces."
+          - name: _run_loop
+            stage: exec
+            description: "Handles loop bodies, enforcing loop budgets and stop reasons."
+          - name: _run_unit_node
+            stage: exec
+            description: "Executes a single node with scoped budgets and policy enforcement."
+
+      extension_points:
+        - hook: ToolAdapter
+          type: protocol
+          usage: "Adapters implement estimate_cost/execute to participate in the runner."
+        - hook: PolicyStack
+          type: DI injection
+          usage: "Inject custom policy behaviour or telemetry sinks."
+
+      configuration:
+        config_file: null
+        options: []
+
+      automation_support:
+        triggers: []
+        environment_variables: []
+        ci_tasks: []
+
+      error_contracts:
+        expected_exceptions:
+          - name: BudgetBreachError
+            raised_by: run
+            when: "A blocking budget is encountered during execution."
+            recoverable: false
+          - name: PolicyViolationError
+            raised_by: run
+            when: "PolicyStack denies a tool."
+            recoverable: false
+
+      serialization:
+        format: json
+        serializer_class: null
+        fields_serialized: ["event", "scope_type", "scope_id", "payload"]
+        persistence_target: trace sinks
+
+      typing_constraints:
+        strict_mode: true
+        annotations:
+          - name: run
+            signature: "(*, flow_id: str, run_id: str, nodes: Iterable[Mapping[str, object]]) -> list[NodeExecution]"
+
+      runtime_dependencies:
+        environment:
+          required_vars: []
+          required_tools: []
+          required_python_packages: []
+        services: []
+
+      security_notes:
+        permissions_required: []
+        sandbox_safe: true
+        sensitive_data_handled: false
+
+      deprecated_elements: []
+
+      performance_notes:
+        resource_impact:
+          cpu_ms: 5.0
+          memory_mb: 5.0
+          network_calls: 0
+        optimization_tips:
+          - "Reuse adapter instances to avoid repeated setup per iteration."
+
+    - name: TraceEventEmitter
+      description: "In-memory trace emitter with optional sink and validator hooks."
+      source_file: codex/code/work/dsl/trace.py
+
+      cli_usage:
+        exposed: false
+        commands: []
+        entry_point: null
+
+      public_interface:
+        methods:
+          - name: attach_sink
+            signature: "def attach_sink(self, sink: Callable[[TraceEvent], None] | None) -> None"
+            purpose: "Register an observer to receive emitted events."
+          - name: attach_validator
+            signature: "def attach_validator(self, validator: Callable[[TraceEvent], None] | None) -> None"
+            purpose: "Register a guard executed before events are stored."
+          - name: emit
+            signature: "def emit(self, event: str, *, scope_type: str, scope_id: str, payload: Mapping[str, Any] | None = None) -> TraceEvent"
+            purpose: "Create immutable trace records and forward to sink/validator."
+          - name: events
+            signature: "@property def events(self) -> tuple[TraceEvent, ...]"
+            purpose: "Expose accumulated trace records for assertions."
+          - name: clear
+            signature: "def clear(self) -> None"
+            purpose: "Reset captured events during tests."
+        classes:
+          - name: TraceEvent
+            base_classes: [object]
+            purpose: "Frozen data class capturing event metadata."
+
+      inheritance:
+        base_classes: []
+        implements_interfaces: []
+
+      lifecycle:
+        methods:
+          - name: __init__
+            stage: init
+            description: "Prepare event buffer and optional hooks."
+          - name: emit
+            stage: exec
+            description: "Freeze payloads, invoke validator, persist, and forward to sink."
+
+      extension_points:
+        - hook: sink
+          type: DI injection
+          usage: "Attach structured logging or OTEL exporters downstream."
+        - hook: validator
+          type: DI injection
+          usage: "Enforce schema checks per event before storage."
+
+      configuration:
+        config_file: null
+        options: []
+
+      automation_support:
+        triggers: []
+        environment_variables: []
+        ci_tasks: []
+
+      error_contracts:
+        expected_exceptions: []
+
+      serialization:
+        format: json
+        serializer_class: null
+        fields_serialized: ["event", "scope_type", "scope_id", "payload"]
+        persistence_target: in-memory buffer or downstream sink
+
+      typing_constraints:
+        strict_mode: true
+        annotations:
+          - name: emit
+            signature: "(str, *, scope_type: str, scope_id: str, payload: Mapping[str, Any] | None) -> TraceEvent"
+
+      runtime_dependencies:
+        environment:
+          required_vars: []
+          required_tools: []
+          required_python_packages: []
+        services: []
+
+      security_notes:
+        permissions_required: []
+        sandbox_safe: true
+        sensitive_data_handled: false
+
+      deprecated_elements: []
+
+      performance_notes:
+        resource_impact:
+          cpu_ms: 0.3
+          memory_mb: 1.0
+          network_calls: 0
+        optimization_tips:
+          - "Reuse validators to avoid per-event allocations."

--- a/codex/POSTEXECUTION/P4/07b_budget_guards_and_runner_integration.yaml-006584c3-01d5-4132-8dd0-12fa533c4053
+++ b/codex/POSTEXECUTION/P4/07b_budget_guards_and_runner_integration.yaml-006584c3-01d5-4132-8dd0-12fa533c4053
@@ -1,0 +1,107 @@
+postexecution:
+  phase: P4
+  task_id: 07b_budget_guards_and_runner_integration.yaml
+  branches_reviewed:
+    - codex/complete-phase-3-for-tdd-feature-54y5b9
+    - codex/complete-phase-3-for-tdd-feature-rd6egz
+    - codex/complete-phase-3-for-tdd-feature-7i9h5x
+    - codex/implement-phase-3-using-tdd-for-feature
+    - codex/implement-phase-3-using-tdd-for-feature-lypjv9
+    - codex/implement-phase-3-using-tdd-for-feature-ije1jy
+    - codex/implement-phase-3-using-tdd-for-feature-nxygro
+    - codex/implement-phase-3-using-tdd-for-feature-bk4a29
+  winning_branch: codex/complete-phase-3-for-tdd-feature-rd6egz
+  source_repo: pfahlr/
+  reviewers_notes:
+    - Loop-aware FlowRunner plus immutable budget domain from rd6egz delivered the cleanest, production-ready surface.
+  time_to_review_minutes: 90
+  ci_outcomes_summary:
+    - branch: codex/complete-phase-3-for-tdd-feature-rd6egz
+      green: true
+      last_commit_sha: c2b4526d1db5a05102073f27607455ef83e057db
+    - branch: codex/complete-phase-3-for-tdd-feature-7i9h5x
+      green: false
+      last_commit_sha: 59a1638eaaf53e0dce7c48a6877d11b253a08817
+    - branch: codex/complete-phase-3-for-tdd-feature-54y5b9
+      green: false
+      last_commit_sha: 43fc4a50674e9a5f8e6ae624592fb0d5df6aff76
+    - branch: codex/implement-phase-3-using-tdd-for-feature
+      green: false
+      last_commit_sha: b9d7848870a1b8593127d24058a2a7783cf45b8a
+    - branch: codex/implement-phase-3-using-tdd-for-feature-lypjv9
+      green: false
+      last_commit_sha: d4bf37084eb3c33b1fe59e12abc575d179bc0f67
+    - branch: codex/implement-phase-3-using-tdd-for-feature-ije1jy
+      green: false
+      last_commit_sha: adf3a61b600c7f1da4647b91965b0a121342922f
+    - branch: codex/implement-phase-3-using-tdd-for-feature-nxygro
+      green: false
+      last_commit_sha: da5553f0e6cd2add16651452e66dc7e48d82fb71
+    - branch: codex/implement-phase-3-using-tdd-for-feature-bk4a29
+      green: false
+      last_commit_sha: 655a0d8402af46b01ba9fe98e1449e5976b23471
+  reusable_modules:
+    - name: TraceWriter+Emitter abstraction
+      source_branch: codex/implement-phase-3-using-tdd-for-feature-lypjv9
+      from_file: codex/code/phase3-budget-runner-4f72/dsl/trace.py
+      why_reusable: Provides injectable sinks and deep-freezing payload helper for downstream observability hooks.
+      where_to_reuse: dsl trace pipeline
+      linked_extended_task: trace_writer_sink_injection
+  test_coverage_summary:
+    - branch: codex/complete-phase-3-for-tdd-feature-rd6egz
+      new_tests: 5
+      missing_tests: []
+      regression_tests_added: true
+      coverage_notes: Loop, policy violation, and trace validation scenarios are exercised alongside budget manager cases.
+    - branch: codex/complete-phase-3-for-tdd-feature-7i9h5x
+      new_tests: 5
+      missing_tests: []
+      regression_tests_added: true
+      coverage_notes: Mirrors rd6egz suite without additional assertions.
+    - branch: codex/implement-phase-3-using-tdd-for-feature
+      new_tests: 5
+      missing_tests: []
+      regression_tests_added: true
+      coverage_notes: Adds same integration coverage but retains redundant legacy fixtures.
+    - branch: codex/implement-phase-3-using-tdd-for-feature-lypjv9
+      new_tests: 8
+      missing_tests: []
+      regression_tests_added: true
+      coverage_notes: Extends suite with TraceWriter specific cases while duplicating existing flow tests.
+    - branch: codex/implement-phase-3-using-tdd-for-feature-ije1jy
+      new_tests: 8
+      missing_tests: []
+      regression_tests_added: true
+      coverage_notes: Similar to lypjv9, covering recorder adapter paths.
+    - branch: codex/implement-phase-3-using-tdd-for-feature-nxygro
+      new_tests: 5
+      missing_tests: []
+      regression_tests_added: true
+      coverage_notes: Focuses on pkgs/dsl relocation but no new behaviours.
+    - branch: codex/implement-phase-3-using-tdd-for-feature-bk4a29
+      new_tests: 5
+      missing_tests: []
+      regression_tests_added: true
+      coverage_notes: Exercises pkgs/dsl runner yet diverges from canonical API.
+    - branch: codex/complete-phase-3-for-tdd-feature-54y5b9
+      new_tests: 3
+      missing_tests: []
+      regression_tests_added: true
+      coverage_notes: Stops at run/node scopes with no loop scenarios.
+  design_rationales:
+    - feature: Loop-aware FlowRunner budgeting
+      principle: single responsibility
+      summary: Separate helpers manage run, loop, and node scopes so FlowRunner coordinates policy + budget decisions without mutating shared state.
+      risk_if_excluded: Loops would leak charges or miss stop signals, breaking budget guarantees.
+      preferred_contexts: Multi-iteration flow execution where budgets span run/loop scopes.
+    - feature: Immutable cost/value objects
+      principle: immutability
+      summary: CostSnapshot and BudgetDecision freeze payloads before trace emission to prevent accidental mutation across observers.
+      risk_if_excluded: Trace consumers or adapters could mutate historical data causing audit drift.
+      preferred_contexts: Any budgeting or telemetry surface that shares payloads with untrusted sinks.
+  refactor_candidates:
+    - from_branch: codex/implement-phase-3-using-tdd-for-feature-bk4a29
+      file: codex/code/phase3-budget-guards-d98ee6c7/pkgs/dsl/runner.py
+      issue: FlowRunner handles adapter orchestration, policy stack management, and breach reporting in one method.
+      suggested_fix: Split execution phases into discrete helpers (preflight, commit, teardown) before considering upstream merge.
+      urgency: medium

--- a/codex/REVIEWS/P4/07b_budget_guards_and_runner_integration.yaml-006584c3-01d5-4132-8dd0-12fa533c4053
+++ b/codex/REVIEWS/P4/07b_budget_guards_and_runner_integration.yaml-006584c3-01d5-4132-8dd0-12fa533c4053
@@ -1,0 +1,35 @@
+review_summary:
+  code_task: 07b_budget_guards_and_runner_integration.yaml
+  top_branch: codex/complete-phase-3-for-tdd-feature-rd6egz
+  rationale:
+    - Loop-aware execution covers run, loop, and node scopes with clear trace emission, matching spec semantics.
+    - Budget domain is immutable and normalized, making tests deterministic and payload-safe.
+  improvement_areas_identified:
+    - Trace emitter lacks pluggable sinks present in other candidates; plan follow-up.
+    - Production copy still needs relocation from sandbox path into pkgs/dsl package.
+  high_quality_snippets:
+    - file: codex/code/work/dsl/flow_runner.py
+      reason: Clean separation of unit node execution and loop orchestration with budget previews prior to commit.
+      extract: |
+        def _run_unit_node(
+            self,
+            *,
+            run_scope: bm.ScopeKey,
+            raw_node: Mapping[str, object],
+            loop_scope: bm.ScopeKey | None,
+            loop_id: str | None,
+            iteration: int | None,
+        ) -> NodeExecution:
+            ...
+            run_decision = self._apply_budget(
+                run_scope, cost_snapshot, commit=False
+            )
+            ...
+            if loop_decision is not None:
+                self._budgets.commit_charge(loop_decision)
+            self._budgets.commit_charge(node_decision)
+  recommendation_tags:
+    - cohesion
+    - separation_of_concerns
+    - testability
+    - architecture_strength

--- a/codex/TESTS/P4/07b_budget_guards_and_runner_integration.yaml-006584c3-01d5-4132-8dd0-12fa533c4053
+++ b/codex/TESTS/P4/07b_budget_guards_and_runner_integration.yaml-006584c3-01d5-4132-8dd0-12fa533c4053
@@ -1,0 +1,9 @@
+missing_tests:
+  for_task: 07b_budget_guards_and_runner_integration.yaml
+  context: "Generated from branches reviewed in Phase 4"
+  proposed_tests:
+    - name: test_trace_emitter_snapshot_freezes_nested_payloads
+      target_file: tests/unit/dsl/test_trace_emitter_validation.py
+      rationale: Ensure nested dict/list payloads are deep-frozen when a sink is attached so downstream observers cannot mutate history.
+      derived_from_branch: codex/implement-phase-3-using-tdd-for-feature-lypjv9
+      spec_section: observability.trace_payloads

--- a/codex/agents/P4/production_copy_plan.yaml
+++ b/codex/agents/P4/production_copy_plan.yaml
@@ -1,0 +1,21 @@
+task: 07b_budget_guards_and_runner_integration.yaml
+winning_branch: codex/complete-phase-3-for-tdd-feature-rd6egz
+actions:
+  - from: codex/code/work/dsl/budget_models.py
+    to: pkgs/dsl/budget_models.py
+  - from: codex/code/work/dsl/budget_manager.py
+    to: pkgs/dsl/budget_manager.py
+  - from: codex/code/work/dsl/flow_runner.py
+    to: pkgs/dsl/flow_runner.py
+  - from: codex/code/work/dsl/trace.py
+    to: pkgs/dsl/trace.py
+  - from: codex/code/work/tests/test_budget_manager.py
+    to: tests/unit/dsl/test_budget_manager.py
+  - from: codex/code/work/tests/test_budget_models.py
+    to: tests/unit/dsl/test_budget_models.py
+  - from: codex/code/work/tests/test_flow_runner_budget_integration.py
+    to: tests/unit/dsl/test_flow_runner_budget_integration.py
+  - from: codex/code/work/tests/test_flow_runner_loop_policy.py
+    to: tests/unit/dsl/test_flow_runner_loop_policy.py
+  - from: codex/code/work/tests/test_trace_emitter_validation.py
+    to: tests/unit/dsl/test_trace_emitter_validation.py


### PR DESCRIPTION
## Summary
- record Phase 4 review, postexecution, test gap, and documentation notes for task 07b
- capture production copy plan targeting codex/complete-phase-3-for-tdd-feature-rd6egz as the winning branch
- outline reusable modules and follow-up tasks based on alternate implementations

## Testing
- not run (non-code changes)


------
https://chatgpt.com/codex/tasks/task_e_68e8d2a02560832cbbe291a886137b8d