### PR TITLE
Add CodeQL workflow with manual C++ build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+name: codeql
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pybind11
+
+      - name: Compute pybind11 CMake directory
+        run: echo "pybind11_DIR=$(python -m pybind11 --cmakedir)" >> "$GITHUB_ENV"
+
+      - name: Install native build tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python, cpp
+
+      - name: Configure CMake build
+        run: |
+          cmake -S cpp -B build -G Ninja \
+            -Dpybind11_DIR="$pybind11_DIR" \
+            -DPYBIND11_FINDPYTHON=ON
+
+      - name: Build native extensions
+        run: cmake --build build --config Release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- add a dedicated CodeQL workflow that runs on pushes, pull requests, and a weekly schedule
- install Python and pybind11, configure CMake, and build the native module so CodeQL sees the C++ sources

## Testing
- ./scripts/ensure_green.sh *(fails: existing lint violations in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e8e0e0a304832cb82d17cb39d83ec0