### PR TITLE
Fix phase3 runner run log destination

### DIFF
--- a/codex/code/phase3-budget-guards-d98ee6c7/phase3_runner.py
+++ b/codex/code/phase3-budget-guards-d98ee6c7/phase3_runner.py
@@ -1,0 +1,90 @@
+"""Phase 3 sandbox runner for budget guards integration.
+
+This helper executes the sandbox pytest suite and captures stdout/stderr
+into the postexecution run log expected by Codex automation.  The previous
+iteration attempted to build the run log path from ``ROOT.parent / "agents"``
+which accidentally resolved to ``codex/code/agents`` because ``ROOT`` points at
+this phase3 code directory.  Consumers (CI and documentation tooling) look for
+artifacts under ``codex/agents/POSTEXECUTION`` instead, so the log was never
+picked up.
+
+The runner now derives the Codex root via ``ROOT.parents[1]`` to ensure the log
+lands in ``codex/agents`` regardless of where the sandbox code itself lives.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence
+
+ROOT = Path(__file__).resolve().parent
+CODEX_ROOT = ROOT.parents[1]
+AGENTS_ROOT = CODEX_ROOT / "agents"
+POSTEXECUTION_ROOT = AGENTS_ROOT / "POSTEXECUTION" / "P3"
+DEFAULT_RUNLOG_NAME = (
+    "07b_budget_guards_and_runner_integration.yaml-"
+    "47537ede-0ec2-4de1-b9cd-10e0f3c0d68c-runlog.txt"
+)
+DEFAULT_RUNLOG_PATH = POSTEXECUTION_ROOT / DEFAULT_RUNLOG_NAME
+DEFAULT_PYTEST_COMMAND = (
+    sys.executable,
+    "-m",
+    "pytest",
+    str(ROOT / "tests"),
+    "-q",
+)
+
+
+def _execute(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Run ``command`` and capture stdout/stderr without raising on failure."""
+
+    return subprocess.run(command, capture_output=True, text=True, check=False)
+
+
+def _write_runlog(path: Path, result: subprocess.CompletedProcess[str]) -> None:
+    """Persist ``result`` output to ``path`` ensuring parent directories exist."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content_parts: list[str] = [result.stdout]
+    if result.stderr:
+        content_parts.extend(["", result.stderr])
+    path.write_text("\n".join(part for part in content_parts if part), encoding="utf-8")
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Run the sandbox test suite and write the aggregated run log."""
+
+    parser = argparse.ArgumentParser(description="Run phase3 sandbox tests")
+    parser.add_argument(
+        "--runlog",
+        type=Path,
+        default=DEFAULT_RUNLOG_PATH,
+        help="Destination for the captured run log",
+    )
+    parser.add_argument(
+        "--pytest-cmd",
+        nargs=argparse.REMAINDER,
+        help=(
+            "Override the pytest command. Provide arguments after --pytest-cmd; "
+            "defaults to the sandbox test suite."
+        ),
+    )
+    parsed = parser.parse_args(list(argv) if argv is not None else None)
+
+    command: Sequence[str]
+    if parsed.pytest_cmd:
+        command = tuple(parsed.pytest_cmd)
+    else:
+        command = DEFAULT_PYTEST_COMMAND
+
+    result = _execute(command)
+    _write_runlog(parsed.runlog, result)
+
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/postexecution/test_phase3_runner.py
+++ b/tests/unit/postexecution/test_phase3_runner.py
@@ -1,0 +1,24 @@
+"""Regression tests for the phase3 sandbox runner helpers."""
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT_PATH = Path("codex/code/phase3-budget-guards-d98ee6c7/phase3_runner.py")
+MODULE_SPEC = importlib.util.spec_from_file_location("phase3_runner", SCRIPT_PATH)
+assert MODULE_SPEC is not None and MODULE_SPEC.loader is not None
+phase3_runner = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(phase3_runner)
+
+
+def test_default_runlog_points_to_agents_postexecution():
+    runlog_path = phase3_runner.DEFAULT_RUNLOG_PATH
+    assert "codex/agents/POSTEXECUTION" in runlog_path.as_posix()
+    assert "codex/code/agents" not in runlog_path.as_posix()
+
+
+def test_write_runlog_creates_parent_directories(tmp_path):
+    destination = tmp_path / "nested" / "runlog.txt"
+    result = type("Result", (), {"stdout": "ok", "stderr": ""})
+    phase3_runner._write_runlog(destination, result)  # type: ignore[attr-defined]
+    assert destination.exists()
+    assert destination.read_text() == "ok"


### PR DESCRIPTION
## Summary
- ensure the phase3 sandbox runner resolves its run log under `codex/agents/POSTEXECUTION`
- add regression tests covering the corrected run log path and writer helper

## Testing
- pytest tests/unit/postexecution/test_phase3_runner.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e8e8c9f0e4832ca40901c28c9ad681