### PR TITLE
Fix MCP SchemaRegistry to validate response envelopes

### DIFF
--- a/apps/mcp_server/service/mcp_service.py
+++ b/apps/mcp_server/service/mcp_service.py
@@ -310,7 +310,9 @@ class McpService:
             schema_version=schema_version,
             deterministic=deterministic_logs,
         )
-        validation_registry = SchemaRegistry()
+        validation_registry = SchemaRegistry(
+            envelope_schema_path=schema_dir / "envelope.schema.json"
+        )
         validation_log = EnvelopeValidationLogManager(
             log_dir=log_dir,
             schema_version=schema_version,

--- a/tests/unit/test_envelope_schema_validation.py
+++ b/tests/unit/test_envelope_schema_validation.py
@@ -82,6 +82,42 @@ def test_envelope_validator_rejects_error_payload_for_success(
         validator.validate(invalid_payload)
 
 
+def test_envelope_validator_accepts_valid_response_envelope(
+    schema_registry: SchemaRegistry,
+) -> None:
+    """Response envelopes produced by the service schema should validate."""
+
+    validator = schema_registry.load_envelope()
+    valid_payload = {
+        "ok": True,
+        "data": {"result": "ok"},
+        "error": None,
+        "meta": {
+            "requestId": "req-1",
+            "traceId": "trace-1",
+            "spanId": "span-1",
+            "schemaVersion": "0.1.0",
+            "deterministic": False,
+            "transport": "http",
+            "route": "discover",
+            "method": "mcp.discover",
+            "status": "ok",
+            "attempt": 0,
+            "execution": {
+                "durationMs": 1.0,
+                "inputBytes": 128,
+                "outputBytes": 256,
+            },
+            "idempotency": {"cacheHit": False},
+            "toolId": None,
+            "promptId": None,
+        },
+    }
+
+    # Should not raise if the registry is wired to the response envelope schema.
+    validator.validate(valid_payload)
+
+
 def test_tool_io_registry_returns_named_validators(schema_registry: SchemaRegistry) -> None:
     """Per-tool validator objects must expose validate() for input/output payloads."""
     validators = schema_registry.load_tool_io("mcp.tool:web.search.query")


### PR DESCRIPTION
## Summary
- ensure the MCP service initialises SchemaRegistry with the response envelope schema path
- add a regression test confirming response envelopes pass validation

## Testing
- pytest tests/unit/test_envelope_schema_validation.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e8e9273320832cba4d8d357bc2c989