### PR TITLE
Normalize task dependency key naming

### DIFF
--- a/codex/agents/TASKS/06aV2_core_tools_minimal_subset.yaml
+++ b/codex/agents/TASKS/06aV2_core_tools_minimal_subset.yaml
@@ -12,7 +12,7 @@ description: >
   diff script that enforce stability while whitelisting volatile fields.
 
 component_ids: [core_tools, mcp_server, toolpacks_runtime, observability]
-depends_on:
+dependencies:
   - 05a_toolpacks_loader_minimal
   - 05b_toolpacks_executor_python_only
   - 05c_toolpacks_loader_spec_alignment

--- a/codex/agents/TASKS/06bV2_mcp_server_bootstrap.yaml
+++ b/codex/agents/TASKS/06bV2_mcp_server_bootstrap.yaml
@@ -11,7 +11,7 @@ description: >
   and responses, emit JSONL logs with keep-last-5 rotation and a stable "latest"
   symlink, and provide a CLI to toggle transports and deterministic test runs.
 component_ids: [mcp_server, toolpacks_runtime, observability, cli]
-depends_on:
+dependencies:
   - 05a_toolpacks_loader_minimal
   - 05b_toolpacks_executor_python_only
   - 05c_toolpacks_loader_spec_alignment

--- a/codex/agents/TASKS/06cV2A_mcp_envelope_and_schema_validation_A.yaml
+++ b/codex/agents/TASKS/06cV2A_mcp_envelope_and_schema_validation_A.yaml
@@ -31,7 +31,7 @@ constraints:
   - On-disk log fields use camelCase; volatile identifiers are whitelisted in diffs.
 
 component_ids: ["mcp_server", "toolpacks_runtime", "observability"]
-depends_on: ["06b_mcp_server_bootstrap", "06a_core_tools_minimal_subset"]
+dependencies: ["06b_mcp_server_bootstrap", "06a_core_tools_minimal_subset"]
 arg_spec: ["mcp_server", "task_runner"]
 
 config_flags:

--- a/codex/agents/TASKS/06cV2B_mcp_envelope_and_schema_validation_B.yaml
+++ b/codex/agents/TASKS/06cV2B_mcp_envelope_and_schema_validation_B.yaml
@@ -2,7 +2,7 @@ version: 1
 id: 06cV2B_mcp_envelope_and_schema_validation_B
 title: MCP Envelope & Schema Validation (Part B — Implementation & Enhancements)
 
-depends_on:
+dependencies:
   - 06c_mcp_envelope_and_schema_validation_A_tests_first
 
 summary: >

--- a/codex/agents/TASKS/06dV2A_mcp_toolpacks_transport_tests_first.yaml
+++ b/codex/agents/TASKS/06dV2A_mcp_toolpacks_transport_tests_first.yaml
@@ -37,7 +37,7 @@ constraints:
   - Golden updates require an explicit approval step.
 
 component_ids: [apps.mcp_server.service, apps.toolpacks.executor, tests.e2e.mcp]
-depends_on: [06cV2A_mcp_envelope_and_schema_validation_A, 06b_mcp_server_bootstrap]
+dependencies: [06cV2A_mcp_envelope_and_schema_validation_A, 06b_mcp_server_bootstrap]
 
 arg_spec:
   - --deterministic-ids

--- a/codex/agents/TASKS/06dV2B_mcp_toolpacks_transport_impl.yaml
+++ b/codex/agents/TASKS/06dV2B_mcp_toolpacks_transport_impl.yaml
@@ -2,7 +2,7 @@ version: 1
 id: 06dV2B_mcp_toolpacks_transport_impl.yaml
 title: MCP Toolpacks Transport — Unified execution, guardrails, and telemetry (Part B — Implementation & Enhancements)
 
-depends_on:
+dependencies:
   - 06d_mcp_toolpacks_transport_A_tests_first
 
 summary: >

--- a/codex/agents/TASKS/106a-mcp-server-prod-enhancements.yaml
+++ b/codex/agents/TASKS/106a-mcp-server-prod-enhancements.yaml
@@ -11,7 +11,7 @@ description: >
   performance optimizations (orjson, caching, Pydantic v2), configuration flags,
   and CI/CD workflows for golden management and artifact publishing.
 component_ids: [observability, mcp_server, security, ci_cd, performance]
-depends_on:
+dependencies:
   - 06b_mcp_server_bootstrap
   - 06ab_core_tools_minimal_subset
 arg_spec: [mcp_server, task_runner]

--- a/codex/agents/TASKS/20a-flowscript-spec-and-grammar.yaml
+++ b/codex/agents/TASKS/20a-flowscript-spec-and-grammar.yaml
@@ -2,7 +2,7 @@ id: 20a-flowscript-spec-and-grammar
 title: FlowScript v0.1 – human-readable DSL spec + grammar
 owner: codex
 priority: P0
-depends_on: [03_vectordb_md_ingest, 05a_toolpacks_loader_minimal, 06b_mcp_server_bootstrap]
+dependencies: [03_vectordb_md_ingest, 05a_toolpacks_loader_minimal, 06b_mcp_server_bootstrap]
 goal: >
   Define the human-readable FlowScript language that compiles to the canonical YAML DSL
   in codex/specs/ragx_master_spec.yaml (components: dsl). Ship a formal grammar + examples.

--- a/codex/agents/TASKS/20b-flowscript-parser-ast.yaml
+++ b/codex/agents/TASKS/20b-flowscript-parser-ast.yaml
@@ -2,7 +2,7 @@ id: 20b-flowscript-parser-ast
 title: FlowScript parser → AST (deterministic, no codegen yet)
 owner: codex
 priority: P0
-depends_on: [20a-flowscript-spec-and-grammar]
+dependencies: [20a-flowscript-spec-and-grammar]
 goal: Implement a deterministic parser for FlowScript (.fs) producing a typed AST.
 inputs:
   - pkgs/dsl/flowscript/grammar.ebnf

--- a/codex/agents/TASKS/20c-flowscript-compiler-to-yaml.yaml
+++ b/codex/agents/TASKS/20c-flowscript-compiler-to-yaml.yaml
@@ -2,7 +2,7 @@ id: 20c-flowscript-compiler-to-yaml
 title: FlowScript compiler → canonical YAML DSL
 owner: codex
 priority: P0
-depends_on: [20b-flowscript-parser-ast]
+dependencies: [20b-flowscript-parser-ast]
 goal: Compile FlowScript AST into the canonical YAML DSL (schemas defined in spec).
 inputs:
   - codex/specs/ragx_master_spec.yaml

--- a/codex/agents/TASKS/20d-runner-execution-core.yaml
+++ b/codex/agents/TASKS/20d-runner-execution-core.yaml
@@ -2,7 +2,7 @@ id: 20d-runner-execution-core
 title: DSL Runner – execution core (sequential, no loops/decisions yet)
 owner: codex
 priority: P0
-depends_on: [20c-flowscript-compiler-to-yaml]
+dependencies: [20c-flowscript-compiler-to-yaml]
 goal: Execute YAML DSL graphs (unit + transform nodes) sequentially with templating and tracing.
 inputs:
   - codex/specs/ragx_master_spec.yaml

--- a/codex/agents/TASKS/20e-policy-and-budget-engine.yaml
+++ b/codex/agents/TASKS/20e-policy-and-budget-engine.yaml
@@ -2,7 +2,7 @@ id: 20e-policy-and-budget-engine
 title: Policy stack + budget meters (hard/soft) with enforcement
 owner: codex
 priority: P0
-depends_on: [20d-runner-execution-core]
+dependencies: [20d-runner-execution-core]
 goal: Enforce hierarchical policy allow/deny and budget caps at run/node/spec scope.
 inputs:
   - codex/specs/ragx_master_spec.yaml

--- a/codex/agents/TASKS/20f-transforms-sandbox.yaml
+++ b/codex/agents/TASKS/20f-transforms-sandbox.yaml
@@ -2,7 +2,7 @@ id: 20f-transforms-sandbox
 title: Transform sandbox – jinja/python (shell opt-in via flag)
 owner: codex
 priority: P1
-depends_on: [20d-runner-execution-core]
+dependencies: [20d-runner-execution-core]
 goal: "Safe execution of transform nodes with resource bounds; default: jinja + python only."
 inputs:
   - codex/specs/ragx_master_spec.yaml

--- a/codex/agents/TASKS/20g-decisions-and-loops.yaml
+++ b/codex/agents/TASKS/20g-decisions-and-loops.yaml
@@ -2,7 +2,7 @@ id: 20g-decisions-and-loops
 title: Decision predicates + loop control with stop/budget
 owner: codex
 priority: P0
-depends_on: [20e-policy-and-budget-engine]
+dependencies: [20e-policy-and-budget-engine]
 goal: Implement decision nodes and loop controllers; branch policies and loop budgets.
 inputs:
   - codex/specs/ragx_master_spec.yaml

--- a/codex/agents/TASKS/20h-adapters-and-costing.yaml
+++ b/codex/agents/TASKS/20h-adapters-and-costing.yaml
@@ -2,7 +2,7 @@ id: 20h-adapters-and-costing
 title: Tool/LLM/MCP adapters + costing from tool_registry
 owner: codex
 priority: P0
-depends_on: [20e-policy-and-budget-engine, 06b_mcp_server_bootstrap, 05b_toolpacks_executor_python_only]
+dependencies: [20e-policy-and-budget-engine, 06b_mcp_server_bootstrap, 05b_toolpacks_executor_python_only]
 goal: Uniform adapter interface with cost estimation (tokens/calls/usd) using tool_registry.
 inputs:
   - codex/specs/ragx_master_spec.yaml

--- a/codex/agents/TASKS/20i-dsl-linter-and-ci.yaml
+++ b/codex/agents/TASKS/20i-dsl-linter-and-ci.yaml
@@ -2,7 +2,7 @@ id: 20i-dsl-linter-and-ci
 title: Static DSL linter + CI gate (unreachable tools, budget blow-ups)
 owner: codex
 priority: P0
-depends_on: [20h-adapters-and-costing]
+dependencies: [20h-adapters-and-costing]
 goal: Ship linter CLI and wire into CI as a required step.
 inputs:
   - codex/specs/ragx_master_spec.yaml

--- a/codex/agents/TASKS/20j-example-flows-and-docs.yaml
+++ b/codex/agents/TASKS/20j-example-flows-and-docs.yaml
@@ -2,7 +2,7 @@ id: 20j-example-flows-and-docs
 title: Example flows (ReAct + Self-Refine) in FlowScript + YAML + docs
 owner: codex
 priority: P0
-depends_on: [20c-flowscript-compiler-to-yaml, 20g-decisions-and-loops, 20i-dsl-linter-and-ci]
+dependencies: [20c-flowscript-compiler-to-yaml, 20g-decisions-and-loops, 20i-dsl-linter-and-ci]
 goal: Provide canonical examples and end-to-end tests from FlowScript → YAML → run.
 inputs:
   - codex/specs/ragx_master_spec.yaml

--- a/codex/agents/TASKS/30a-mcp-envelope-and-schema.yaml
+++ b/codex/agents/TASKS/30a-mcp-envelope-and-schema.yaml
@@ -2,7 +2,7 @@ id: 30a-mcp-envelope-and-schema
 title: MCP – Envelope + schema validation (HTTP & STDIO parity)
 owner: codex
 priority: P0
-depends_on: [20d-runner-execution-core]
+dependencies: [20d-runner-execution-core]
 goal: Implement uniform Envelope model and JSON Schema validation for all MCP responses; ensure HTTP/STDIO parity.
 inputs:
   - codex/specs/ragx_master_spec.yaml

--- a/codex/agents/TASKS/30b-mcp-discovery-and-prompts.yaml
+++ b/codex/agents/TASKS/30b-mcp-discovery-and-prompts.yaml
@@ -2,7 +2,7 @@ id: 30b-mcp-discovery-and-prompts
 title: MCP – /mcp/discover + prompt registry
 owner: codex
 priority: P0
-depends_on: [30a-mcp-envelope-and-schema]
+dependencies: [30a-mcp-envelope-and-schema]
 goal: Deterministic discovery document and prompt registry with versioned specs.
 outputs:
   - apps/mcp_server/registry/prompts.py

--- a/codex/agents/TASKS/30c-toolpacks-loader-and-exec.yaml
+++ b/codex/agents/TASKS/30c-toolpacks-loader-and-exec.yaml
@@ -2,7 +2,7 @@ id: 30c-toolpacks-loader-and-exec
 title: Toolpacks – loader + exec (python|cli|http) with $ref and limits
 owner: codex
 priority: P0
-depends_on: [30a-mcp-envelope-and-schema]
+dependencies: [30a-mcp-envelope-and-schema]
 goal: Load *.tool.yaml; resolve $ref schemas; execute tools with stdin/stdout JSON; enforce time/size limits; deterministic cache.
 outputs:
   - apps/toolpacks/loader.py

--- a/codex/agents/TASKS/30d-core-tools-canonical.yaml
+++ b/codex/agents/TASKS/30d-core-tools-canonical.yaml
@@ -2,7 +2,7 @@ id: 30d-core-tools-canonical
 title: Core Tools – normalized schemas and fixtures
 owner: codex
 priority: P0
-depends_on: [30c-toolpacks-loader-and-exec]
+dependencies: [30c-toolpacks-loader-and-exec]
 goal: Implement canonical toolpacks with normalized I/O and golden fixtures.
 outputs:
   - apps/mcp_server/toolpacks/web.search.query.tool.yaml

--- a/codex/agents/TASKS/31a-rest-parity-facade.yaml
+++ b/codex/agents/TASKS/31a-rest-parity-facade.yaml
@@ -2,7 +2,7 @@ id: 31a-rest-parity-facade
 title: REST facade – /v1/search /v1/plan /v1/research + tests
 owner: codex
 priority: P1
-depends_on: [30d-core-tools-canonical]
+dependencies: [30d-core-tools-canonical]
 goal: Thin HTTP endpoints that call into same service layer as MCP tools; JSON schemas.
 outputs:
   - apps/rest/api.py

--- a/codex/agents/TASKS/40a-vectordb-faiss-shim-and-serialize.yaml
+++ b/codex/agents/TASKS/40a-vectordb-faiss-shim-and-serialize.yaml
@@ -2,7 +2,7 @@ id: 40a-vectordb-faiss-shim-and-serialize
 title: VectorDB – FAISS shim + CPU serialize + docmap contract
 owner: codex
 priority: P0
-depends_on: []
+dependencies: []
 goal: Ship Python shim and minimal backend (dummy or FAISS if available) honoring serialize contract and index dir layout.
 outputs:
   - ragcore/interfaces.py

--- a/codex/agents/TASKS/40b-vectordb-sharding-and-merge.yaml
+++ b/codex/agents/TASKS/40b-vectordb-sharding-and-merge.yaml
@@ -2,7 +2,7 @@ id: 40b-vectordb-sharding-and-merge
 title: VectorDB – shard build + merge + resume
 owner: codex
 priority: P0
-depends_on: [40a-vectordb-faiss-shim-and-serialize]
+dependencies: [40a-vectordb-faiss-shim-and-serialize]
 goal: Build shards up to `--shard-size`, allow resume after crash, and merge into final index.
 outputs:
   - pkgs/indexer/builder.py

--- a/codex/agents/TASKS/40c-vectordb-md-ingest-frontmatter.yaml
+++ b/codex/agents/TASKS/40c-vectordb-md-ingest-frontmatter.yaml
@@ -2,7 +2,7 @@ id: 40c-vectordb-md-ingest-frontmatter
 title: VectorDB – Markdown ingestion with YAML front-matter
 owner: codex
 priority: P0
-depends_on: [40b-vectordb-sharding-and-merge]
+dependencies: [40b-vectordb-sharding-and-merge]
 goal: Index builder accepts .md alongside PDFs; extracts optional front-matter (YAML or RFC822-style) into metadata.
 inputs:
   - eval/verification/rag_gold_corpus_neuroplasticity.zip

--- a/codex/agents/TASKS/41a-retrieval-hybrid-and-rerank.yaml
+++ b/codex/agents/TASKS/41a-retrieval-hybrid-and-rerank.yaml
@@ -2,7 +2,7 @@ id: 41a-retrieval-hybrid-and-rerank
 title: Retrieval – hybrid BM25+vector and cross-encoder rerank
 owner: codex
 priority: P1
-depends_on: [30d-core-tools-canonical, 40a-vectordb-faiss-shim-and-serialize]
+dependencies: [30d-core-tools-canonical, 40a-vectordb-faiss-shim-and-serialize]
 goal: RetrieverFactory with hybrid scoring and optional cross-encoder reranker; NDCG fixtures offline.
 outputs:
   - pkgs/retrieval/retriever.py

--- a/codex/agents/TASKS/42a-planner-and-mindmap.yaml
+++ b/codex/agents/TASKS/42a-planner-and-mindmap.yaml
@@ -2,7 +2,7 @@ id: 42a-planner-and-mindmap
 title: Planner – deterministic perspectives, questions, mind-map JSON
 owner: codex
 priority: P1
-depends_on: [20j-example-flows-and-docs]
+dependencies: [20j-example-flows-and-docs]
 goal: Produce stable perspectives & questions with seeded RNG; mind-map export/import.
 outputs:
   - pkgs/planner/planner.py

--- a/codex/agents/TASKS/42b-hitl-outline-and-merge.yaml
+++ b/codex/agents/TASKS/42b-hitl-outline-and-merge.yaml
@@ -2,7 +2,7 @@ id: 43a-agents-research-pipeline
 title: Agents – planner → executor → publisher end-to-end
 owner: codex
 priority: P1
-depends_on: [41a-retrieval-hybrid-and-rerank, 42b-hitl-outline-and-merge]
+dependencies: [41a-retrieval-hybrid-and-rerank, 42b-hitl-outline-and-merge]
 goal: E2E pipeline returning notes, sources, and artifacts (report/outline/bibliography) with snapshots.
 outputs:
   - pkgs/research/pipeline.py

--- a/codex/agents/TASKS/50a-observability-trace-contracts.yaml
+++ b/codex/agents/TASKS/50a-observability-trace-contracts.yaml
@@ -2,7 +2,7 @@ id: 50a-observability-trace-contracts
 title: Observability – trace JSONL contracts and metrics smoke tests
 owner: codex
 priority: P0
-depends_on: [20d-runner-execution-core]
+dependencies: [20d-runner-execution-core]
 goal: Validate trace event shapes and minimal metrics counters for runner and MCP.
 outputs:
   - tests/obs/test_trace_contracts.py

--- a/codex/agents/TASKS/50b-ci-coverage-and-cache.yaml
+++ b/codex/agents/TASKS/50b-ci-coverage-and-cache.yaml
@@ -2,7 +2,7 @@ id: 50b-ci-coverage-and-cache
 title: CI – coverage gate + ccache sanity + build matrix guard
 owner: codex
 priority: P0
-depends_on: []
+dependencies: []
 goal: Enforce coverage ≥ spec minimum; confirm ccache active; matrix skips when no native code changes.
 outputs:
   - .github/workflows/ci.yml (amend)

--- a/codex/agents/TASKS/60a-codex-bootstrap-and-guardrails.yaml
+++ b/codex/agents/TASKS/60a-codex-bootstrap-and-guardrails.yaml
@@ -2,7 +2,7 @@ id: 60a-codex-bootstrap-and-guardrails
 title: Agents – bootstrap guard (stop until tests pass) + env checks
 owner: codex
 priority: P0
-depends_on: []
+dependencies: []
 goal: Provide scripts and docs that force Codex to run tests first and abort if red; check OpenAI key when needed.
 outputs:
   - codex/agents/CODEX_BOOTSTRAP.md

--- a/codex/agents/TASKS/70a-docs-foundation.yaml
+++ b/codex/agents/TASKS/70a-docs-foundation.yaml
@@ -2,7 +2,7 @@ id: 70a-docs-foundation
 title: Docs – quickstart, DSL, MCP, VectorDB pages
 owner: codex
 priority: P1
-depends_on: [20j-example-flows-and-docs, 30d-core-tools-canonical, 40b-vectordb-sharding-and-merge]
+dependencies: [20j-example-flows-and-docs, 30d-core-tools-canonical, 40b-vectordb-sharding-and-merge]
 goal: Author concise docs pages and link them from README; ensure internal links resolve.
 outputs:
   - docs/quickstart.md

--- a/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20240516-opsz
+++ b/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20240516-opsz
@@ -52,7 +52,7 @@ tasks:
     reusable: true
     description: Add ToolDescriptor registry, PolicyDecision/PolicyResolution diagnostics map, and enriched trace payloads (candidates, stack depth).
     adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
-    depends_on: [policy_stack_foundation]
+    dependencies: [policy_stack_foundation]
     source_files:
       - pkgs/dsl/models.py
       - pkgs/dsl/policy.py
@@ -66,7 +66,7 @@ tasks:
     reusable: false
     description: Introduce PolicyDenial/PolicySnapshot, enforce() API with PolicyViolationError, and optional event sink integration for push/pop/violation events.
     adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-yp01n0
-    depends_on: [policy_decision_diagnostics]
+    dependencies: [policy_decision_diagnostics]
     source_files:
       - pkgs/dsl/policy.py
       - pkgs/dsl/__init__.py
@@ -80,7 +80,7 @@ tasks:
     reusable: true
     description: Update FlowLinter to evaluate unit nodes, decision branches, and loop contexts using cloned stacks seeded with global/graph policies.
     adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-reclz1
-    depends_on: [policy_decision_diagnostics]
+    dependencies: [policy_decision_diagnostics]
     source_files:
       - pkgs/dsl/linter.py
     tests:
@@ -93,7 +93,7 @@ tasks:
     reusable: false
     description: Expand unit coverage for decision overrides, loop propagation, fallback reachability, and pop() scope mismatches; ensure fixtures are self-contained.
     adapted_from_branch: codex/implement-dsl-policy-engine-in-yaml-81p0id
-    depends_on: [linter_reachability_analysis]
+    dependencies: [linter_reachability_analysis]
     source_files:
       - tests/unit/test_policy_stack_resolution.py
       - tests/unit/test_linter_unreachable_tools.py

--- a/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
+++ b/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
@@ -98,7 +98,7 @@ actions:
           summary: Layer PolicySnapshot/enforce API onto the corrected PolicyStack.
           adapted_from_branch:
             - codex/implement-dsl-policy-engine-in-yaml-yp01n0
-          depends_on:
+          dependencies:
             - policy_stack_core
           steps:
             - Produce immutable PolicySnapshot objects that capture allowed tools, denial metadata, and stack scopes without recomputing traces.
@@ -120,7 +120,7 @@ actions:
           adapted_from_branch:
             - codex/implement-dsl-policy-engine-in-yaml-reclz1
             - codex/implement-dsl-policy-engine-in-yaml-81p0id
-          depends_on:
+          dependencies:
             - policy_stack_core
           steps:
             - Build a reusable analyzer that clones the PolicyStack per loop/decision branch and records trace context for unreachable findings.

--- a/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250105-gpt5
+++ b/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250105-gpt5
@@ -41,7 +41,7 @@ component_ids:
   - tests.unit.budget
   - tests.unit.runner
   - tests.e2e.runner
-depends_on:
+dependencies:
   - 07a_dsl_policy_engine_completion.plan
 arg_spec: []
 config_flags: []
@@ -150,7 +150,7 @@ actions:
             - codex/implement-budget-guards-with-test-first-approach
             - codex/integrate-budget-guards-with-runner-pbdel9
             - codex/integrate-budget-guards-with-runner-zwi2ny
-          depends_on:
+          dependencies:
             - budget_domain_model
           steps:
             - Implement BudgetManager that constructs BudgetMeter instances per scope, exposes preflight_* and commit_* APIs, and returns BudgetCheck/BudgetCharge outcomes.
@@ -176,7 +176,7 @@ actions:
             - codex/implement-budget-guards-with-test-first-approach-8wxk32
             - codex/implement-budget-guards-with-test-first-approach-fa0vm9
             - codex/implement-budget-guards-with-test-first-approach-qhq0jq
-          depends_on:
+          dependencies:
             - budget_manager_and_trace
           steps:
             - Execute nodes via ToolAdapter protocol, capturing estimates, enforcing PolicyStack before execution, and charging BudgetManager with actual costs.
@@ -200,7 +200,7 @@ actions:
           adapted_from_branch:
             - codex/integrate-budget-guards-with-runner-pbdel9
             - codex/implement-budget-guards-with-test-first-approach-fa0vm9
-          depends_on:
+          dependencies:
             - flow_runner_integration
           steps:
             - Add integration test exercising simultaneous run+loop soft warnings followed by hard stop, verifying trace ordering.

--- a/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250330-gpt5codex
+++ b/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250330-gpt5codex
@@ -34,7 +34,7 @@ constraints:
   - Trace payloads must adhere to a shared schema validated during tests to prevent drift.
 component_ids:
   - pkgs/dsl
-depends_on:
+dependencies:
   - codex/specs/ragx_master_spec.yaml
 structured_logging_contract:
   summary: Budget and policy events share a TraceWriter-backed sink emitting immutable payloads for push/pop/charge/breach.

--- a/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250427T160000Z-gpt5codex
+++ b/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250427T160000Z-gpt5codex
@@ -42,7 +42,7 @@ component_ids:
   - pkgs.dsl.trace
   - tests.unit.budget
   - tests.e2e.runner
-depends_on:
+dependencies:
   - 07a_policy_stack_refinement
 arg_spec:
   - flow_id

--- a/codex/specs/schemas/full_task.schema.json
+++ b/codex/specs/schemas/full_task.schema.json
@@ -128,7 +128,7 @@
       "items": { "type": "string" },
       "minItems": 1
     },
-    "depends_on": {
+    "dependencies": {
       "type": "array",
       "items": { "type": "string" }
     },


### PR DESCRIPTION
## Summary
- replace the non-schema `depends_on` key with `dependencies` across all task specifications
- update the `full_task` schema to advertise the `dependencies` array instead of `depends_on`

## Testing
- pytest -q *(fails: missing optional dependencies such as numpy, uvicorn, and Hypothesis fixed_dictionaries)*

------
https://chatgpt.com/codex/tasks/task_e_68e8ed5d56ac832c80a8bb173f2f25d6