### PR TITLE
Allow JSON-RPC notifications without ids

### DIFF
--- a/codex/specs/schemas/envelope.schema.json
+++ b/codex/specs/schemas/envelope.schema.json
@@ -1,39 +1,107 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://spec.ragx.ai/mcp/envelope.schema.json",
-  "title": "RAGX MCP Envelope",
-  "type": "object",
-  "$comment": "JSON-RPC requests and notifications share this envelope. Notifications omit 'id'.",
-  "additionalProperties": false,
-  "required": ["jsonrpc", "method", "params"],
-  "properties": {
-    "id": {
-      "description": "Deterministic request identifier (UUID or stable string).",
-      "$comment": "When absent the envelope is treated as a notification.",
-      "type": ["string", "integer", "null"]
-    },
-    "jsonrpc": {
-      "description": "JSON-RPC protocol version indicator.",
-      "type": "string",
-      "const": "2.0"
-    },
-    "method": {
-      "description": "Fully qualified method invoked via MCP transport.",
-      "type": "string",
-      "minLength": 1
-    },
-    "params": {
-      "description": "Transport-specific payload validated against per-tool schemas.",
-      "type": "object"
-    },
-    "meta": {
-      "description": "Optional metadata emitted in envelopes.",
+  "title": "RAGX JSON-RPC 2.0 Envelope",
+  "$comment": "Shared schema covering JSON-RPC requests, notifications, and responses.",
+  "oneOf": [
+    {"$ref": "#/$defs/request"},
+    {"$ref": "#/$defs/notification"},
+    {"$ref": "#/$defs/response"}
+  ],
+  "$defs": {
+    "commonRequest": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": false,
+      "properties": {
+        "jsonrpc": {
+          "description": "JSON-RPC protocol version indicator.",
+          "type": "string",
+          "const": "2.0"
+        },
+        "id": {
+          "description": "Deterministic request identifier (UUID or stable string).",
+          "type": ["string", "integer", "null"]
+        },
+        "method": {
+          "description": "Fully qualified method invoked via MCP transport.",
+          "type": "string",
+          "minLength": 1
+        },
+        "params": {
+          "description": "Transport-specific payload validated against per-tool schemas.",
+          "type": "object"
+        },
+        "meta": {
+          "description": "Optional metadata emitted in envelopes.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "idempotencyKey": {
+          "description": "Optional idempotency token to deduplicate requests.",
+          "type": "string"
+        }
+      }
     },
-    "idempotencyKey": {
-      "description": "Optional idempotency token to deduplicate requests.",
-      "type": "string"
+    "request": {
+      "allOf": [
+        {"$ref": "#/$defs/commonRequest"},
+        {
+          "required": ["jsonrpc", "id", "method"],
+          "properties": {
+            "params": {"type": "object"}
+          }
+        }
+      ]
+    },
+    "notification": {
+      "allOf": [
+        {"$ref": "#/$defs/commonRequest"},
+        {
+          "required": ["jsonrpc", "method"],
+          "not": {"required": ["id"]}
+        }
+      ]
+    },
+    "response": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "jsonrpc": {
+          "description": "JSON-RPC protocol version indicator.",
+          "type": "string",
+          "const": "2.0"
+        },
+        "id": {
+          "description": "Identifier copied from the corresponding request.",
+          "type": ["string", "integer", "null"]
+        },
+        "result": {
+          "description": "Successful response payload.",
+          "type": ["object", "array", "string", "number", "boolean", "null"]
+        },
+        "error": {
+          "description": "Error object returned when a request fails.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["code", "message"],
+          "properties": {
+            "code": {"type": "integer"},
+            "message": {"type": "string"},
+            "data": {"type": ["object", "array", "string", "number", "boolean", "null"]}
+          }
+        }
+      },
+      "required": ["jsonrpc", "id"],
+      "oneOf": [
+        {
+          "required": ["result"],
+          "not": {"required": ["error"]}
+        },
+        {
+          "required": ["error"],
+          "not": {"required": ["result"]}
+        }
+      ]
     }
   }
 }

--- a/tests/unit/mcp/test_jsonrpc_envelope_schema.py
+++ b/tests/unit/mcp/test_jsonrpc_envelope_schema.py
@@ -1,0 +1,66 @@
+"""Executable tests for the JSON-RPC envelope schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+SCHEMA_PATH = Path("codex/specs/schemas/envelope.schema.json")
+
+
+@pytest.fixture(scope="module")
+def jsonrpc_validator() -> Draft202012Validator:
+    schema = json.loads(SCHEMA_PATH.read_text())
+    return Draft202012Validator(schema)
+
+
+def test_notification_without_id_is_valid(jsonrpc_validator: Draft202012Validator) -> None:
+    payload = {"jsonrpc": "2.0", "method": "$/cancel"}
+    jsonrpc_validator.validate(payload)
+
+
+def test_request_with_id_is_valid(jsonrpc_validator: Draft202012Validator) -> None:
+    payload = {"jsonrpc": "2.0", "id": "req-1", "method": "mcp.discover", "params": {}}
+    jsonrpc_validator.validate(payload)
+
+
+def test_notification_with_params_without_id_is_valid(
+    jsonrpc_validator: Draft202012Validator,
+) -> None:
+    payload = {"jsonrpc": "2.0", "method": "$/progress", "params": {"token": "t"}}
+    jsonrpc_validator.validate(payload)
+
+
+def test_response_requires_id(jsonrpc_validator: Draft202012Validator) -> None:
+    payload = {"jsonrpc": "2.0", "result": {"ok": True}}
+    with pytest.raises(ValidationError):
+        jsonrpc_validator.validate(payload)
+
+
+def test_response_with_error_or_result_is_valid(
+    jsonrpc_validator: Draft202012Validator,
+) -> None:
+    success = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    jsonrpc_validator.validate(success)
+
+    error = {
+        "jsonrpc": "2.0",
+        "id": "req-2",
+        "error": {"code": -32000, "message": "Failure"},
+    }
+    jsonrpc_validator.validate(error)
+
+
+
+def test_response_rejects_result_and_error(jsonrpc_validator: Draft202012Validator) -> None:
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "req-3",
+        "result": {"ok": True},
+        "error": {"code": -32000, "message": "Failure"},
+    }
+    with pytest.raises(ValidationError):
+        jsonrpc_validator.validate(payload)


### PR DESCRIPTION
## Summary
- expand the JSON-RPC envelope schema so notifications can omit an id while requests and responses keep their constraints
- add unit coverage that exercises notification, request, and response validation against the shared schema

## Testing
- pytest tests/unit/mcp/test_jsonrpc_envelope_schema.py


------
https://chatgpt.com/codex/tasks/task_e_68e8e969e968832cbf5340c1ccc40d1e