### PR TITLE
Guard JSON-RPC error payloads from mutation

### DIFF
--- a/apps/mcp_server/service/errors.py
+++ b/apps/mcp_server/service/errors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from copy import deepcopy
 from dataclasses import dataclass
 
 __all__ = ["CanonicalError"]
@@ -126,4 +127,5 @@ class CanonicalError:
         if not isinstance(template, _JsonRpcErrorTemplate):  # pragma: no cover - defensive
             raise TypeError("JSON-RPC mapping must be a _JsonRpcErrorTemplate")
         http_status = cls.to_http_status(code)
-        return template.build_payload(canonical_code=code, http_status=http_status)
+        payload = template.build_payload(canonical_code=code, http_status=http_status)
+        return deepcopy(payload)

--- a/apps/mcp_server/service/errors_stub.py
+++ b/apps/mcp_server/service/errors_stub.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from copy import deepcopy
 from dataclasses import dataclass
 
 __all__ = ["CanonicalError"]
@@ -57,4 +58,4 @@ class CanonicalError:
         value = cls._lookup(code, cls._JSONRPC_ERROR_MAP, context="JSON-RPC error")
         if not isinstance(value, dict):  # pragma: no cover - defensive
             raise TypeError("JSON-RPC mapping must be a dictionary")
-        return value.copy()
+        return deepcopy(value)

--- a/tests/unit/test_canonical_error_mapping.py
+++ b/tests/unit/test_canonical_error_mapping.py
@@ -62,3 +62,15 @@ def test_unknown_mappings_raise_key_error_when_missing(code: str) -> None:
     """Stubs should clearly communicate missing mappings during development."""
     with pytest.raises(KeyError):
         CanonicalError._lookup(code, mapping={})
+
+
+def test_jsonrpc_payload_mutations_do_not_persist() -> None:
+    """Mutating a returned payload must not corrupt the canonical mapping."""
+
+    payload = CanonicalError.to_jsonrpc_error("INVALID_INPUT")
+    payload["data"]["details"] = {"foo": "bar"}
+    payload["custom"] = True
+
+    subsequent = CanonicalError.to_jsonrpc_error("INVALID_INPUT")
+    assert "details" not in subsequent["data"]
+    assert "custom" not in subsequent


### PR DESCRIPTION
## Summary
- ensure JSON-RPC error payloads returned by `CanonicalError` are deep copied so mutations cannot bleed into canonical mappings
- add a regression test that mutates a returned JSON-RPC payload and verifies subsequent calls are unaffected
- mirror the defensive copy behaviour in the stub implementation for consistency

## Testing
- pytest tests/unit/test_canonical_error_mapping.py


------
https://chatgpt.com/codex/tasks/task_e_68e8e95282ec832ca894018caf45a8f1