### PR TITLE
Fix YAML tasks to use mappings

### DIFF
--- a/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
+++ b/codex/agents/TASKS_FINAL/P2/07a_dsl_policy_engine_completion.yaml-20250320-ops1
@@ -73,67 +73,64 @@ actions:
   - stage: policy_stack_core
     summary: Reconcile stack invariants, metadata modeling, and trace emission.
     tasks:
-      - |
-          execution_mode: always
-          reusable: false
-          summary: Merge ToolDescriptor modeling with registry-backed validation and nearest-scope traversal.
-          adapted_from_branch:
-            - codex/implement-dsl-policy-engine-in-yaml
-            - codex/implement-dsl-policy-engine-in-yaml-reclz1
-          steps:
-            - Embed ToolDescriptor normalization inside PolicyStack so allow/deny references validate against the registry while exposing descriptor views.
-            - Rework effective_allowlist traversal to iterate newest→oldest, combining candidate filtering from -81p0id with implicit deny semantics from -reclz1.
-            - Restore policy_push/pop/resolved trace events with enriched payloads (candidates, denial reasons, stack depth).
-          tests:
-            - tests/unit/test_policy_stack_resolution.py::test_branch_policy_overrides
-            - tests/unit/test_policy_stack_resolution.py::test_allow_tags_and_tool_sets_union
-          artifacts:
-            - pkgs/dsl/policy.py
+      - execution_mode: always
+        reusable: false
+        summary: Merge ToolDescriptor modeling with registry-backed validation and nearest-scope traversal.
+        adapted_from_branch:
+          - codex/implement-dsl-policy-engine-in-yaml
+          - codex/implement-dsl-policy-engine-in-yaml-reclz1
+        steps:
+          - Embed ToolDescriptor normalization inside PolicyStack so allow/deny references validate against the registry while exposing descriptor views.
+          - Rework effective_allowlist traversal to iterate newest→oldest, combining candidate filtering from -81p0id with implicit deny semantics from -reclz1.
+          - Restore policy_push/pop/resolved trace events with enriched payloads (candidates, denial reasons, stack depth).
+        tests:
+          - tests/unit/test_policy_stack_resolution.py::test_branch_policy_overrides
+          - tests/unit/test_policy_stack_resolution.py::test_allow_tags_and_tool_sets_union
+        artifacts:
+          - pkgs/dsl/policy.py
   - stage: policy_enforcement
     summary: Introduce runtime enforcement and violation tracing.
     tasks:
-      - |
-          execution_mode: always
-          reusable: false
-          summary: Layer PolicySnapshot/enforce API onto the corrected PolicyStack.
-          adapted_from_branch:
-            - codex/implement-dsl-policy-engine-in-yaml-yp01n0
-          depends_on:
-            - policy_stack_core
-          steps:
-            - Produce immutable PolicySnapshot objects that capture allowed tools, denial metadata, and stack scopes without recomputing traces.
-            - Implement enforce() to emit policy_violation events through the shared trace emitter and optionally raise PolicyViolationError.
-            - Document enforcement semantics in docs/policies.md with examples for fallback escalation.
-          tests:
-            - tests/unit/test_policy_stack_resolution.py::test_enforce_violation_emits_trace
-            - tests/unit/test_policy_stack_resolution.py::test_snapshot_determinism
-          artifacts:
-            - pkgs/dsl/policy.py
-            - docs/policies.md
+      - execution_mode: always
+        reusable: false
+        summary: Layer PolicySnapshot/enforce API onto the corrected PolicyStack.
+        adapted_from_branch:
+          - codex/implement-dsl-policy-engine-in-yaml-yp01n0
+        depends_on:
+          - policy_stack_core
+        steps:
+          - Produce immutable PolicySnapshot objects that capture allowed tools, denial metadata, and stack scopes without recomputing traces.
+          - Implement enforce() to emit policy_violation events through the shared trace emitter and optionally raise PolicyViolationError.
+          - Document enforcement semantics in docs/policies.md with examples for fallback escalation.
+        tests:
+          - tests/unit/test_policy_stack_resolution.py::test_enforce_violation_emits_trace
+          - tests/unit/test_policy_stack_resolution.py::test_snapshot_determinism
+        artifacts:
+          - pkgs/dsl/policy.py
+          - docs/policies.md
   - stage: linter_and_observability
     summary: Enhance linter to explore full policy contexts and validate traces.
     tasks:
-      - |
-          execution_mode: always
-          reusable: true
-          summary: Refactor lint_unreachable_tools to use stack cloning with fallback and decision coverage.
-          adapted_from_branch:
-            - codex/implement-dsl-policy-engine-in-yaml-reclz1
-            - codex/implement-dsl-policy-engine-in-yaml-81p0id
-          depends_on:
-            - policy_stack_core
-          steps:
-            - Build a reusable analyzer that clones the PolicyStack per loop/decision branch and records trace context for unreachable findings.
-            - Validate fallback.try lists and decision branches emit precise issue paths (`graph.nodes[i]...`).
-            - Capture structured logging samples showing policy_push/pop/resolved/violation sequences for representative flows.
-          tests:
-            - tests/unit/test_linter_unreachable_tools.py::test_branch_override_clears_error
-            - tests/unit/test_linter_unreachable_tools.py::test_fallback_exhaustion_error
-            - tests/unit/test_runner_loops.py::test_loop_policy_context_propagates
-          artifacts:
-            - pkgs/dsl/linter.py
-            - docs/policies.md
-            - codex/fixtures/policy_traces.jsonl
+      - execution_mode: always
+        reusable: true
+        summary: Refactor lint_unreachable_tools to use stack cloning with fallback and decision coverage.
+        adapted_from_branch:
+          - codex/implement-dsl-policy-engine-in-yaml-reclz1
+          - codex/implement-dsl-policy-engine-in-yaml-81p0id
+        depends_on:
+          - policy_stack_core
+        steps:
+          - Build a reusable analyzer that clones the PolicyStack per loop/decision branch and records trace context for unreachable findings.
+          - Validate fallback.try lists and decision branches emit precise issue paths (`graph.nodes[i]...`).
+          - Capture structured logging samples showing policy_push/pop/resolved/violation sequences for representative flows.
+        tests:
+          - tests/unit/test_linter_unreachable_tools.py::test_branch_override_clears_error
+          - tests/unit/test_linter_unreachable_tools.py::test_fallback_exhaustion_error
+          - tests/unit/test_runner_loops.py::test_loop_policy_context_propagates
+        artifacts:
+          - pkgs/dsl/linter.py
+          - docs/policies.md
+          - codex/fixtures/policy_traces.jsonl
 acceptance:
   - tests/unit/test_policy_stack_resolution.py
   - tests/unit/test_linter_unreachable_tools.py

--- a/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250105-gpt5
+++ b/codex/agents/TASKS_FINAL/P2/07b_budget_guards_and_runner_integration.yaml-20250105-gpt5
@@ -120,98 +120,94 @@ actions:
   - stage: budget_domain_model
     summary: Consolidate immutable budget data structures and validation.
     tasks:
-      - |
-          execution_mode: always
-          reusable: true
-          summary: Merge CostSnapshot/BudgetSpec immutability with BudgetMode/BudgetCheck semantics and BudgetBreach metadata.
-          adapted_from_branch:
-            - codex/integrate-budget-guards-with-runner-zwi2ny
-            - codex/implement-budget-guards-with-test-first-approach-qhq0jq
-            - codex/implement-budget-guards-with-test-first-approach-fa0vm9
-            - codex/implement-budget-guards-with-test-first-approach-8wxk32
-          steps:
-            - Create CostSnapshot and Cost dataclasses supporting tokens_in/tokens_out aggregation and total computation.
-            - Define BudgetSpec with validation for negative/unknown metrics and normalize time_ms/time_sec inputs.
-            - Implement BudgetCharge and BudgetCheck results that carry remaining/overage mappings and breach metadata using mapping_proxy.
-            - Add BudgetBreach dataclass capturing scope, metric, amount, and breach_kind for trace parity.
-          tests:
-            - tests/unit/test_budget_meter_limits.py::test_charge_respects_soft_and_hard_modes
-            - tests/unit/test_budget_meter_limits.py::test_remaining_and_overages_are_immutable
-          artifacts:
-            - pkgs/dsl/budget.py
+      - execution_mode: always
+        reusable: true
+        summary: Merge CostSnapshot/BudgetSpec immutability with BudgetMode/BudgetCheck semantics and BudgetBreach metadata.
+        adapted_from_branch:
+          - codex/integrate-budget-guards-with-runner-zwi2ny
+          - codex/implement-budget-guards-with-test-first-approach-qhq0jq
+          - codex/implement-budget-guards-with-test-first-approach-fa0vm9
+          - codex/implement-budget-guards-with-test-first-approach-8wxk32
+        steps:
+          - Create CostSnapshot and Cost dataclasses supporting tokens_in/tokens_out aggregation and total computation.
+          - Define BudgetSpec with validation for negative/unknown metrics and normalize time_ms/time_sec inputs.
+          - Implement BudgetCharge and BudgetCheck results that carry remaining/overage mappings and breach metadata using mapping_proxy.
+          - Add BudgetBreach dataclass capturing scope, metric, amount, and breach_kind for trace parity.
+        tests:
+          - tests/unit/test_budget_meter_limits.py::test_charge_respects_soft_and_hard_modes
+          - tests/unit/test_budget_meter_limits.py::test_remaining_and_overages_are_immutable
+        artifacts:
+          - pkgs/dsl/budget.py
   - stage: budget_manager_and_trace
     summary: Implement BudgetManager orchestration and trace emission plumbing.
     tasks:
-      - |
-          execution_mode: always
-          reusable: true
-          summary: Build BudgetManager preflight/commit per scope and unify trace recorder usage with PolicyStack.
-          adapted_from_branch:
-            - codex/implement-budget-guards-with-test-first-approach
-            - codex/integrate-budget-guards-with-runner-pbdel9
-            - codex/integrate-budget-guards-with-runner-zwi2ny
-          depends_on:
-            - budget_domain_model
-          steps:
-            - Implement BudgetManager that constructs BudgetMeter instances per scope, exposes preflight_* and commit_* APIs, and returns BudgetCheck/BudgetCharge outcomes.
-            - Ensure breach_action stop semantics trigger explicit `should_stop` flags without mutating meters on failure paths.
-            - Emit budget_charge and budget_breach events via a shared RunnerTraceEmitter that also accepts policy events.
-            - Provide in-memory recorder plus optional sink callable, returning immutable trace payloads for tests.
-          tests:
-            - tests/unit/test_budget_manager_preflight.py::test_preflight_detects_soft_breaches
-            - tests/unit/test_budget_manager_preflight.py::test_commit_sets_should_stop_flag
-            - tests/unit/test_policy_stack_traces.py::test_policy_and_budget_share_recorder
-          artifacts:
-            - pkgs/dsl/budget.py
-            - pkgs/dsl/trace.py
+      - execution_mode: always
+        reusable: true
+        summary: Build BudgetManager preflight/commit per scope and unify trace recorder usage with PolicyStack.
+        adapted_from_branch:
+          - codex/implement-budget-guards-with-test-first-approach
+          - codex/integrate-budget-guards-with-runner-pbdel9
+          - codex/integrate-budget-guards-with-runner-zwi2ny
+        depends_on:
+          - budget_domain_model
+        steps:
+          - Implement BudgetManager that constructs BudgetMeter instances per scope, exposes preflight_* and commit_* APIs, and returns BudgetCheck/BudgetCharge outcomes.
+          - Ensure breach_action stop semantics trigger explicit `should_stop` flags without mutating meters on failure paths.
+          - Emit budget_charge and budget_breach events via a shared RunnerTraceEmitter that also accepts policy events.
+          - Provide in-memory recorder plus optional sink callable, returning immutable trace payloads for tests.
+        tests:
+          - tests/unit/test_budget_manager_preflight.py::test_preflight_detects_soft_breaches
+          - tests/unit/test_budget_manager_preflight.py::test_commit_sets_should_stop_flag
+          - tests/unit/test_policy_stack_traces.py::test_policy_and_budget_share_recorder
+        artifacts:
+          - pkgs/dsl/budget.py
+          - pkgs/dsl/trace.py
   - stage: flow_runner_integration
     summary: Retrofit FlowRunner to enforce policy, adapters, and budgets cohesively.
     tasks:
-      - |
-          execution_mode: always
-          reusable: false
-          summary: Integrate adapters with BudgetManager outcomes, loop summaries, and trace emission.
-          adapted_from_branch:
-            - codex/integrate-budget-guards-with-runner
-            - codex/implement-budget-guards-with-test-first-approach-8wxk32
-            - codex/implement-budget-guards-with-test-first-approach-fa0vm9
-            - codex/implement-budget-guards-with-test-first-approach-qhq0jq
-          depends_on:
-            - budget_manager_and_trace
-          steps:
-            - Execute nodes via ToolAdapter protocol, capturing estimates, enforcing PolicyStack before execution, and charging BudgetManager with actual costs.
-            - Produce NodeExecution records and accumulate LoopSummary instances including stop reasons and breach lists.
-            - Break loops based on BudgetManager.should_stop or PolicyViolationError, ensuring warnings propagate when breach_action="warn".
-            - Populate RunResult with outputs, immutable trace events, and loop summaries while keeping adapter contract synchronous.
-          tests:
-            - tests/unit/test_flow_runner_budget_manager.py::test_runner_stops_on_stop_breach
-            - tests/e2e/test_runner_budget_stop.py::test_loop_soft_warn_and_hard_stop
-            - tests/e2e/test_runner_policy_budget_trace.py::test_policy_and_budget_traces_in_order
-          artifacts:
-            - pkgs/dsl/runner.py
-            - pkgs/dsl/policy.py
+      - execution_mode: always
+        reusable: false
+        summary: Integrate adapters with BudgetManager outcomes, loop summaries, and trace emission.
+        adapted_from_branch:
+          - codex/integrate-budget-guards-with-runner
+          - codex/implement-budget-guards-with-test-first-approach-8wxk32
+          - codex/implement-budget-guards-with-test-first-approach-fa0vm9
+          - codex/implement-budget-guards-with-test-first-approach-qhq0jq
+        depends_on:
+          - budget_manager_and_trace
+        steps:
+          - Execute nodes via ToolAdapter protocol, capturing estimates, enforcing PolicyStack before execution, and charging BudgetManager with actual costs.
+          - Produce NodeExecution records and accumulate LoopSummary instances including stop reasons and breach lists.
+          - Break loops based on BudgetManager.should_stop or PolicyViolationError, ensuring warnings propagate when breach_action="warn".
+          - Populate RunResult with outputs, immutable trace events, and loop summaries while keeping adapter contract synchronous.
+        tests:
+          - tests/unit/test_flow_runner_budget_manager.py::test_runner_stops_on_stop_breach
+          - tests/e2e/test_runner_budget_stop.py::test_loop_soft_warn_and_hard_stop
+          - tests/e2e/test_runner_policy_budget_trace.py::test_policy_and_budget_traces_in_order
+        artifacts:
+          - pkgs/dsl/runner.py
+          - pkgs/dsl/policy.py
   - stage: regression_tests_and_docs
     summary: Harden coverage and document budgeting behaviour.
     tasks:
-      - |
-          execution_mode: always
-          reusable: true
-          summary: Extend tests and docs for combined policy/budget observability.
-          adapted_from_branch:
-            - codex/integrate-budget-guards-with-runner-pbdel9
-            - codex/implement-budget-guards-with-test-first-approach-fa0vm9
-          depends_on:
-            - flow_runner_integration
-          steps:
-            - Add integration test exercising simultaneous run+loop soft warnings followed by hard stop, verifying trace ordering.
-            - Document trace schema and budgeting workflow in docs/runner/budgeting.md, referencing shared trace emitter contract.
-            - Capture fixture trace samples for golden regression under tests/fixtures/flows/.
-          tests:
-            - tests/e2e/test_runner_policy_budget_trace.py::test_combined_policy_budget_trace_payload
-            - tests/property/test_budget_charge_invariants.py
-          artifacts:
-            - docs/runner/budgeting.md
-            - tests/e2e/test_runner_policy_budget_trace.py
+      - execution_mode: always
+        reusable: true
+        summary: Extend tests and docs for combined policy/budget observability.
+        adapted_from_branch:
+          - codex/integrate-budget-guards-with-runner-pbdel9
+          - codex/implement-budget-guards-with-test-first-approach-fa0vm9
+        depends_on:
+          - flow_runner_integration
+        steps:
+          - Add integration test exercising simultaneous run+loop soft warnings followed by hard stop, verifying trace ordering.
+          - Document trace schema and budgeting workflow in docs/runner/budgeting.md, referencing shared trace emitter contract.
+          - Capture fixture trace samples for golden regression under tests/fixtures/flows/.
+        tests:
+          - tests/e2e/test_runner_policy_budget_trace.py::test_combined_policy_budget_trace_payload
+          - tests/property/test_budget_charge_invariants.py
+        artifacts:
+          - docs/runner/budgeting.md
+          - tests/e2e/test_runner_policy_budget_trace.py
 acceptance:
   - tests/unit/test_budget_meter_limits.py
   - tests/unit/test_budget_manager_preflight.py


### PR DESCRIPTION
## Summary
- replace block scalar task entries with mappings so downstream tooling can parse structured fields
- adjust indentation for nested lists to maintain valid YAML structure

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8ed35a22c832cbc2f583f1cefda05