### PR TITLE
Quote backtick-prefixed review bullets for YAML parsing

### DIFF
--- a/codex/agents/REVIEWS/P1/07b_budget_guards_and_runner_integration.yaml-20240504T153500Z
+++ b/codex/agents/REVIEWS/P1/07b_budget_guards_and_runner_integration.yaml-20240504T153500Z
@@ -159,12 +159,12 @@ analysis:
       - Several implementations drop deterministic adapter execution in favour of mocked cost payloads, undermining integration realism required by the spec.
       - Test coverage regresses from the base branch; rewritten runners often invalidate `tests/unit/test_budget_meter_limits.py` without equivalent replacements.
     unique_strengths:
-      - `codex/integrate-budget-guards-with-runner-zwi2ny` offers reusable `BudgetSpec`/`CostSnapshot` value objects and a `TraceWriter` abstraction we can compose.
-      - `codex/integrate-budget-guards-with-runner-pbdel9` surfaces per-meter `remaining`/`overages` snapshots suitable for observability dashboards.
-      - `codex/implement-budget-guards-with-test-first-approach` provides a `BudgetManager` facade with preflight/commit hooks aligned to future runner orchestration.
-      - `codex/implement-budget-guards-with-test-first-approach-qhq0jq` captures loop summaries and normalizes budget modes via an enum, improving reporting fidelity.
-      - `codex/implement-budget-guards-with-test-first-approach-8wxk32` models node executions and costs with immutable dataclasses and injectable clocks for determinism.
-      - `codex/implement-budget-guards-with-test-first-approach-fa0vm9` formalizes adapter contracts and breach metadata, easing downstream tool integration.
+      - "`codex/integrate-budget-guards-with-runner-zwi2ny` offers reusable `BudgetSpec`/`CostSnapshot` value objects and a `TraceWriter` abstraction we can compose."
+      - "`codex/integrate-budget-guards-with-runner-pbdel9` surfaces per-meter `remaining`/`overages` snapshots suitable for observability dashboards."
+      - "`codex/implement-budget-guards-with-test-first-approach` provides a `BudgetManager` facade with preflight/commit hooks aligned to future runner orchestration."
+      - "`codex/implement-budget-guards-with-test-first-approach-qhq0jq` captures loop summaries and normalizes budget modes via an enum, improving reporting fidelity."
+      - "`codex/implement-budget-guards-with-test-first-approach-8wxk32` models node executions and costs with immutable dataclasses and injectable clocks for determinism."
+      - "`codex/implement-budget-guards-with-test-first-approach-fa0vm9` formalizes adapter contracts and breach metadata, easing downstream tool integration."
     critical_gaps:
       - Soft budget semantics diverge: some branches never surface warnings, others auto-raise even when `breach_action == "stop"`, so unified handling is missing.
       - Loop stop reasons and trace payload schemas differ, requiring reconciliation before merging into the runner contract.

--- a/codex/agents/REVIEWS/P1/07b_budget_guards_and_runner_integration.yaml-20250328-opsreview
+++ b/codex/agents/REVIEWS/P1/07b_budget_guards_and_runner_integration.yaml-20250328-opsreview
@@ -200,7 +200,7 @@ analysis:
       - codex/implement-budget-guards-with-test-first-approach introduces a `BudgetManager` orchestration layer separating preflight vs commit flows.
     critical_gaps:
       - Branches with redesigned budgets (`zwi2ny`, `8wxk32`) omit necessary imports, preventing modules from loading.
-      - `implement-budget-guards-with-test-first-approach` removes executable runner logic altogether, blocking integration.
+      - "`implement-budget-guards-with-test-first-approach` removes executable runner logic altogether, blocking integration."
       - None of the branches validates cycles/unknown tool sets within budget specs when loops reference shared meters.
 confidence_notes:
   - area: enforce() semantics

--- a/codex/agents/REVIEWS/P1/07b_budget_guards_and_runner_integration.yaml-gpt5codex
+++ b/codex/agents/REVIEWS/P1/07b_budget_guards_and_runner_integration.yaml-gpt5codex
@@ -173,10 +173,10 @@ analysis:
       - Soft budget handling is either absent or inconsistently surfaced; none of the branches produce a canonical `budget_resolved` trace for soft warnings.
       - Runner integration with policy enforcement (`PolicyStack`) is missing across all variants, so tool gating remains disconnected from budget decisions.
     unique_strengths:
-      - `codex/integrate-budget-guards-with-runner-zwi2ny` adds reusable trace writers and deterministic event payloads that match acceptance expectations.
-      - `codex/integrate-budget-guards-with-runner-pbdel9` provides structured `BudgetCharge` responses suitable for downstream diagnostics.
-      - `codex/implement-budget-guards-with-test-first-approach` introduces a `BudgetManager` abstraction enabling preflight vs commit semantics that align with TDD scaffolding.
-      - `codex/implement-budget-guards-with-test-first-approach-fa0vm9` demonstrates the most complete runner loop integration, including adapter orchestration and stop signals.
+      - "`codex/integrate-budget-guards-with-runner-zwi2ny` adds reusable trace writers and deterministic event payloads that match acceptance expectations."
+      - "`codex/integrate-budget-guards-with-runner-pbdel9` provides structured `BudgetCharge` responses suitable for downstream diagnostics."
+      - "`codex/implement-budget-guards-with-test-first-approach` introduces a `BudgetManager` abstraction enabling preflight vs commit semantics that align with TDD scaffolding."
+      - "`codex/implement-budget-guards-with-test-first-approach-fa0vm9` demonstrates the most complete runner loop integration, including adapter orchestration and stop signals."
     critical_gaps:
       - No branch delivers a unified trace contract that covers `push`, `pop`, `policy_resolved`, and `violation` events alongside budget telemetry.
       - Limit normalization and unit conversion rules diverge, risking inconsistent enforcement across scopes.
@@ -187,7 +187,7 @@ confidence_notes:
     reason: branches disagree on exception types (`BudgetBreachHard`, `BudgetExceededError`) and soft-stop behavior, so harmonization requires careful reconciliation.
 coverage_gaps:
   - missing: regression asserting `budget_charge` events include both cost and remaining headroom.
-  - missing: unit test covering loop-level soft breach with `breach_action: stop`.
+  - missing: "unit test covering loop-level soft breach with `breach_action: stop`."
 traceability_checklist:
   - must-emit: push
   - must-emit: pop

--- a/codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e
+++ b/codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e
@@ -29,7 +29,7 @@ analysis:
         - Adds the long-needed `enforce()` API, `PolicyViolationError`, and `PolicySnapshot`/`PolicyDenial` structures plus an injectable event sink, giving the runner a way to emit `policy_violation` telemetry.
         - Persists the tool registry on the stack, simplifying callers relative to reclz1, and structures violation payloads with scope + reason metadata suitable for observability pipelines.
         - Still iterates frames in insertion order (inheriting the nearest-scope regression from 81p0id) and removes `pop` scope validation, so overrides in decision branches fail silently and stack misuse goes undetected.
-        - `policy_resolved` is never emitted, unknown tool references are accepted, and no loop/decision/trace sequencing tests accompany the new enforcement surface, leaving runner integration high risk.
+        - "`policy_resolved` is never emitted, unknown tool references are accepted, and no loop/decision/trace sequencing tests accompany the new enforcement surface, leaving runner integration high risk."
   redundancy_or_hallucination_check:
     - None of the branches invent new DSL concepts, but 81p0id and yp01n0 hallucinate a `policy_allowlist` trace event that is unsupported by the spec while simultaneously omitting required `policy_resolved` telemetry.
     - reclz1 and yp01n0 duplicate partial fixes for nearest-scope precedence; only reclz1 actually restores reverse iteration, so merging both without care would reintroduce the FIFO bug.

--- a/codex/agents/REVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5
+++ b/codex/agents/REVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5
@@ -13,13 +13,13 @@ comparative_review:
   - branch: codex/integrate-budget-guards-with-runner-zwi2ny
     bullets:
       - Introduces immutable `BudgetSpec`/`CostSnapshot`/`BudgetChargeOutcome` models plus a `TraceWriter`, greatly improving data hygiene and observability hooks.
-      - `_execute_node` is stubbed to fabricate costs, severing adapters and making budget enforcement impossible to validate end-to-end; acceptance harnesses would fail because real tool execution disappears.
+      - "`_execute_node` is stubbed to fabricate costs, severing adapters and making budget enforcement impossible to validate end-to-end; acceptance harnesses would fail because real tool execution disappears."
       - Defaulting meters to `mode="hard"` while ignoring `breach_action` keeps soft budgets inert; loop stop behaviour therefore violates DSL semantics for warn/stop policies.
       - Emits `budget_charge` and `budget_breach` events but invents payload shapes that diverge from the policy trace schema and omits `policy_resolved`, so cross-system trace fidelity remains broken.
   - branch: codex/integrate-budget-guards-with-runner-pbdel9
     bullets:
       - Adds structured `BudgetCharge` payloads with `remaining`/`overages` plus `BudgetBreachHard`, giving downstream diagnostics the necessary context to display overrun metrics.
-      - `BudgetMeter.charge()` swallows breaches when `breach_action == "stop"`, and the runner never inspects the returned `breached` flag; loops therefore keep executing past hard stops, regressing enforcement guarantees.
+      - '`BudgetMeter.charge()` swallows breaches when `breach_action == "stop"`, and the runner never inspects the returned `breached` flag; loops therefore keep executing past hard stops, regressing enforcement guarantees.'
       - Trace payloads adopt immutable mapping proxies which align with observability requirements, yet the schema differs from DSL expectations (e.g., new event names) and policy traces remain absent.
       - Time accounting mixes seconds and milliseconds without normalization, causing scope totals to drift between adapters and meters.
       - Tests emphasise happy-path charging only; there is no regression asserting stop-on-breach or warning emission, so the failure above is uncaught.
@@ -45,7 +45,7 @@ comparative_review:
     bullets:
       - Introduces a `ToolAdapter` protocol with `estimate_cost` vs `execute` phases and explicit loop-context stacks, finally reattaching budgets to adapters and surfacing `BudgetBreach` diagnostics.
       - Trace handling accumulates events in mutable lists before optional sink forwarding; without immutable snapshots this breaks stack safety if shared across threads and diverges from DSL schemas.
-      - `BudgetMeter.charge()` mutates shared dictionaries and depends on adapters to normalise cost keys, risking cross-scope leakage and spec drift (time stored in ms, adapters emit seconds).
+      - "`BudgetMeter.charge()` mutates shared dictionaries and depends on adapters to normalise cost keys, risking cross-scope leakage and spec drift (time stored in ms, adapters emit seconds)."
       - Stop signals via `_LoopStopSignal` are promising yet bespoke; they should map to the DSL's canonical stop reason vocabulary to maintain consistency.
       - Tests cover adapter orchestration paths but do not assert schema fidelity for emitted traces or combined policy/budget violations, leaving major acceptance gaps.
 redundancy_and_hallucination_check:


### PR DESCRIPTION
## Summary
- quote review bullet strings that begin with backticks in the budget/policy review YAML files so they remain valid scalars

## Testing
- python - <<'PY'
import yaml, pathlib
paths = [
    pathlib.Path('codex/agents/REVIEWS/P1/07b_budget_guards_and_runner_integration.yaml-20240504T153500Z'),
    pathlib.Path('codex/agents/REVIEWS/P1/07b_budget_guards_and_runner_integration.yaml-20250328-opsreview'),
    pathlib.Path('codex/agents/REVIEWS/P1/07b_budget_guards_and_runner_integration.yaml-gpt5codex'),
    pathlib.Path('codex/agents/REVIEWS/P2/07a_dsl_policy_engine_completion.yaml-20240719-7b3e'),
    pathlib.Path('codex/agents/REVIEWS/P2/07b_budget_guards_and_runner_integration.yaml-20250427-gpt5'),
]
for path in paths:
    with path.open() as f:
        yaml.safe_load(f)
    print(path, 'parsed successfully')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e8e8045ff0832cb29c5fd7f90ca3b9