### PR TITLE
Fix run budget charge ordering for node rejections

### DIFF
--- a/pkgs/dsl/flow_runner.py
+++ b/pkgs/dsl/flow_runner.py
@@ -239,10 +239,10 @@ class FlowRunner:
             node_decision = self._apply_budget(
                 node_scope, cost_snapshot, commit=False
             )
-            self._budgets.commit_charge(run_decision)
+            self._budgets.commit_charge(node_decision)
             if loop_decision is not None:
                 self._budgets.commit_charge(loop_decision)
-            self._budgets.commit_charge(node_decision)
+            self._budgets.commit_charge(run_decision)
             result = adapter.execute(node_payload)
             record = NodeExecution(
                 node_id=node_id,


### PR DESCRIPTION
## Summary
- commit node and loop scope budget charges before applying the run-level charge so nodes rejected by their own limits do not consume run budget
- add a regression test that verifies run spending is unchanged when a node is stopped by its node budget

## Testing
- `PYTHONPATH=. python - <<'PY'
import importlib
import sys
import types
import pytest

code_mod = sys.modules.setdefault("codex.code", types.ModuleType("codex.code"))
if not hasattr(code_mod, "__path__"):
    code_mod.__path__ = []  # type: ignore[attr-defined]
work_mod = sys.modules.setdefault("codex.code.work", types.ModuleType("codex.code.work"))
if not hasattr(work_mod, "__path__"):
    work_mod.__path__ = []  # type: ignore[attr-defined]
dsl_pkg = sys.modules.setdefault("codex.code.work.dsl", types.ModuleType("codex.code.work.dsl"))
if not hasattr(dsl_pkg, "__path__"):
    dsl_pkg.__path__ = []  # type: ignore[attr-defined]

for name in ("budget_models", "budget_manager", "flow_runner", "trace"):
    target = importlib.import_module(f"pkgs.dsl.{name}")
    sys.modules[f"codex.code.work.dsl.{name}"] = target
    setattr(dsl_pkg, name, target)

result = pytest.main([
    "tests/unit/dsl/test_flow_runner_budget_integration.py",
])
if result != 0:
    sys.exit(result)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68e8e8db89a8832c90c8794ae85e9108