### PR TITLE
Fix CodeQL manual build mode

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: python, cpp
+          build-mode: manual
 
       - name: Configure CMake build
         run: |


### PR DESCRIPTION
## Summary
- declare CodeQL initialization to use manual build mode so that the custom CMake build is instrumented

## Testing
- `./scripts/ensure_green.sh` *(fails: existing lint issues in codex/code/phase3_budget_runner_r7h3 and related files)*

------
https://chatgpt.com/codex/tasks/task_e_68e8e556e2e4832cab35e19290c7b5e8