### PR TITLE
Fix executor stats isolation for concurrent tool runs

### DIFF
--- a/docs/toolpacks_executor.md
+++ b/docs/toolpacks_executor.md
@@ -30,8 +30,8 @@ print(result["text"], stats.duration_ms)
 
 Pass ``use_cache=False`` to `run_toolpack_with_stats` when you need to bypass
 deterministic caching (for example, to isolate transport-specific invocations)
-without flushing previously cached entries. The most recent metrics can always
-be retrieved via `executor.last_run_stats()`.
+without flushing previously cached entries. The most recent metrics for the
+current execution context can be retrieved via `executor.last_run_stats()`.
 
 ## Behaviour
 
@@ -47,8 +47,9 @@ be retrieved via `executor.last_run_stats()`.
   duration, payload sizes, and cache-hit status for the invocation. It exposes a
   ``use_cache`` flag to bypass caching when required.
 - `Executor.last_run_stats()` returns the metrics collected for the most recent
-  invocation, allowing transports to preserve observability when they temporarily
-  disable caching.
+  invocation **within the current thread or asyncio task**, allowing transports
+  to preserve observability when they temporarily disable caching without
+  leaking state across concurrent requests.
 - Non-deterministic toolpacks bypass the cache entirely.
 - Handlers are resolved via the `execution.module` field using the
   `module:callable` convention. Invalid formats, missing modules, missing

--- a/tests/helpers/toolpack_samples.py
+++ b/tests/helpers/toolpack_samples.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping
 from typing import Any
 
@@ -17,3 +18,12 @@ def uppercase(payload: Mapping[str, Any]) -> dict[str, Any]:
 
     text = str(payload.get("text", ""))
     return {"original": text, "upper": text.upper()}
+
+
+def delayed_echo(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Sleep for ``delayMs`` before mirroring the payload."""
+
+    delay_ms = float(payload.get("delayMs", 0))
+    if delay_ms > 0:
+        time.sleep(delay_ms / 1000.0)
+    return {"echo": dict(payload)}


### PR DESCRIPTION
## Summary
- store executor last_run_stats values in a context-local slot to prevent concurrent requests from overwriting each other
- add a delayed echo helper and regression test covering concurrent last_run_stats access
- document that last_run_stats is scoped per execution context

## Testing
- pytest tests/unit/toolpacks/test_executor_stats.py

------
https://chatgpt.com/codex/tasks/task_e_68e8e9811e00832c8e6b2ef0c672fac0